### PR TITLE
feat(chat): chat message schemas, CRUD, and REST routes

### DIFF
--- a/backend/crud/__init__.py
+++ b/backend/crud/__init__.py
@@ -12,6 +12,11 @@ from .campaign import (
     update_campaign,
     delete_campaign,
 )
+from .chat_message import (
+    get_chat_messages,
+    create_chat_message,
+    delete_chat_messages_by_campaign,
+)
 
 __all__ = [
     "get_ad_variants",
@@ -24,4 +29,7 @@ __all__ = [
     "create_campaign",
     "update_campaign",
     "delete_campaign",
+    "get_chat_messages",
+    "create_chat_message",
+    "delete_chat_messages_by_campaign",
 ]

--- a/backend/crud/chat_message.py
+++ b/backend/crud/chat_message.py
@@ -1,0 +1,63 @@
+"""CRUD operations for chat_messages table (append-only)."""
+
+from sqlalchemy import select, delete as sa_delete
+from sqlalchemy.orm import Session
+
+from models.chat_message import ChatMessage
+from schemas.chat_message import ChatMessageCreate
+
+
+def get_chat_messages(
+    db: Session,
+    campaign_id: int,
+    business_client_id: int,
+    skip: int = 0,
+    limit: int = 200,
+) -> list[ChatMessage]:
+    """Return messages for a campaign owned by the given client, oldest-first."""
+    query = (
+        select(ChatMessage)
+        .where(
+            ChatMessage.campaign_id == campaign_id,
+            ChatMessage.business_client_id == business_client_id,
+        )
+        .order_by(ChatMessage.timestamp.asc())
+        .offset(skip)
+        .limit(limit)
+    )
+    return list(db.scalars(query).all())
+
+
+def create_chat_message(
+    db: Session,
+    business_client_id: int,
+    data: ChatMessageCreate,
+) -> ChatMessage:
+    """Insert a new chat message and return it."""
+    message = ChatMessage(
+        **data.model_dump(),
+        business_client_id=business_client_id,
+    )
+    db.add(message)
+    db.commit()
+    db.refresh(message)
+    return message
+
+
+def delete_chat_messages_by_campaign(
+    db: Session,
+    campaign_id: int,
+    business_client_id: int,
+) -> int:
+    """Delete all messages for a campaign owned by the given client.
+
+    Returns the number of rows deleted.
+    """
+    result = db.execute(
+        sa_delete(ChatMessage).where(
+            ChatMessage.campaign_id == campaign_id,
+            ChatMessage.business_client_id == business_client_id,
+        )
+    )
+    db.commit()
+    return result.rowcount  # type: ignore[return-value]

--- a/backend/main.py
+++ b/backend/main.py
@@ -13,6 +13,7 @@ from routes.auth import router as auth_router
 #  Resource routes (CRUD)
 from routes.ad_variants import router as ad_variants_router
 from routes.campaigns import router as campaigns_router
+from routes.chat_messages import router as chat_messages_router
 from routes.consumers import router as consumers_router
 
 app = FastAPI(
@@ -45,6 +46,7 @@ app.include_router(script_creation_worker_router, prefix="/script-creation-worke
 # Resource routers (CRUD)
 app.include_router(ad_variants_router, prefix="/ad-variants", tags=["Ad Variants"])
 app.include_router(campaigns_router, prefix="/campaigns", tags=["Campaigns"])
+app.include_router(chat_messages_router, prefix="/chat-messages", tags=["Chat Messages"])
 app.include_router(consumers_router, prefix="/consumers", tags=["Consumers"])
 
 # Methods (GET and HEAD) for uptime robot to keep the app alive

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,3 +8,7 @@ bcrypt>=4.0.0
 python-jose[cryptography]>=3.3.0
 python-multipart>=0.0.6
 azure-identity>=1.15.0
+
+# Test dependencies
+pytest>=9.0.0
+httpx>=0.27.0,<0.28

--- a/backend/routes/__init__.py
+++ b/backend/routes/__init__.py
@@ -1,5 +1,6 @@
 from .ad_variants import router as ad_variants_router
-from .consumers import router as consumers_router
 from .campaigns import router as campaigns_router
+from .chat_messages import router as chat_messages_router
+from .consumers import router as consumers_router
 
-__all__ = ["ad_variants_router", "consumers_router", "campaigns_router"]
+__all__ = ["ad_variants_router", "campaigns_router", "chat_messages_router", "consumers_router"]

--- a/backend/routes/chat_messages.py
+++ b/backend/routes/chat_messages.py
@@ -1,0 +1,60 @@
+"""API routes for chat_messages — append-only endpoints (JWT-protected)."""
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from database import get_db
+from dependencies import get_current_client_id
+from schemas.chat_message import ChatMessageCreate, ChatMessageResponse
+from crud.chat_message import (
+    get_chat_messages,
+    create_chat_message,
+    delete_chat_messages_by_campaign,
+)
+
+router = APIRouter()
+
+
+@router.get("/", response_model=list[ChatMessageResponse])
+def list_chat_messages(
+    campaign_id: int = Query(..., description="Campaign to fetch messages for"),
+    skip: int = 0,
+    limit: int = 200,
+    db: Session = Depends(get_db),
+    client_id: int = Depends(get_current_client_id),
+):
+    """Get all chat messages for a campaign (oldest-first)."""
+    return get_chat_messages(
+        db,
+        campaign_id=campaign_id,
+        business_client_id=client_id,
+        skip=skip,
+        limit=limit,
+    )
+
+
+@router.post("/", response_model=ChatMessageResponse, status_code=201)
+def create_new_chat_message(
+    data: ChatMessageCreate,
+    db: Session = Depends(get_db),
+    client_id: int = Depends(get_current_client_id),
+):
+    """Create a new chat message."""
+    return create_chat_message(db, business_client_id=client_id, data=data)
+
+
+@router.delete("/", status_code=204)
+def clear_chat_messages(
+    campaign_id: int = Query(..., description="Campaign whose messages to delete"),
+    db: Session = Depends(get_db),
+    client_id: int = Depends(get_current_client_id),
+):
+    """Delete all chat messages for a campaign (reset conversation)."""
+    deleted = delete_chat_messages_by_campaign(
+        db, campaign_id=campaign_id, business_client_id=client_id,
+    )
+    if deleted == 0:
+        raise HTTPException(
+            status_code=404,
+            detail="No messages found for this campaign.",
+        )

--- a/backend/schemas/__init__.py
+++ b/backend/schemas/__init__.py
@@ -1,9 +1,11 @@
 from .ad_variant import AdVariantCreate, AdVariantUpdate, AdVariantResponse
 from .campaign import CampaignCreate, CampaignUpdate, CampaignResponse
+from .chat_message import ChatMessageCreate, ChatMessageResponse
 from .consumer import ConsumerCreate, ConsumerResponse, ConsumerCsvUploadResponse
 
 __all__ = [
     "AdVariantCreate", "AdVariantUpdate", "AdVariantResponse",
     "CampaignCreate", "CampaignUpdate", "CampaignResponse",
+    "ChatMessageCreate", "ChatMessageResponse",
     "ConsumerCreate", "ConsumerResponse", "ConsumerCsvUploadResponse",
 ]

--- a/backend/schemas/chat_message.py
+++ b/backend/schemas/chat_message.py
@@ -1,0 +1,41 @@
+"""Pydantic schemas for chat_messages — request/response validation."""
+
+from datetime import datetime
+from typing import Literal, Optional
+
+from pydantic import BaseModel
+
+# Allowed values (must match the model comments)
+ChatRole = Literal["user", "assistant", "system"]
+ChatMessageType = Literal["message", "plan", "plan_response"]
+
+
+# ---------- Request schema ----------
+
+class ChatMessageCreate(BaseModel):
+    """Schema for creating a new chat message.
+
+    business_client_id is NOT included here — it is injected from the
+    JWT token by the route handler.
+    """
+    campaign_id: int
+    role: ChatRole
+    message_type: ChatMessageType = "message"
+    content: str
+    version_ref: Optional[int] = None
+
+
+# ---------- Response schema ----------
+
+class ChatMessageResponse(BaseModel):
+    """Schema returned to the frontend."""
+    id: int
+    campaign_id: int
+    business_client_id: int
+    role: ChatRole
+    message_type: ChatMessageType
+    content: str
+    version_ref: Optional[int] = None
+    timestamp: datetime
+
+    model_config = {"from_attributes": True}

--- a/backend/tests/test_chat_messages.py
+++ b/backend/tests/test_chat_messages.py
@@ -1,0 +1,258 @@
+"""Tests for the /chat-messages endpoints — create, list, and clear.
+
+Run from the backend directory:
+    cd backend && python -m pytest tests/test_chat_messages.py -v
+"""
+
+import sys
+from pathlib import Path
+
+# Ensure backend/ is on the Python path
+_backend_dir = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_backend_dir))
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from database import Base, get_db
+from dependencies import get_current_client_id
+from models.chat_message import ChatMessage
+from main import app
+
+# ---------------------------------------------------------------------------
+# Fixtures – in-memory SQLite database + auth override
+# ---------------------------------------------------------------------------
+
+FAKE_CLIENT_ID = 42
+
+_original_schema = ChatMessage.__table__.schema
+
+engine = create_engine(
+    "sqlite:///:memory:",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture(autouse=True)
+def setup_db():
+    """Create the chat_messages table before each test and drop it after."""
+    ChatMessage.__table__.schema = None
+    Base.metadata.create_all(bind=engine, tables=[ChatMessage.__table__])
+    yield
+    Base.metadata.drop_all(bind=engine, tables=[ChatMessage.__table__])
+    ChatMessage.__table__.schema = _original_schema
+
+
+@pytest.fixture()
+def client():
+    """Return a FastAPI TestClient with DB and auth dependencies overridden."""
+
+    def _override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    def _override_get_current_client_id():
+        return FAKE_CLIENT_ID
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[get_current_client_id] = _override_get_current_client_id
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _create_message(client: TestClient, **overrides) -> dict:
+    """POST a chat message with sensible defaults, return the JSON response."""
+    payload = {
+        "campaign_id": 1,
+        "role": "user",
+        "content": "Hello, world!",
+        "message_type": "message",
+    }
+    payload.update(overrides)
+    resp = client.post("/chat-messages/", json=payload)
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+# ---------------------------------------------------------------------------
+# Tests — Create
+# ---------------------------------------------------------------------------
+
+
+class TestCreateChatMessage:
+    """POST /chat-messages/"""
+
+    def test_create_minimal(self, client: TestClient):
+        body = _create_message(client)
+        assert body["campaign_id"] == 1
+        assert body["business_client_id"] == FAKE_CLIENT_ID
+        assert body["role"] == "user"
+        assert body["message_type"] == "message"
+        assert body["content"] == "Hello, world!"
+        assert body["version_ref"] is None
+        assert "id" in body
+        assert "timestamp" in body
+
+    def test_create_with_version_ref(self, client: TestClient):
+        body = _create_message(client, version_ref=5)
+        assert body["version_ref"] == 5
+
+    def test_create_plan_message(self, client: TestClient):
+        body = _create_message(
+            client, role="assistant", message_type="plan", content="Here is the plan..."
+        )
+        assert body["role"] == "assistant"
+        assert body["message_type"] == "plan"
+
+    def test_create_rejects_invalid_role(self, client: TestClient):
+        resp = client.post("/chat-messages/", json={
+            "campaign_id": 1,
+            "role": "invalid_role",
+            "content": "test",
+        })
+        assert resp.status_code == 422
+
+    def test_create_rejects_invalid_message_type(self, client: TestClient):
+        resp = client.post("/chat-messages/", json={
+            "campaign_id": 1,
+            "role": "user",
+            "message_type": "invalid_type",
+            "content": "test",
+        })
+        assert resp.status_code == 422
+
+    def test_create_rejects_missing_content(self, client: TestClient):
+        resp = client.post("/chat-messages/", json={
+            "campaign_id": 1,
+            "role": "user",
+        })
+        assert resp.status_code == 422
+
+    def test_create_rejects_missing_campaign_id(self, client: TestClient):
+        resp = client.post("/chat-messages/", json={
+            "role": "user",
+            "content": "test",
+        })
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Tests — List
+# ---------------------------------------------------------------------------
+
+
+class TestListChatMessages:
+    """GET /chat-messages/?campaign_id=..."""
+
+    def test_list_empty(self, client: TestClient):
+        resp = client.get("/chat-messages/", params={"campaign_id": 1})
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_list_returns_created_messages(self, client: TestClient):
+        _create_message(client, content="first")
+        _create_message(client, content="second")
+
+        resp = client.get("/chat-messages/", params={"campaign_id": 1})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 2
+        # Oldest-first ordering
+        assert data[0]["content"] == "first"
+        assert data[1]["content"] == "second"
+
+    def test_list_filters_by_campaign(self, client: TestClient):
+        _create_message(client, campaign_id=1, content="camp1")
+        _create_message(client, campaign_id=2, content="camp2")
+
+        resp = client.get("/chat-messages/", params={"campaign_id": 1})
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["content"] == "camp1"
+
+    def test_list_requires_campaign_id(self, client: TestClient):
+        resp = client.get("/chat-messages/")
+        assert resp.status_code == 422
+
+    def test_list_pagination(self, client: TestClient):
+        for i in range(5):
+            _create_message(client, content=f"msg-{i}")
+
+        resp = client.get("/chat-messages/", params={"campaign_id": 1, "skip": 0, "limit": 2})
+        assert len(resp.json()) == 2
+
+        resp = client.get("/chat-messages/", params={"campaign_id": 1, "skip": 2, "limit": 10})
+        assert len(resp.json()) == 3
+
+    def test_list_scoped_to_client(self, client: TestClient):
+        """Messages created by one client are not visible to another."""
+        _create_message(client, content="my message")
+
+        # Simulate a different client
+        app.dependency_overrides[get_current_client_id] = lambda: 999
+
+        resp = client.get("/chat-messages/", params={"campaign_id": 1})
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+        # Restore original override
+        app.dependency_overrides[get_current_client_id] = lambda: FAKE_CLIENT_ID
+
+
+# ---------------------------------------------------------------------------
+# Tests — Delete (clear conversation)
+# ---------------------------------------------------------------------------
+
+
+class TestClearChatMessages:
+    """DELETE /chat-messages/?campaign_id=..."""
+
+    def test_clear_deletes_all_for_campaign(self, client: TestClient):
+        _create_message(client, campaign_id=1, content="a")
+        _create_message(client, campaign_id=1, content="b")
+        _create_message(client, campaign_id=2, content="other campaign")
+
+        resp = client.delete("/chat-messages/", params={"campaign_id": 1})
+        assert resp.status_code == 204
+
+        # Campaign 1 messages gone
+        resp = client.get("/chat-messages/", params={"campaign_id": 1})
+        assert resp.json() == []
+
+        # Campaign 2 messages untouched
+        resp = client.get("/chat-messages/", params={"campaign_id": 2})
+        assert len(resp.json()) == 1
+
+    def test_clear_returns_404_when_no_messages(self, client: TestClient):
+        resp = client.delete("/chat-messages/", params={"campaign_id": 999})
+        assert resp.status_code == 404
+
+    def test_clear_requires_campaign_id(self, client: TestClient):
+        resp = client.delete("/chat-messages/")
+        assert resp.status_code == 422
+
+    def test_clear_scoped_to_client(self, client: TestClient):
+        """One client cannot delete another client's messages."""
+        _create_message(client, content="my message")
+
+        # Simulate a different client trying to delete
+        app.dependency_overrides[get_current_client_id] = lambda: 999
+        resp = client.delete("/chat-messages/", params={"campaign_id": 1})
+        assert resp.status_code == 404
+
+        # Restore and verify original messages still exist
+        app.dependency_overrides[get_current_client_id] = lambda: FAKE_CLIENT_ID
+        resp = client.get("/chat-messages/", params={"campaign_id": 1})
+        assert len(resp.json()) == 1


### PR DESCRIPTION
## Summary
- Add Pydantic schemas (`ChatMessageCreate`, `ChatMessageResponse`) with `Literal` type
  constraints for `role` and `message_type`
- Add append-only CRUD functions (create, list by campaign, delete by campaign)
- Add JWT-protected REST routes at `/chat-messages` (GET, POST, DELETE)
- Wire up module exports and register router in `main.py`
- Add 17 tests covering create, list, delete, validation, pagination, and client scoping
- Add `pytest` and `httpx` to `requirements.txt` as test dependencies

## Design decisions
- `business_client_id` injected from JWT token, not accepted in request body
- All queries scoped to the authenticated client (one client cannot see/modify another's messages)
- Messages returned oldest-first (natural chat order)
- `DELETE /chat-messages/?campaign_id=X` clears all messages for a campaign (reset conversation)

## Test plan
- [x] `test_create_minimal` — basic message creation with defaults
- [x] `test_create_with_version_ref` — optional version_ref field
- [x] `test_create_plan_message` — assistant/plan message type
- [x] `test_create_rejects_invalid_role` — 422 on bad role
- [x] `test_create_rejects_invalid_message_type` — 422 on bad message_type
- [x] `test_create_rejects_missing_content` — 422 on missing required field
- [x] `test_create_rejects_missing_campaign_id` — 422 on missing required field
- [x] `test_list_empty` — empty list for campaign with no messages
- [x] `test_list_returns_created_messages` — oldest-first ordering
- [x] `test_list_filters_by_campaign` — only returns messages for requested campaign
- [x] `test_list_requires_campaign_id` — 422 when campaign_id missing
- [x] `test_list_pagination` — skip/limit works correctly
- [x] `test_list_scoped_to_client` — client isolation
- [x] `test_clear_deletes_all_for_campaign` — deletes only target campaign's messages
- [x] `test_clear_returns_404_when_no_messages` — 404 when nothing to delete
- [x] `test_clear_requires_campaign_id` — 422 when campaign_id missing
- [x] `test_clear_scoped_to_client` — one client can't delete another's messages

All these changes are after database migrations done in the previous round of PRs to make sure everything is in sync.