### PR TITLE
Create campaign previews and full campaign ad videos 

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -26,12 +26,12 @@ All services run on **port 8000** with different route prefixes:
 
 1. **Ad Job Worker** - `/ad-job-worker/hello`
 2. **Ad Post Worker** - `/ad-post-worker/hello`
-3. **Script Creation Worker** - `/script-creation-worker/hello`
+
+Script creation is a pipeline step (no HTTP); use `workers.script_creation_worker.generate_script(data)` from code.
 
 ## Testing Hello Endpoints
 
 ```bash
 curl http://localhost:8000/ad-job-worker/hello
 curl http://localhost:8000/ad-post-worker/hello
-curl http://localhost:8000/script-creation-worker/hello
 ```

--- a/backend/crud/__init__.py
+++ b/backend/crud/__init__.py
@@ -1,6 +1,7 @@
 from .ad_variant import (
     get_ad_variants,
     get_ad_variant,
+    get_ad_variant_by_campaign_consumer_version,
     create_ad_variant,
     update_ad_variant,
     delete_ad_variant,
@@ -21,6 +22,7 @@ from .chat_message import (
 __all__ = [
     "get_ad_variants",
     "get_ad_variant",
+    "get_ad_variant_by_campaign_consumer_version",
     "create_ad_variant",
     "update_ad_variant",
     "delete_ad_variant",

--- a/backend/crud/ad_job.py
+++ b/backend/crud/ad_job.py
@@ -1,0 +1,139 @@
+"""CRUD operations for ad_jobs table."""
+
+from datetime import datetime, timezone
+from typing import Optional
+from uuid import UUID
+
+from sqlalchemy import select, update
+from sqlalchemy.orm import Session
+
+from models.ad_job import AdJob
+from schemas.ad_job import AdJobCreate, AdJobUpdate
+
+
+def get_ad_job(db: Session, ad_job_id: UUID) -> Optional[AdJob]:
+    """Return a single ad job by ID, or None."""
+    return db.get(AdJob, ad_job_id)
+
+
+def get_ad_jobs(
+    db: Session,
+    batch_id: Optional[UUID] = None,
+    status: Optional[str] = None,
+    skip: int = 0,
+    limit: int = 100,
+) -> list[AdJob]:
+    """Return a list of ad jobs with optional filters."""
+    query = select(AdJob)
+    if batch_id is not None:
+        query = query.where(AdJob.batch_id == batch_id)
+    if status is not None:
+        query = query.where(AdJob.status == status)
+    query = query.order_by(AdJob.created_at.desc()).offset(skip).limit(limit)
+    return list(db.scalars(query).all())
+
+
+def get_pending_ad_jobs(
+    db: Session,
+    *,
+    limit: int = 1,
+    max_attempts: int = 3,
+    status: str = "pending",
+) -> list[AdJob]:
+    """Return ad jobs that are pending, unlocked, and under the attempt limit.
+    Used by the poller to find work. Ordered by created_at ascending (FIFO).
+    """
+    query = (
+        select(AdJob)
+        .where(AdJob.status == status)
+        .where(AdJob.locked_at.is_(None))
+        .where(AdJob.attempt_count < max_attempts)
+        .order_by(AdJob.created_at.asc())
+        .limit(limit)
+    )
+    return list(db.scalars(query).all())
+
+
+def claim_ad_job(
+    db: Session,
+    ad_job_id: UUID,
+    worker_id: str,
+    *,
+    status_while_running: str = "running",
+) -> bool:
+    """Atomically claim a job by setting locked_at and locked_by only if it is still unclaimed.
+    Returns True if this worker claimed the job, False if someone else did or it was already processed.
+    """
+    now = datetime.now(timezone.utc)
+    stmt = (
+        update(AdJob)
+        .where(AdJob.id == ad_job_id)
+        .where(AdJob.locked_at.is_(None))
+        .where(AdJob.status == "pending")
+        .values(
+            locked_at=now,
+            locked_by=worker_id,
+            status=status_while_running,
+            attempt_count=AdJob.attempt_count + 1,
+            updated_at=now,
+        )
+    )
+    result = db.execute(stmt)
+    db.commit()
+    return result.rowcount > 0
+
+
+def release_job_lock(
+    db: Session,
+    ad_job_id: UUID,
+    *,
+    status: str = "pending",
+    worker_id: Optional[str] = None,
+) -> None:
+    """Clear lock on a job (e.g. after failure so another worker can retry).
+    If worker_id is set, only clears the lock when locked_by equals worker_id.
+    """
+    stmt = update(AdJob).where(AdJob.id == ad_job_id)
+    if worker_id is not None:
+        stmt = stmt.where(AdJob.locked_by == worker_id)
+    stmt = stmt.values(
+        locked_at=None, locked_by=None, status=status, updated_at=datetime.now(timezone.utc)
+    )
+    db.execute(stmt)
+    db.commit()
+
+
+def create_ad_job(db: Session, data: AdJobCreate) -> AdJob:
+    """Insert a new ad job and return it."""
+    ad_job = AdJob(**data.model_dump())
+    db.add(ad_job)
+    db.commit()
+    db.refresh(ad_job)
+    return ad_job
+
+
+def update_ad_job(
+    db: Session,
+    ad_job_id: UUID,
+    data: AdJobUpdate,
+) -> Optional[AdJob]:
+    """Update an existing ad job. Returns None if not found."""
+    ad_job = db.get(AdJob, ad_job_id)
+    if ad_job is None:
+        return None
+    for field, value in data.model_dump(exclude_unset=True).items():
+        setattr(ad_job, field, value)
+    ad_job.updated_at = datetime.now(timezone.utc)
+    db.commit()
+    db.refresh(ad_job)
+    return ad_job
+
+
+def delete_ad_job(db: Session, ad_job_id: UUID) -> bool:
+    """Delete an ad job by ID. Returns True if deleted, False if not found."""
+    ad_job = db.get(AdJob, ad_job_id)
+    if ad_job is None:
+        return False
+    db.delete(ad_job)
+    db.commit()
+    return True

--- a/backend/crud/ad_job_batch.py
+++ b/backend/crud/ad_job_batch.py
@@ -1,0 +1,116 @@
+"""CRUD operations for ad_job_batches table."""
+
+from datetime import datetime, timezone
+from typing import Optional
+from uuid import UUID
+
+from sqlalchemy import case, select, update
+from sqlalchemy.orm import Session
+
+from models.ad_job_batch import AdJobBatch
+from schemas.ad_job_batch import AdJobBatchCreate, AdJobBatchUpdate
+
+
+def get_ad_job_batch(db: Session, batch_id: UUID) -> Optional[AdJobBatch]:
+    """Return a single ad job batch by ID, or None."""
+    return db.get(AdJobBatch, batch_id)
+
+
+def get_ad_job_batches(
+    db: Session,
+    user_id: Optional[UUID] = None,
+    status: Optional[str] = None,
+    skip: int = 0,
+    limit: int = 100,
+) -> list[AdJobBatch]:
+    """Return a list of ad job batches with optional filters."""
+    query = select(AdJobBatch)
+    if user_id is not None:
+        query = query.where(AdJobBatch.user_id == user_id)
+    if status is not None:
+        query = query.where(AdJobBatch.status == status)
+    query = query.order_by(AdJobBatch.created_at.desc()).offset(skip).limit(limit)
+    return list(db.scalars(query).all())
+
+
+def create_ad_job_batch(db: Session, data: AdJobBatchCreate) -> AdJobBatch:
+    """Insert a new ad job batch and return it."""
+    batch = AdJobBatch(**data.model_dump())
+    db.add(batch)
+    db.commit()
+    db.refresh(batch)
+    return batch
+
+
+def update_ad_job_batch(
+    db: Session,
+    batch_id: UUID,
+    data: AdJobBatchUpdate,
+) -> Optional[AdJobBatch]:
+    """Update an existing ad job batch. Returns None if not found."""
+    batch = db.get(AdJobBatch, batch_id)
+    if batch is None:
+        return None
+    for field, value in data.model_dump(exclude_unset=True).items():
+        setattr(batch, field, value)
+    batch.updated_at = datetime.now(timezone.utc)
+    db.commit()
+    db.refresh(batch)
+    return batch
+
+
+def increment_ad_job_batch_progress(
+    db: Session,
+    batch_id: UUID,
+    *,
+    succeeded_delta: int = 0,
+    failed_delta: int = 0,
+) -> None:
+    """Atomically increment succeeded/failed job counts for a batch.
+
+    Also updates `status` to a terminal status once succeeded+failed reaches total_jobs:
+    - completed (no failures)
+    - completed_with_errors (one or more failures)
+
+    If the batch is already cancelled (canceled_at not null), status is left unchanged.
+    """
+    if succeeded_delta == 0 and failed_delta == 0:
+        return
+
+    now = datetime.now(timezone.utc)
+
+    new_succeeded = AdJobBatch.succeeded_jobs + succeeded_delta
+    new_failed = AdJobBatch.failed_jobs + failed_delta
+    new_done = new_succeeded + new_failed
+
+    terminal_status = case(
+        (new_failed > 0, "completed_with_errors"),
+        else_="completed",
+    )
+
+    stmt = (
+        update(AdJobBatch)
+        .where(AdJobBatch.id == batch_id)
+        .values(
+            succeeded_jobs=new_succeeded,
+            failed_jobs=new_failed,
+            updated_at=now,
+            status=case(
+                (AdJobBatch.canceled_at.isnot(None), AdJobBatch.status),
+                (new_done >= AdJobBatch.total_jobs, terminal_status),
+                else_=AdJobBatch.status,
+            ),
+        )
+    )
+    db.execute(stmt)
+    db.commit()
+
+
+def delete_ad_job_batch(db: Session, batch_id: UUID) -> bool:
+    """Delete an ad job batch by ID. Returns True if deleted, False if not found."""
+    batch = db.get(AdJobBatch, batch_id)
+    if batch is None:
+        return False
+    db.delete(batch)
+    db.commit()
+    return True

--- a/backend/crud/ad_variant.py
+++ b/backend/crud/ad_variant.py
@@ -15,16 +15,35 @@ def get_ad_variants(
     skip: int = 0,
     limit: int = 100,
     campaign_id: Optional[int] = None,
+    version_number: Optional[int] = None,
     status: Optional[str] = None,
 ) -> list[AdVariant]:
     """Return a list of ad variants with optional filters."""
     query = select(AdVariant)
     if campaign_id is not None:
         query = query.where(AdVariant.campaign_id == campaign_id)
+    if version_number is not None:
+        query = query.where(AdVariant.version_number == version_number)
     if status is not None:
         query = query.where(AdVariant.status == status)
     query = query.order_by(AdVariant.id).offset(skip).limit(limit)
     return list(db.scalars(query).all())
+
+
+def get_ad_variant_by_campaign_consumer_version(
+    db: Session,
+    campaign_id: int,
+    consumer_id: int,
+    version_number: int,
+) -> Optional[AdVariant]:
+    """Return the ad variant for this campaign/consumer/version, or None if not found."""
+    query = (
+        select(AdVariant)
+        .where(AdVariant.campaign_id == campaign_id)
+        .where(AdVariant.consumer_id == consumer_id)
+        .where(AdVariant.version_number == version_number)
+    )
+    return db.scalars(query).first()
 
 
 def get_ad_variant(db: Session, ad_variant_id: int) -> Optional[AdVariant]:

--- a/backend/crud/consumer.py
+++ b/backend/crud/consumer.py
@@ -22,7 +22,7 @@ def get_existing_emails(db: Session, client_id: int, emails: list[str]) -> set[s
 def get_consumer(
     db: Session,
     consumer_id: int,
-) -> Consumer:
+) -> Optional[Consumer]:
     """Return a consumer by ID."""
     return db.get(Consumer, consumer_id)
 

--- a/backend/crud/consumer.py
+++ b/backend/crud/consumer.py
@@ -19,6 +19,19 @@ def get_existing_emails(db: Session, client_id: int, emails: list[str]) -> set[s
     )
     return set(db.scalars(query).all())
 
+def get_consumer(
+    db: Session,
+    consumer_id: int,
+) -> Consumer:
+    """Return a consumer by ID."""
+    return db.get(Consumer, consumer_id)
+
+def get_consumers_by_persona_id(
+    db: Session,
+    persona_id: str,
+) -> list[Consumer]:
+    """Return consumers whose primary persona matches the given persona ID (UUID string)."""
+    return list(db.scalars(select(Consumer).where(Consumer.primary_persona_id == persona_id)).all())
 
 def get_consumers(
     db: Session,
@@ -70,6 +83,14 @@ def get_unassigned_consumer_ids(db: Session, client_id: int) -> list[int]:
     )
     return list(db.scalars(query).all())
 
+
+def get_all_consumers(db: Session) -> list[Consumer]:
+    """Return all consumers (no pagination)."""
+    query = (
+        select(Consumer)
+        .order_by(Consumer.id)
+    )
+    return list(db.scalars(query).all())
 
 def create_consumer(db: Session, client_id: int, data: ConsumerCreate) -> Consumer:
     """Insert a new consumer and return it."""

--- a/backend/crud/persona.py
+++ b/backend/crud/persona.py
@@ -1,0 +1,28 @@
+"""CRUD operations for personas table."""
+
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from models.persona import Persona
+
+
+def get_persona(db: Session, persona_id: str) -> Optional[Persona]:
+    """Return a persona by ID, or None if not found."""
+    return db.get(Persona, persona_id)
+
+
+def get_personas(
+    db: Session,
+    skip: int = 0,
+    limit: int = 100,
+) -> list[Persona]:
+    """Return personas ordered by name, with optional pagination."""
+    query = (
+        select(Persona)
+        .order_by(Persona.name)
+        .offset(skip)
+        .limit(limit)
+    )
+    return list(db.scalars(query).all())

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,6 @@
 import os
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -11,18 +13,36 @@ from routes.auth import router as auth_router
 
 #  Resource routes (CRUD)
 from routes.ad_variants import router as ad_variants_router
+from routes.ad_jobs import router as ad_jobs_router
+from routes.ad_job_batches import router as ad_job_batches_router
 from routes.campaigns import router as campaigns_router
 from routes.chat_messages import router as chat_messages_router
 from routes.consumers import router as consumers_router
 from routes.personas import router as personas_router
 from routes.product import router as product_router
 
+from services.ad_job_poller.service import run_poller
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Start the ad_job poller task when the app starts; cancel it on shutdown."""
+    import asyncio
+    poller_task = asyncio.create_task(run_poller())
+    yield
+    poller_task.cancel()
+    try:
+        await poller_task
+    except asyncio.CancelledError:
+        pass
+
 app = FastAPI(
     title="Adgentic AI API",
     description="Adgentic AI is a platform that helps businesses create and manage their social media ads.",
     version="1.0.0",
     docs_url="/docs",
-    redoc_url="/redoc"
+    redoc_url="/redoc",
+    lifespan=lifespan,
 )
 
 # CORS middleware 
@@ -45,6 +65,8 @@ app.include_router(ad_post_worker_router, prefix="/ad-post-worker", tags=["Ad Po
 
 # Resource routers (CRUD)
 app.include_router(ad_variants_router, prefix="/ad-variants", tags=["Ad Variants"])
+app.include_router(ad_jobs_router, prefix="/ad-jobs", tags=["Ad Jobs"])
+app.include_router(ad_job_batches_router, prefix="/ad-job-batches", tags=["Ad Job Batches"])
 app.include_router(campaigns_router, prefix="/campaigns", tags=["Campaigns"])
 app.include_router(chat_messages_router, prefix="/chat-messages", tags=["Chat Messages"])
 app.include_router(consumers_router, prefix="/consumers", tags=["Consumers"])
@@ -61,8 +83,7 @@ async def root():
         "status": "running",
         "services": [
             "ad-job-worker",
-            "ad-post-worker",
-            "script-creation-worker"
+            "ad-post-worker"
         ]
     }
 

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,4 +1,6 @@
 from .ad_variant import AdVariant
+from .ad_job import AdJob
+from .ad_job_batch import AdJobBatch
 from .business_client import BusinessClient
 from .campaign import Campaign
 from .chat_message import ChatMessage
@@ -9,6 +11,8 @@ from .product import Product
 
 __all__ = [
     "AdVariant",
+    "AdJob",
+    "AdJobBatch",
     "BusinessClient",
     "Campaign",
     "ChatMessage",

--- a/backend/models/ad_job.py
+++ b/backend/models/ad_job.py
@@ -1,0 +1,45 @@
+"""SQLAlchemy model for the dbo.ad_jobs table."""
+
+import uuid
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy import DateTime, Integer, String, Text
+from sqlalchemy.dialects.mssql import UNIQUEIDENTIFIER
+from sqlalchemy.orm import Mapped, mapped_column
+
+from database import Base
+
+
+class AdJob(Base):
+    __tablename__ = "ad_jobs"
+    __table_args__ = {"schema": "dbo"}
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UNIQUEIDENTIFIER(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    batch_id: Mapped[uuid.UUID] = mapped_column(
+        UNIQUEIDENTIFIER(as_uuid=True),
+        nullable=False,
+    )
+    status: Mapped[str] = mapped_column(String(20), nullable=False)
+    input_json: Mapped[str] = mapped_column(Text, nullable=False)
+    output_json: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    error_message: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    attempt_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    locked_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    locked_by: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime,
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    def __repr__(self) -> str:
+        return f"<AdJob(id={self.id}, batch_id={self.batch_id}, status='{self.status}')>"

--- a/backend/models/ad_job_batch.py
+++ b/backend/models/ad_job_batch.py
@@ -1,0 +1,44 @@
+"""SQLAlchemy model for the dbo.ad_job_batches table."""
+
+import uuid
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy import DateTime, Integer, String
+from sqlalchemy.dialects.mssql import UNIQUEIDENTIFIER
+from sqlalchemy.orm import Mapped, mapped_column
+
+from database import Base
+
+
+class AdJobBatch(Base):
+    __tablename__ = "ad_job_batches"
+    __table_args__ = {"schema": "dbo"}
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UNIQUEIDENTIFIER(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UNIQUEIDENTIFIER(as_uuid=True),
+        nullable=False,
+    )
+    status: Mapped[str] = mapped_column(String(20), nullable=False)
+    total_jobs: Mapped[int] = mapped_column(Integer, nullable=False)
+    succeeded_jobs: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    failed_jobs: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    idempotency_key: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime,
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+    canceled_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+
+    def __repr__(self) -> str:
+        return f"<AdJobBatch(id={self.id}, user_id={self.user_id}, status='{self.status}')>"

--- a/backend/models/ad_variant.py
+++ b/backend/models/ad_variant.py
@@ -23,6 +23,7 @@ class AdVariant(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=lambda: datetime.now(timezone.utc))
     updated_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
     published_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    product_id: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
 
     def __repr__(self) -> str:
         return f"<AdVariant(id={self.id}, campaign_id={self.campaign_id}, status='{self.status}')>"

--- a/backend/models/product.py
+++ b/backend/models/product.py
@@ -18,12 +18,12 @@ class Product(Base):
     name: Mapped[str] = mapped_column(String, nullable=False)
     description: Mapped[Optional[str]] = mapped_column(String, nullable=True)
     image_url: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    image_name: Mapped[Optional[str]] = mapped_column(String, nullable=True)
     product_link: Mapped[Optional[str]] = mapped_column(String, nullable=True)
     product_metadata: Mapped[Optional[str]] = mapped_column(String, nullable=True)
     is_active: Mapped[Optional[bool]] = mapped_column(Boolean, nullable=True)
     created_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True, default=lambda: datetime.now(timezone.utc))
     updated_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
-    image_name: Mapped[Optional[str]] = mapped_column(String, nullable=True)
 
     def __repr__(self) -> str:
         return f"<Product(id={self.id}, name='{self.name}', business_client_id={self.business_client_id})>"

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_mode = auto
+testpaths = tests

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,6 +10,7 @@ python-multipart>=0.0.6
 azure-identity>=1.15.0
 openai>=1.0.0
 xai-sdk>=0.1.0
+azure-storage-blob>=12.0.0
 
 # Test dependencies
 pytest>=9.0.0

--- a/backend/routes/__init__.py
+++ b/backend/routes/__init__.py
@@ -4,7 +4,6 @@ from .ad_job_batches import router as ad_job_batches_router
 from .consumers import router as consumers_router
 from .campaigns import router as campaigns_router
 from .chat_messages import router as chat_messages_router
-from .consumers import router as consumers_router
 
 __all__ = [
     "ad_variants_router",

--- a/backend/routes/__init__.py
+++ b/backend/routes/__init__.py
@@ -1,6 +1,16 @@
 from .ad_variants import router as ad_variants_router
+from .ad_jobs import router as ad_jobs_router
+from .ad_job_batches import router as ad_job_batches_router
+from .consumers import router as consumers_router
 from .campaigns import router as campaigns_router
 from .chat_messages import router as chat_messages_router
 from .consumers import router as consumers_router
 
-__all__ = ["ad_variants_router", "campaigns_router", "chat_messages_router", "consumers_router"]
+__all__ = [
+    "ad_variants_router",
+    "ad_jobs_router",
+    "ad_job_batches_router",
+    "consumers_router",
+    "campaigns_router",
+    "chat_messages_router",
+]

--- a/backend/routes/ad_job_batches.py
+++ b/backend/routes/ad_job_batches.py
@@ -1,0 +1,66 @@
+"""API routes for ad_job_batches — full CRUD endpoints."""
+
+from typing import Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from database import get_db
+from schemas.ad_job_batch import AdJobBatchCreate, AdJobBatchUpdate, AdJobBatchResponse
+from crud.ad_job_batch import (
+    get_ad_job_batch,
+    get_ad_job_batches,
+    create_ad_job_batch,
+    update_ad_job_batch,
+    delete_ad_job_batch,
+)
+
+router = APIRouter()
+
+
+@router.get("/", response_model=list[AdJobBatchResponse])
+def list_ad_job_batches(
+    skip: int = 0,
+    limit: int = 100,
+    user_id: Optional[UUID] = None,
+    status: Optional[str] = None,
+    db: Session = Depends(get_db),
+):
+    """Get all ad job batches, with optional filtering by user_id or status."""
+    return get_ad_job_batches(db, user_id=user_id, status=status, skip=skip, limit=limit)
+
+
+@router.get("/{batch_id}", response_model=AdJobBatchResponse)
+def read_ad_job_batch(batch_id: UUID, db: Session = Depends(get_db)):
+    """Get a single ad job batch by ID."""
+    batch = get_ad_job_batch(db, batch_id)
+    if batch is None:
+        raise HTTPException(status_code=404, detail="Ad job batch not found")
+    return batch
+
+
+@router.post("/", response_model=AdJobBatchResponse, status_code=201)
+def create_new_ad_job_batch(data: AdJobBatchCreate, db: Session = Depends(get_db)):
+    """Create a new ad job batch."""
+    return create_ad_job_batch(db, data)
+
+
+@router.put("/{batch_id}", response_model=AdJobBatchResponse)
+def update_existing_ad_job_batch(
+    batch_id: UUID,
+    data: AdJobBatchUpdate,
+    db: Session = Depends(get_db),
+):
+    """Update an existing ad job batch."""
+    batch = update_ad_job_batch(db, batch_id, data)
+    if batch is None:
+        raise HTTPException(status_code=404, detail="Ad job batch not found")
+    return batch
+
+
+@router.delete("/{batch_id}", status_code=204)
+def remove_ad_job_batch(batch_id: UUID, db: Session = Depends(get_db)):
+    """Delete an ad job batch by ID."""
+    if not delete_ad_job_batch(db, batch_id):
+        raise HTTPException(status_code=404, detail="Ad job batch not found")

--- a/backend/routes/ad_jobs.py
+++ b/backend/routes/ad_jobs.py
@@ -1,0 +1,66 @@
+"""API routes for ad_jobs — full CRUD endpoints."""
+
+from typing import Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from database import get_db
+from schemas.ad_job import AdJobCreate, AdJobUpdate, AdJobResponse
+from crud.ad_job import (
+    get_ad_job,
+    get_ad_jobs,
+    create_ad_job,
+    update_ad_job,
+    delete_ad_job,
+)
+
+router = APIRouter()
+
+
+@router.get("/", response_model=list[AdJobResponse])
+def list_ad_jobs(
+    skip: int = 0,
+    limit: int = 100,
+    batch_id: Optional[UUID] = None,
+    status: Optional[str] = None,
+    db: Session = Depends(get_db),
+):
+    """Get all ad jobs, with optional filtering by batch_id or status."""
+    return get_ad_jobs(db, batch_id=batch_id, status=status, skip=skip, limit=limit)
+
+
+@router.get("/{ad_job_id}", response_model=AdJobResponse)
+def read_ad_job(ad_job_id: UUID, db: Session = Depends(get_db)):
+    """Get a single ad job by ID."""
+    ad_job = get_ad_job(db, ad_job_id)
+    if ad_job is None:
+        raise HTTPException(status_code=404, detail="Ad job not found")
+    return ad_job
+
+
+@router.post("/", response_model=AdJobResponse, status_code=201)
+def create_new_ad_job(data: AdJobCreate, db: Session = Depends(get_db)):
+    """Create a new ad job."""
+    return create_ad_job(db, data)
+
+
+@router.put("/{ad_job_id}", response_model=AdJobResponse)
+def update_existing_ad_job(
+    ad_job_id: UUID,
+    data: AdJobUpdate,
+    db: Session = Depends(get_db),
+):
+    """Update an existing ad job."""
+    ad_job = update_ad_job(db, ad_job_id, data)
+    if ad_job is None:
+        raise HTTPException(status_code=404, detail="Ad job not found")
+    return ad_job
+
+
+@router.delete("/{ad_job_id}", status_code=204)
+def remove_ad_job(ad_job_id: UUID, db: Session = Depends(get_db)):
+    """Delete an ad job by ID."""
+    if not delete_ad_job(db, ad_job_id):
+        raise HTTPException(status_code=404, detail="Ad job not found")

--- a/backend/schemas/__init__.py
+++ b/backend/schemas/__init__.py
@@ -1,4 +1,6 @@
 from .ad_variant import AdVariantCreate, AdVariantUpdate, AdVariantResponse
+from .ad_job import AdJobCreate, AdJobUpdate, AdJobResponse
+from .ad_job_batch import AdJobBatchCreate, AdJobBatchUpdate, AdJobBatchResponse
 from .campaign import CampaignCreate, CampaignUpdate, CampaignResponse
 from .chat_message import ChatMessageCreate, ChatMessageResponse
 from .consumer import ConsumerCreate, ConsumerResponse, ConsumerCsvUploadResponse
@@ -6,6 +8,8 @@ from .persona import PersonaResponse, PersonaBrief
 
 __all__ = [
     "AdVariantCreate", "AdVariantUpdate", "AdVariantResponse",
+    "AdJobCreate", "AdJobUpdate", "AdJobResponse",
+    "AdJobBatchCreate", "AdJobBatchUpdate", "AdJobBatchResponse",
     "CampaignCreate", "CampaignUpdate", "CampaignResponse",
     "ChatMessageCreate", "ChatMessageResponse",
     "ConsumerCreate", "ConsumerResponse", "ConsumerCsvUploadResponse",

--- a/backend/schemas/ad_job.py
+++ b/backend/schemas/ad_job.py
@@ -1,0 +1,48 @@
+"""Pydantic schemas for ad_jobs — request/response validation."""
+
+from datetime import datetime
+from typing import Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+# ---------- Request schemas ----------
+
+
+class AdJobCreate(BaseModel):
+    """Schema for creating a new ad job."""
+    batch_id: UUID
+    status: str = Field(..., max_length=20)
+    input_json: str
+    attempt_count: int = 0
+
+
+class AdJobUpdate(BaseModel):
+    """Schema for updating an ad job. All fields optional."""
+    status: Optional[str] = Field(None, max_length=20)
+    output_json: Optional[str] = None
+    error_message: Optional[str] = None
+    attempt_count: Optional[int] = None
+    locked_at: Optional[datetime] = None
+    locked_by: Optional[str] = Field(None, max_length=100)
+
+
+# ---------- Response schema ----------
+
+
+class AdJobResponse(BaseModel):
+    """Schema returned to the frontend."""
+    id: UUID
+    batch_id: UUID
+    status: str
+    input_json: str
+    output_json: Optional[str] = None
+    error_message: Optional[str] = None
+    attempt_count: int
+    locked_at: Optional[datetime] = None
+    locked_by: Optional[str] = None
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}

--- a/backend/schemas/ad_job_batch.py
+++ b/backend/schemas/ad_job_batch.py
@@ -1,0 +1,48 @@
+"""Pydantic schemas for ad_job_batches — request/response validation."""
+
+from datetime import datetime
+from typing import Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+
+
+class AdJobBatchCreate(BaseModel):
+    """Schema for creating a new ad job batch."""
+    user_id: UUID
+    status: str = Field(..., max_length=20)
+    total_jobs: int
+    succeeded_jobs: int = 0
+    failed_jobs: int = 0
+    idempotency_key: Optional[str] = Field(None, max_length=255)
+
+
+class AdJobBatchUpdate(BaseModel):
+    """Schema for updating an ad job batch. All fields optional."""
+    status: Optional[str] = Field(None, max_length=20)
+    total_jobs: Optional[int] = None
+    succeeded_jobs: Optional[int] = None
+    failed_jobs: Optional[int] = None
+    idempotency_key: Optional[str] = Field(None, max_length=255)
+    canceled_at: Optional[datetime] = None
+
+
+# ---------- Response schema ----------
+
+
+class AdJobBatchResponse(BaseModel):
+    """Schema returned to the frontend."""
+    id: UUID
+    user_id: UUID
+    status: str
+    total_jobs: int
+    succeeded_jobs: int
+    failed_jobs: int
+    idempotency_key: Optional[str] = None
+    created_at: datetime
+    updated_at: datetime
+    canceled_at: Optional[datetime] = None
+
+    model_config = {"from_attributes": True}

--- a/backend/schemas/ad_variant.py
+++ b/backend/schemas/ad_variant.py
@@ -11,7 +11,8 @@ class AdVariantCreate(BaseModel):
     """Schema for creating a new ad variant."""
     campaign_id: int
     consumer_id: Optional[int] = None
-    status: str
+    product_id: Optional[int] = None
+    status: str = "creating"
     media_url: Optional[str] = None
     meta: Optional[str] = None
     version_number: int = 1

--- a/backend/schemas/ad_variant.py
+++ b/backend/schemas/ad_variant.py
@@ -22,6 +22,7 @@ class AdVariantUpdate(BaseModel):
     """Schema for updating an ad variant. All fields optional."""
     campaign_id: Optional[int] = None
     consumer_id: Optional[int] = None
+    product_id: Optional[int] = None
     status: Optional[str] = None
     media_url: Optional[str] = None
     meta: Optional[str] = None
@@ -36,6 +37,7 @@ class AdVariantResponse(BaseModel):
     id: int
     campaign_id: int
     consumer_id: Optional[int] = None
+    product_id: Optional[int] = None
     status: str
     media_url: Optional[str] = None
     meta: Optional[str] = None

--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -1,0 +1,1 @@
+# Services package

--- a/backend/services/ad_job_poller/__init__.py
+++ b/backend/services/ad_job_poller/__init__.py
@@ -1,0 +1,1 @@
+# Ad job poller service

--- a/backend/services/ad_job_poller/service.py
+++ b/backend/services/ad_job_poller/service.py
@@ -1,0 +1,149 @@
+"""Poller that periodically claims and processes jobs from the ad_jobs table."""
+
+import asyncio
+import json
+import logging
+import os
+import socket
+from uuid import UUID
+
+from database import _get_session_factory
+from crud.ad_job import (
+    get_pending_ad_jobs,
+    claim_ad_job,
+    update_ad_job,
+    release_job_lock,
+)
+from crud.ad_job_batch import increment_ad_job_batch_progress
+from schemas.ad_job import AdJobUpdate
+from workers.ad_job_worker.worker import execute_ad_job
+
+logger = logging.getLogger(__name__)
+
+# Default: poll every 5 seconds, max 3 attempts per job
+POLL_INTERVAL_SECONDS = float(os.environ.get("AD_JOB_POLL_INTERVAL_SECONDS", "5"))
+MAX_ATTEMPTS = int(os.environ.get("AD_JOB_MAX_ATTEMPTS", "3"))
+
+
+def _worker_id() -> str:
+    """Unique identifier for this poller process (e.g. hostname:pid)."""
+    return f"{socket.gethostname()}:{os.getpid()}"
+
+
+def _parse_input(input_json: str) -> dict:
+    """Parse input_json from an ad_job. Expected keys: campaign_id, product_id, consumer_id, version_number."""
+    data = json.loads(input_json)
+    return {
+        "campaign_id": int(data["campaign_id"]),
+        "product_id": int(data["product_id"]),
+        "consumer_id": int(data["consumer_id"]),
+        "version_number": int(data.get("version_number", 1)),
+    }
+
+
+async def _process_one_job(job_id: UUID, batch_id: UUID, input_json: str, worker_id: str) -> None:
+    """Parse input before claim so invalid jobs are marked failed without claiming or incrementing attempt_count."""
+    try:
+        payload = _parse_input(input_json)
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError) as e:
+        logger.warning("Job %s invalid input_json: %s", job_id, e)
+        factory = _get_session_factory()
+        db = factory()
+        try:
+            updated = update_ad_job(
+                db,
+                job_id,
+                AdJobUpdate(
+                    status="failed",
+                    error_message=f"Invalid input_json: {e!s}"[:65535],
+                ),
+            )
+            if updated is not None:
+                increment_ad_job_batch_progress(db, batch_id, failed_delta=1)
+        finally:
+            db.close()
+        return
+
+    factory = _get_session_factory()
+    db = factory()
+    try:
+        claimed = claim_ad_job(db, job_id, worker_id)
+        if not claimed:
+            logger.debug("Job %s was already claimed, skipping", job_id)
+            return
+
+        logger.info("Processing ad_job %s: campaign_id=%s consumer_id=%s", job_id, payload["campaign_id"], payload["consumer_id"])
+
+        try:
+            ad_variant_id = await execute_ad_job(
+                campaign_id=payload["campaign_id"],
+                product_id=payload["product_id"],
+                consumer_id=payload["consumer_id"],
+                version_number=payload["version_number"],
+            )
+            update_ad_job(
+                db,
+                job_id,
+                AdJobUpdate(
+                    status="completed",
+                    output_json=json.dumps({"ad_variant_id": ad_variant_id}),
+                    locked_at=None,
+                    locked_by=None,
+                ),
+            )
+            increment_ad_job_batch_progress(db, batch_id, succeeded_delta=1)
+            logger.info("Completed ad_job %s -> ad_variant_id=%s", job_id, ad_variant_id)
+        except Exception as e:
+            logger.exception("Ad job %s failed: %s", job_id, e)
+            update_ad_job(
+                db,
+                job_id,
+                AdJobUpdate(
+                    status="failed",
+                    error_message=str(e)[:65535],
+                    locked_at=None,
+                    locked_by=None,
+                ),
+            )
+            increment_ad_job_batch_progress(db, batch_id, failed_delta=1)
+    except Exception as e:
+        logger.exception("Poller error for job %s: %s", job_id, e)
+        try:
+            release_job_lock(db, job_id, status="pending", worker_id=worker_id)
+        except Exception:
+            pass
+    finally:
+        db.close()
+
+
+async def run_poller(
+    *,
+    poll_interval_seconds: float = POLL_INTERVAL_SECONDS,
+    max_attempts: int = MAX_ATTEMPTS,
+    worker_id: str | None = None,
+) -> None:
+    """
+    Run the ad_job poller loop. Polls the database for pending jobs, claims one at a time,
+    runs execute_ad_job, and updates the row. Runs until the task is cancelled.
+    """
+    wid = worker_id or _worker_id()
+    logger.info("Ad job poller started (worker_id=%s, interval=%.1fs)", wid, poll_interval_seconds)
+
+    while True:
+        try:
+            factory = _get_session_factory()
+            db = factory()
+            try:
+                pending = get_pending_ad_jobs(db, limit=1, max_attempts=max_attempts)
+                if pending:
+                    job = pending[0]
+                    await _process_one_job(job.id, job.batch_id, job.input_json, wid)
+            finally:
+                db.close()
+        except asyncio.CancelledError:
+            logger.info("Ad job poller cancelled")
+            raise
+        except Exception as e:
+            logger.exception("Poller cycle error: %s", e)
+
+        await asyncio.sleep(poll_interval_seconds)

--- a/backend/services/ad_job_scheduler/service.py
+++ b/backend/services/ad_job_scheduler/service.py
@@ -1,0 +1,11 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.post("/schedule-ad-job")
+async def schedule_ad_job(ad_job: AdJob):
+    return {
+        "service": "Ad Job Scheduler",
+        "message": "Ad job scheduled",
+        "description": "Scheduler for AI ad generation"
+    }

--- a/backend/services/ad_job_scheduler/service.py
+++ b/backend/services/ad_job_scheduler/service.py
@@ -1,9 +1,12 @@
 from fastapi import APIRouter
 
+from schemas.ad_job import AdJobCreate
+
 router = APIRouter()
 
+
 @router.post("/schedule-ad-job")
-async def schedule_ad_job(ad_job: AdJob):
+async def schedule_ad_job(ad_job: AdJobCreate):
     return {
         "service": "Ad Job Scheduler",
         "message": "Ad job scheduled",

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,8 @@
+"""Pytest configuration and shared fixtures."""
+
+import pytest
+
+
+def pytest_configure(config):
+    """Enable pytest-asyncio auto mode for async tests."""
+    config.addinivalue_line("markers", "asyncio: mark test as an async test (asyncio_mode=auto)")

--- a/backend/tests/test_ad_job_crud.py
+++ b/backend/tests/test_ad_job_crud.py
@@ -1,0 +1,81 @@
+"""Unit tests for ad_job and ad_job_batch CRUD — claim_ad_job, release_job_lock.
+
+Run from the backend directory:
+    cd backend && python -m pytest tests/test_ad_job_crud.py -v
+"""
+
+import sys
+from pathlib import Path
+from uuid import uuid4
+from unittest.mock import MagicMock, patch
+
+_backend_dir = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_backend_dir))
+
+import pytest
+
+from crud.ad_job import claim_ad_job, release_job_lock
+
+
+# ---------------------------------------------------------------------------
+# Tests — claim_ad_job
+# ---------------------------------------------------------------------------
+
+
+def test_claim_ad_job_returns_true_when_row_updated():
+    """claim_ad_job returns True when the UPDATE affects one row (job was pending and unclaimed)."""
+    mock_db = MagicMock()
+    mock_result = MagicMock()
+    mock_result.rowcount = 1
+    mock_db.execute.return_value = mock_result
+    job_id = uuid4()
+
+    result = claim_ad_job(mock_db, job_id, "worker-1")
+
+    assert result is True
+    mock_db.commit.assert_called_once()
+
+
+def test_claim_ad_job_returns_false_when_no_row_updated():
+    """claim_ad_job returns False when the UPDATE affects zero rows (already claimed or not pending)."""
+    mock_db = MagicMock()
+    mock_result = MagicMock()
+    mock_result.rowcount = 0
+    mock_db.execute.return_value = mock_result
+    job_id = uuid4()
+
+    result = claim_ad_job(mock_db, job_id, "worker-1")
+
+    assert result is False
+    mock_db.commit.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Tests — release_job_lock
+# ---------------------------------------------------------------------------
+
+
+def test_release_job_lock_without_worker_id_clears_lock():
+    """release_job_lock with no worker_id updates the job (any locker)."""
+    mock_db = MagicMock()
+    job_id = uuid4()
+
+    release_job_lock(mock_db, job_id, status="pending")
+
+    mock_db.execute.assert_called_once()
+    mock_db.commit.assert_called_once()
+
+
+def test_release_job_lock_with_worker_id_adds_where_clause():
+    """release_job_lock with worker_id only clears when locked_by matches (implementation detail: stmt has extra where)."""
+    mock_db = MagicMock()
+    job_id = uuid4()
+
+    release_job_lock(mock_db, job_id, status="pending", worker_id="worker-1")
+
+    mock_db.execute.assert_called_once()
+    # Statement should have been built with two where clauses (id + locked_by)
+    call_arg = mock_db.execute.call_args[0][0]
+    # SQLAlchemy update stmt has whereclause; we just assert execute was called with one arg
+    assert call_arg is not None
+    mock_db.commit.assert_called_once()

--- a/backend/tests/test_ad_job_poller.py
+++ b/backend/tests/test_ad_job_poller.py
@@ -1,0 +1,183 @@
+"""Unit tests for ad job poller — _process_one_job (parse-before-claim, success, failure).
+
+Run from the backend directory:
+    cd backend && python -m pytest tests/test_ad_job_poller.py -v
+"""
+
+import json
+import sys
+from pathlib import Path
+from uuid import uuid4
+from unittest.mock import AsyncMock, MagicMock, patch
+
+_backend_dir = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_backend_dir))
+
+import pytest
+
+# Poller imports worker which needs azure; skip tests if not installed
+pytest.importorskip("azure.storage.blob", reason="azure-storage-blob required for poller (worker dependency)")
+import services.ad_job_poller.service as _poller_module  # load so patch("...service.claim_ad_job") resolves
+
+
+# ---------------------------------------------------------------------------
+# Tests — _process_one_job: parse before claim
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_process_one_job_invalid_input_marks_failed_without_claiming():
+    """When input_json is invalid, job is marked failed and batch failed_delta is incremented; claim is never called."""
+    job_id = uuid4()
+    batch_id = uuid4()
+    invalid_input = "not valid json"
+    worker_id = "worker-1"
+    mock_db = MagicMock()
+    mock_factory = MagicMock(return_value=mock_db)
+
+    with (
+        patch.object(_poller_module, "_get_session_factory", return_value=mock_factory),
+        patch.object(_poller_module, "update_ad_job") as mock_update,
+        patch.object(_poller_module, "increment_ad_job_batch_progress") as mock_inc,
+        patch.object(_poller_module, "claim_ad_job") as mock_claim,
+        patch.object(_poller_module, "execute_ad_job", new_callable=AsyncMock),
+    ):
+        await _poller_module._process_one_job(job_id, batch_id, invalid_input, worker_id)
+
+    mock_update.assert_called_once()
+    call_args = mock_update.call_args
+    assert call_args[0][1] == job_id
+    update_data = call_args[0][2]
+    assert update_data.status == "failed"
+    assert "Invalid input_json" in (update_data.error_message or "")
+    mock_inc.assert_called_once_with(mock_db, batch_id, failed_delta=1)
+    mock_claim.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_process_one_job_missing_keys_marks_failed_without_claiming():
+    """When input_json is valid JSON but missing required keys, job is marked failed and batch incremented."""
+    job_id = uuid4()
+    batch_id = uuid4()
+    incomplete_input = json.dumps({"campaign_id": 1})  # missing product_id, consumer_id
+    worker_id = "worker-1"
+    mock_db = MagicMock()
+    mock_factory = MagicMock(return_value=mock_db)
+
+    with (
+        patch.object(_poller_module, "_get_session_factory", return_value=mock_factory),
+        patch.object(_poller_module, "update_ad_job") as mock_update,
+        patch.object(_poller_module, "increment_ad_job_batch_progress") as mock_inc,
+        patch.object(_poller_module, "claim_ad_job") as mock_claim,
+    ):
+        await _poller_module._process_one_job(job_id, batch_id, incomplete_input, worker_id)
+
+    mock_update.assert_called_once()
+    assert mock_update.call_args[0][2].status == "failed"
+    mock_inc.assert_called_once_with(mock_db, batch_id, failed_delta=1)
+    mock_claim.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests — _process_one_job: success path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_process_one_job_success_updates_job_and_increments_batch_succeeded():
+    """Valid input, claim succeeds, execute_ad_job succeeds -> job completed, batch succeeded_delta=1."""
+    job_id = uuid4()
+    batch_id = uuid4()
+    input_json = json.dumps({
+        "campaign_id": 1,
+        "product_id": 2,
+        "consumer_id": 3,
+        "version_number": 1,
+    })
+    worker_id = "worker-1"
+    mock_db = MagicMock()
+    mock_factory = MagicMock(return_value=mock_db)
+
+    with (
+        patch.object(_poller_module, "_get_session_factory", return_value=mock_factory),
+        patch.object(_poller_module, "claim_ad_job", return_value=True),
+        patch.object(_poller_module, "update_ad_job") as mock_update,
+        patch.object(_poller_module, "increment_ad_job_batch_progress") as mock_inc,
+        patch.object(_poller_module, "execute_ad_job", new_callable=AsyncMock, return_value=42),
+    ):
+        await _poller_module._process_one_job(job_id, batch_id, input_json, worker_id)
+
+    mock_update.assert_called_once()
+    update_data = mock_update.call_args[0][2]
+    assert update_data.status == "completed"
+    assert update_data.output_json == json.dumps({"ad_variant_id": 42})
+    mock_inc.assert_called_once_with(mock_db, batch_id, succeeded_delta=1)
+
+
+# ---------------------------------------------------------------------------
+# Tests — _process_one_job: execution failure path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_process_one_job_execution_failure_marks_failed_and_increments_batch_failed():
+    """Claim succeeds but execute_ad_job raises -> job status failed, batch failed_delta=1."""
+    job_id = uuid4()
+    batch_id = uuid4()
+    input_json = json.dumps({
+        "campaign_id": 1,
+        "product_id": 2,
+        "consumer_id": 3,
+        "version_number": 1,
+    })
+    worker_id = "worker-1"
+    mock_db = MagicMock()
+    mock_factory = MagicMock(return_value=mock_db)
+
+    with (
+        patch.object(_poller_module, "_get_session_factory", return_value=mock_factory),
+        patch.object(_poller_module, "claim_ad_job", return_value=True),
+        patch.object(_poller_module, "update_ad_job") as mock_update,
+        patch.object(_poller_module, "increment_ad_job_batch_progress") as mock_inc,
+        patch.object(
+            _poller_module,
+            "execute_ad_job",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("Video API error"),
+        ),
+        patch.object(_poller_module, "release_job_lock"),
+    ):
+        await _poller_module._process_one_job(job_id, batch_id, input_json, worker_id)
+
+    mock_update.assert_called_once()
+    update_data = mock_update.call_args[0][2]
+    assert update_data.status == "failed"
+    assert "Video API error" in (update_data.error_message or "")
+    mock_inc.assert_called_once_with(mock_db, batch_id, failed_delta=1)
+
+
+@pytest.mark.asyncio
+async def test_process_one_job_not_claimed_skips_without_update():
+    """When claim_ad_job returns False, no update or increment is called."""
+    job_id = uuid4()
+    batch_id = uuid4()
+    input_json = json.dumps({
+        "campaign_id": 1,
+        "product_id": 2,
+        "consumer_id": 3,
+    })
+    worker_id = "worker-1"
+    mock_db = MagicMock()
+    mock_factory = MagicMock(return_value=mock_db)
+
+    with (
+        patch.object(_poller_module, "_get_session_factory", return_value=mock_factory),
+        patch.object(_poller_module, "claim_ad_job", return_value=False),
+        patch.object(_poller_module, "update_ad_job") as mock_update,
+        patch.object(_poller_module, "increment_ad_job_batch_progress") as mock_inc,
+        patch.object(_poller_module, "execute_ad_job", new_callable=AsyncMock),
+    ):
+        await _poller_module._process_one_job(job_id, batch_id, input_json, worker_id)
+
+    mock_update.assert_not_called()
+    mock_inc.assert_not_called()

--- a/backend/tests/test_ad_job_worker.py
+++ b/backend/tests/test_ad_job_worker.py
@@ -1,0 +1,319 @@
+"""Unit tests for ad job worker — execute_ad_job with mocked DB, blob, and OpenAI.
+
+Requires: azure-storage-blob, pytest-asyncio (for async tests).
+Run from the backend directory:
+    cd backend && pip install -r requirements.txt && python -m pytest tests/test_ad_job_worker.py -v
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+_backend_dir = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_backend_dir))
+
+import pytest
+
+pytest.importorskip("azure.storage.blob", reason="azure-storage-blob required for ad_job_worker tests")
+from workers.ad_job_worker.worker import (
+    execute_ad_job,
+    _brief_for_version,
+    generate_campaign_preview,
+    generate_campaign_ad_variants,
+)
+
+
+# ---------------------------------------------------------------------------
+# Tests — _brief_for_version
+# ---------------------------------------------------------------------------
+
+
+class TestBriefForVersion:
+    """campaign.brief is JSON with keys = version_number, value = brief text."""
+
+    def test_returns_brief_for_version_string_key(self):
+        assert _brief_for_version('{"1": "Brief v1", "2": "Brief v2"}', 1) == "Brief v1"
+        assert _brief_for_version('{"1": "Brief v1", "2": "Brief v2"}', 2) == "Brief v2"
+
+    def test_returns_empty_for_missing_version(self):
+        assert _brief_for_version('{"1": "Only v1"}', 2) == ""
+
+    def test_returns_empty_for_empty_or_invalid_json(self):
+        assert _brief_for_version("", 1) == ""
+        assert _brief_for_version(None, 1) == ""
+        assert _brief_for_version("not json", 1) == ""
+
+    def test_preserves_empty_string_brief_for_version(self):
+        assert _brief_for_version('{"1": ""}', 1) == ""
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — mock DB, blob, script, video
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_db():
+    """Session that doesn't touch a real DB."""
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_session_factory(mock_db):
+    """Factory that returns our mock session."""
+    factory = MagicMock()
+    factory.return_value = mock_db
+    return factory
+
+
+@pytest.fixture
+def mock_ad_variant():
+    """Fake ad variant with an id (int) for return from create_ad_variant."""
+    v = MagicMock()
+    v.id = 42
+    return v
+
+
+@pytest.fixture
+def mock_campaign():
+    """Fake campaign with brief as JSON: keys = version_number, value = brief text."""
+    c = MagicMock()
+    c.brief = '{"1": "Test campaign brief"}'
+    return c
+
+
+@pytest.fixture
+def mock_consumer():
+    """Fake consumer with traits JSON."""
+    c = MagicMock()
+    c.traits = '{"age": "25-34", "interest": "fitness"}'
+    return c
+
+
+@pytest.fixture
+def mock_product():
+    """Fake product with name, description, image_url (or image_name)."""
+    p = MagicMock()
+    p.name = "Test Product"
+    p.description = "A great product"
+    p.image_url = "product-image.png"
+    return p
+
+
+@pytest.fixture
+def mock_blob_client():
+    """Fake BlobClient: download returns bytes, upload is no-op, url set."""
+    client = MagicMock()
+    download = MagicMock()
+    download.readall.return_value = b"fake image bytes"
+    client.download_blob.return_value = download
+    props = MagicMock()
+    props.content_settings.content_type = "image/png"
+    props.name = "product-image.png"
+    client.get_blob_properties.return_value = props
+    client.url = "https://example.blob.core.windows.net/container/blob"
+    return client
+
+
+@pytest.mark.asyncio
+async def test_execute_ad_job_returns_ad_variant_id(
+    mock_db,
+    mock_session_factory,
+    mock_ad_variant,
+    mock_campaign,
+    mock_consumer,
+    mock_product,
+    mock_blob_client,
+):
+    """execute_ad_job with all deps mocked returns the created ad_variant id."""
+    with (
+        patch("workers.ad_job_worker.worker._get_session_factory", return_value=mock_session_factory),
+        patch("workers.ad_job_worker.worker.create_ad_variant", return_value=mock_ad_variant),
+        patch("workers.ad_job_worker.worker.update_ad_variant"),
+        patch("workers.ad_job_worker.worker.get_campaign", return_value=mock_campaign),
+        patch("workers.ad_job_worker.worker.get_consumer", return_value=mock_consumer),
+        patch("workers.ad_job_worker.worker.get_product", return_value=mock_product),
+        patch("workers.ad_job_worker.worker.BlobClient") as blob_cls,
+        patch("workers.ad_job_worker.worker.generate_ad_script", new_callable=AsyncMock, return_value="Mock script text"),
+        patch("workers.ad_job_worker.worker.generate_ad_video", new_callable=AsyncMock, return_value=b"mock video bytes"),
+    ):
+        blob_cls.from_connection_string.return_value = mock_blob_client
+
+        result = await execute_ad_job(
+            campaign_id=1,
+            product_id=1,
+            consumer_id=1,
+            version_number=1,
+        )
+
+    assert result == 42
+    mock_db.close.assert_called_once()
+    # Script and video helpers should have been called
+    from workers.ad_job_worker.worker import generate_ad_script, generate_ad_video
+    # (patched, so we just check they were invoked via the fact that result is 42 and no exception)
+
+
+@pytest.mark.asyncio
+async def test_execute_ad_job_calls_generate_ad_script_with_expected_args(
+    mock_db,
+    mock_session_factory,
+    mock_ad_variant,
+    mock_campaign,
+    mock_consumer,
+    mock_product,
+    mock_blob_client,
+):
+    """execute_ad_job passes product name, description, consumer traits, and campaign brief to generate_ad_script."""
+    mock_gen_script = AsyncMock(return_value="Script")
+    with (
+        patch("workers.ad_job_worker.worker._get_session_factory", return_value=mock_session_factory),
+        patch("workers.ad_job_worker.worker.create_ad_variant", return_value=mock_ad_variant),
+        patch("workers.ad_job_worker.worker.update_ad_variant"),
+        patch("workers.ad_job_worker.worker.get_campaign", return_value=mock_campaign),
+        patch("workers.ad_job_worker.worker.get_consumer", return_value=mock_consumer),
+        patch("workers.ad_job_worker.worker.get_product", return_value=mock_product),
+        patch("workers.ad_job_worker.worker.BlobClient") as blob_cls,
+        patch("workers.ad_job_worker.worker.generate_ad_script", mock_gen_script),
+        patch("workers.ad_job_worker.worker.generate_ad_video", new_callable=AsyncMock, return_value=b"video"),
+    ):
+        blob_cls.from_connection_string.return_value = mock_blob_client
+
+        await execute_ad_job(campaign_id=1, product_id=1, consumer_id=1, version_number=1)
+
+    call_kw = mock_gen_script.await_args
+    assert call_kw is not None
+    args = call_kw[0]
+    assert args[0] == "Test Product"
+    assert args[1] == "A great product"
+    assert "data:image/png;base64," in args[2]
+    assert "age" in args[3] and "fitness" in args[3]
+    assert args[4] == "Test campaign brief"
+
+
+@pytest.mark.asyncio
+async def test_execute_ad_job_calls_generate_ad_video_with_script_and_image(
+    mock_db,
+    mock_session_factory,
+    mock_ad_variant,
+    mock_campaign,
+    mock_consumer,
+    mock_product,
+    mock_blob_client,
+):
+    """execute_ad_job passes script and image bytes/type/filename to generate_ad_video."""
+    mock_generate_video = AsyncMock(return_value=b"video")
+    with (
+        patch("workers.ad_job_worker.worker._get_session_factory", return_value=mock_session_factory),
+        patch("workers.ad_job_worker.worker.create_ad_variant", return_value=mock_ad_variant),
+        patch("workers.ad_job_worker.worker.update_ad_variant"),
+        patch("workers.ad_job_worker.worker.get_campaign", return_value=mock_campaign),
+        patch("workers.ad_job_worker.worker.get_consumer", return_value=mock_consumer),
+        patch("workers.ad_job_worker.worker.get_product", return_value=mock_product),
+        patch("workers.ad_job_worker.worker.BlobClient") as blob_cls,
+        patch("workers.ad_job_worker.worker.generate_ad_script", new_callable=AsyncMock, return_value="Script"),
+        patch("workers.ad_job_worker.worker.generate_ad_video", mock_generate_video),
+    ):
+        blob_cls.from_connection_string.return_value = mock_blob_client
+
+        await execute_ad_job(campaign_id=1, product_id=1, consumer_id=1, version_number=1)
+
+    call_args = mock_generate_video.await_args[0]
+    assert call_args[0] == "Script"
+    assert call_args[1] == b"fake image bytes"
+    assert call_args[2] == "image/png"
+    assert call_args[3] == "product-image.png"
+
+
+@pytest.mark.asyncio
+async def test_execute_ad_job_uses_image_name_fallback(mock_db, mock_session_factory, mock_ad_variant, mock_campaign, mock_consumer, mock_blob_client):
+    """Product without image_url uses image_name or placeholder."""
+    product = MagicMock()
+    product.name = "Prod"
+    product.description = "Desc"
+    product.image_url = None
+    product.image_name = "blob-name.png"
+
+    with (
+        patch("workers.ad_job_worker.worker._get_session_factory", return_value=mock_session_factory),
+        patch("workers.ad_job_worker.worker.create_ad_variant", return_value=mock_ad_variant),
+        patch("workers.ad_job_worker.worker.update_ad_variant"),
+        patch("workers.ad_job_worker.worker.get_campaign", return_value=mock_campaign),
+        patch("workers.ad_job_worker.worker.get_consumer", return_value=mock_consumer),
+        patch("workers.ad_job_worker.worker.get_product", return_value=product),
+        patch("workers.ad_job_worker.worker.BlobClient") as blob_cls,
+        patch("workers.ad_job_worker.worker.generate_ad_script", new_callable=AsyncMock, return_value="S"),
+        patch("workers.ad_job_worker.worker.generate_ad_video", new_callable=AsyncMock, return_value=b"v"),
+    ):
+        blob_cls.from_connection_string.return_value = mock_blob_client
+
+        await execute_ad_job(campaign_id=1, product_id=1, consumer_id=1, version_number=1)
+
+    # Blob client should be created with blob name from product (product-images container)
+    calls = blob_cls.from_connection_string.call_args_list
+    blob_names = [c[1].get("blob_name", "") for c in calls if len(c) > 1 and isinstance(c[1], dict)]
+    assert "blob-name.png" in blob_names
+
+
+# ---------------------------------------------------------------------------
+# Tests — generate_campaign_preview, generate_campaign_ad_variants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_generate_campaign_preview_returns_list_of_ad_variant_ids():
+    """generate_campaign_preview returns a list of ad variant IDs (one per persona with consumers)."""
+    mock_db = MagicMock()
+    mock_factory = MagicMock(return_value=mock_db)
+    mock_campaign = MagicMock()
+    mock_persona = MagicMock()
+    mock_persona.id = "persona-uuid-1"
+    mock_consumer = MagicMock()
+    mock_consumer.id = 10
+    with (
+        patch("workers.ad_job_worker.worker._get_session_factory", return_value=mock_factory),
+        patch("workers.ad_job_worker.worker.get_campaign", return_value=mock_campaign),
+        patch("workers.ad_job_worker.worker.get_personas", return_value=[mock_persona]),
+        patch("workers.ad_job_worker.worker.get_consumers_by_persona_id", return_value=[mock_consumer]),
+        patch("workers.ad_job_worker.worker.execute_ad_job", new_callable=AsyncMock, return_value=99),
+    ):
+        result = await generate_campaign_preview(campaign_id=1, product_id=1, version_number=1)
+    assert result == [99]
+    mock_db.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_generate_campaign_ad_variants_returns_batch_id_when_there_are_consumers_to_generate():
+    """generate_campaign_ad_variants creates a batch and jobs, returns batch ID."""
+    mock_db = MagicMock()
+    mock_factory = MagicMock(return_value=mock_db)
+    mock_consumer = MagicMock()
+    mock_consumer.id = 5
+    mock_batch = MagicMock()
+    mock_batch.id = "batch-uuid-123"
+    with (
+        patch("workers.ad_job_worker.worker._get_session_factory", return_value=mock_factory),
+        patch("workers.ad_job_worker.worker.get_all_consumers", return_value=[mock_consumer]),
+        patch("workers.ad_job_worker.worker.get_ad_variant_by_campaign_consumer_version", return_value=None),
+        patch("workers.ad_job_worker.worker.create_ad_job_batch", return_value=mock_batch),
+        patch("workers.ad_job_worker.worker.create_ad_job"),
+    ):
+        result = await generate_campaign_ad_variants(campaign_id=1, product_id=1, version_number=1)
+    assert result == "batch-uuid-123"
+    mock_db.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_generate_campaign_ad_variants_returns_none_when_no_consumers_need_generation():
+    """generate_campaign_ad_variants returns None when every consumer already has an ad variant."""
+    mock_db = MagicMock()
+    mock_factory = MagicMock(return_value=mock_db)
+    mock_consumer = MagicMock()
+    mock_existing = MagicMock()
+    with (
+        patch("workers.ad_job_worker.worker._get_session_factory", return_value=mock_factory),
+        patch("workers.ad_job_worker.worker.get_all_consumers", return_value=[mock_consumer]),
+        patch("workers.ad_job_worker.worker.get_ad_variant_by_campaign_consumer_version", return_value=mock_existing),
+    ):
+        result = await generate_campaign_ad_variants(campaign_id=1, product_id=1, version_number=1)
+    assert result is None
+    mock_db.close.assert_called_once()

--- a/backend/tests/test_ad_job_worker.py
+++ b/backend/tests/test_ad_job_worker.py
@@ -92,11 +92,11 @@ def mock_consumer():
 
 @pytest.fixture
 def mock_product():
-    """Fake product with name, description, image_url (or image_name)."""
+    """Fake product with name, description, image_name (used by worker for blob lookup)."""
     p = MagicMock()
     p.name = "Test Product"
     p.description = "A great product"
-    p.image_url = "product-image.png"
+    p.image_name = "product-image.png"
     return p
 
 

--- a/backend/tests/test_ad_job_worker.py
+++ b/backend/tests/test_ad_job_worker.py
@@ -289,7 +289,8 @@ async def test_generate_campaign_ad_variants_returns_batch_id_when_there_are_con
     mock_consumer = MagicMock()
     mock_consumer.id = 5
     mock_batch = MagicMock()
-    mock_batch.id = "batch-uuid-123"
+    batch_id = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+    mock_batch.id = batch_id
     with (
         patch("workers.ad_job_worker.worker._get_session_factory", return_value=mock_factory),
         patch("workers.ad_job_worker.worker.get_all_consumers", return_value=[mock_consumer]),
@@ -298,7 +299,7 @@ async def test_generate_campaign_ad_variants_returns_batch_id_when_there_are_con
         patch("workers.ad_job_worker.worker.create_ad_job"),
     ):
         result = await generate_campaign_ad_variants(campaign_id=1, product_id=1, version_number=1)
-    assert result == "batch-uuid-123"
+    assert result == batch_id
     mock_db.close.assert_called_once()
 
 

--- a/backend/tests/test_blob_upload.py
+++ b/backend/tests/test_blob_upload.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""
+Test script for Azure Blob Storage upload.
+Run from backend directory:
+    python -m pytest tests/test_blob_upload.py -v
+    or:  python tests/test_blob_upload.py
+
+Requires .env with AZURE_STORAGE_CONNECTION_STRING set.
+Uses the same container (ad-videos) and naming pattern as the ad job worker.
+"""
+import os
+import sys
+import uuid
+from pathlib import Path
+
+_backend_dir = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_backend_dir))
+
+from dotenv import load_dotenv
+from azure.storage.blob import BlobClient
+
+load_dotenv()
+
+CONTAINER = "ad-videos"
+TEST_BLOB_NAME = f"ad-videos/test-{uuid.uuid4().hex}.txt"
+TEST_CONTENT = b"test upload from backend/tests/test_blob_upload.py"
+
+
+def main() -> None:
+    conn_str = os.getenv("AZURE_STORAGE_CONNECTION_STRING", "").strip()
+    if not conn_str or conn_str.startswith("YOUR_"):
+        print("ERROR: Set AZURE_STORAGE_CONNECTION_STRING in .env (see .env.example)")
+        sys.exit(1)
+
+    print(f"Uploading test blob to container '{CONTAINER}' as '{TEST_BLOB_NAME}' ...")
+    blob_client = BlobClient.from_connection_string(
+        conn_str=conn_str,
+        container_name=CONTAINER,
+        blob_name=TEST_BLOB_NAME,
+    )
+    blob_client.upload_blob(TEST_CONTENT, overwrite=True)
+    url = blob_client.url
+    print(f"Upload OK. URL: {url}")
+
+    # Verify: blob exists and content matches
+    download = blob_client.download_blob()
+    downloaded = download.readall()
+    if downloaded != TEST_CONTENT:
+        print("ERROR: Downloaded content does not match uploaded content")
+        sys.exit(1)
+    print("Verified: downloaded content matches.")
+
+    # Optional: delete the test blob so the container stays clean
+    blob_client.delete_blob()
+    print("Test blob deleted. Blob storage is working.")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/workers/ad_job_worker/service.py
+++ b/backend/workers/ad_job_worker/service.py
@@ -15,7 +15,7 @@ async def run_job(campaign_id: int, product_id: int, consumer_id: int, version_n
     return {"status": "completed", "ad_variant_id": ad_variant_id}
 
 
-@router.get("/generate-campaign-preview")
+@router.post("/generate-campaign-preview")
 async def generate_campaign_preview(campaign_id: int, product_id: int, version_number: int):
     ad_variant_ids = await run_generate_campaign_preview(campaign_id, product_id, version_number)
     return {"status": "completed", "ad_variant_ids": ad_variant_ids}

--- a/backend/workers/ad_job_worker/service.py
+++ b/backend/workers/ad_job_worker/service.py
@@ -1,6 +1,32 @@
 from fastapi import APIRouter
 
+from workers.ad_job_worker.worker import (
+    execute_ad_job,
+    generate_campaign_preview as run_generate_campaign_preview,
+    generate_campaign_ad_variants as run_generate_campaign_ad_variants,
+)
+
 router = APIRouter()
+
+
+@router.post("/run-ad-job")
+async def run_job(campaign_id: int, product_id: int, consumer_id: int, version_number: int):
+    ad_variant_id = await execute_ad_job(campaign_id, product_id, consumer_id, version_number)
+    return {"status": "completed", "ad_variant_id": ad_variant_id}
+
+
+@router.get("/generate-campaign-preview")
+async def generate_campaign_preview(campaign_id: int, product_id: int, version_number: int):
+    ad_variant_ids = await run_generate_campaign_preview(campaign_id, product_id, version_number)
+    return {"status": "completed", "ad_variant_ids": ad_variant_ids}
+
+
+@router.post("/generate-campaign-ad-variants")
+async def generate_campaign_ad_variants(campaign_id: int, product_id: int, version_number: int):
+    batch_id = await run_generate_campaign_ad_variants(campaign_id, product_id, version_number)
+    if batch_id is None:
+        return {"status": "completed", "message": "No ad variants to generate"}
+    return {"status": "completed", "batch_id": str(batch_id), "message": "Campaign ad variants enqueued"}
 
 @router.get("/hello")
 async def hello():

--- a/backend/workers/ad_job_worker/worker.py
+++ b/backend/workers/ad_job_worker/worker.py
@@ -26,7 +26,7 @@ from schemas.ad_job import AdJobCreate
 from schemas.ad_job_batch import AdJobBatchCreate
 from workers.script_creation_worker.worker import generate_ad_script
 from workers.ad_video_generation_worker.worker import generate_ad_video
-from azure.storage.blob import BlobClient
+from azure.storage.blob import BlobClient, ContentSettings
 
 load_dotenv()
 
@@ -88,8 +88,9 @@ async def execute_ad_job(campaign_id: int, product_id: int, consumer_id: int, ve
         product_image_download = product_image_blob_client.download_blob()
         product_image_bytes = product_image_download.readall()
         base64_product_image = base64.b64encode(product_image_bytes).decode("utf-8")
-        product_image_type = product_image_blob_client.get_blob_properties().content_settings.content_type
-        product_image_filename = product_image_blob_client.get_blob_properties().name
+        props = product_image_blob_client.get_blob_properties()
+        product_image_type = props.content_settings.content_type
+        product_image_filename = props.name
         product_image_data_url = f"data:{product_image_type};base64,{base64_product_image}"
 
         script = await generate_ad_script(
@@ -106,7 +107,10 @@ async def execute_ad_job(campaign_id: int, product_id: int, consumer_id: int, ve
             blob_name=f"ad-videos/{uuid.uuid4().hex}.mp4",
         )
         blob_client.upload_blob(
-            ad_video_bytes, overwrite=True, content_settings={"content_type": "video/mp4"}, max_concurrency=4
+            ad_video_bytes,
+            overwrite=True,
+            content_settings=ContentSettings(content_type="video/mp4"),
+            max_concurrency=4,
         )
         media_url = blob_client.url
         update_ad_variant(db, ad_variant_id, AdVariantUpdate(media_url=media_url, status="completed"))

--- a/backend/workers/ad_job_worker/worker.py
+++ b/backend/workers/ad_job_worker/worker.py
@@ -1,0 +1,199 @@
+import base64
+import json
+import os
+import random
+import traceback
+import uuid
+from typing import Optional
+
+from dotenv import load_dotenv
+from sqlalchemy.orm import Session
+
+from database import _get_session_factory
+from crud.ad_variant import (
+    create_ad_variant,
+    update_ad_variant,
+    get_ad_variant_by_campaign_consumer_version,
+)
+from crud.ad_job import create_ad_job
+from crud.ad_job_batch import create_ad_job_batch
+from crud.campaign import get_campaign
+from crud.consumer import get_consumer, get_all_consumers, get_consumers_by_persona_id
+from crud.product import get_product
+from crud.persona import get_personas
+from schemas.ad_variant import AdVariantCreate, AdVariantUpdate
+from schemas.ad_job import AdJobCreate
+from schemas.ad_job_batch import AdJobBatchCreate
+from workers.script_creation_worker.worker import generate_ad_script
+from workers.ad_video_generation_worker.worker import generate_ad_video
+from azure.storage.blob import BlobClient
+
+load_dotenv()
+
+
+def _brief_for_version(brief_json: Optional[str], version_number: int) -> str:
+    """Resolve campaign brief for a version. brief_json is a JSON object with keys = version_number, value = brief text."""
+    if not brief_json or not brief_json.strip():
+        return ""
+    try:
+        data = json.loads(brief_json)
+        if not isinstance(data, dict):
+            return ""
+        # Keys may be stored as string or int
+        val = data.get(str(version_number))
+        if val is None:
+            val = data.get(version_number)
+        return val if val is not None else ""
+    except (json.JSONDecodeError, TypeError):
+        return ""
+
+
+async def execute_ad_job(campaign_id: int, product_id: int, consumer_id: int, version_number: int) -> int:
+    factory = _get_session_factory()
+    db: Session = factory()
+    ad_variant = create_ad_variant(
+        db,
+        AdVariantCreate(campaign_id=campaign_id, consumer_id=consumer_id, status="Generating", version_number=version_number),
+    )
+    ad_variant_id = ad_variant.id
+
+    try:
+        campaign = get_campaign(db, campaign_id)
+        if campaign is None:
+            raise ValueError(f"Campaign not found: {campaign_id}")
+        campaign_brief = _brief_for_version(campaign.brief, version_number)
+
+        consumer = get_consumer(db, consumer_id)
+        if consumer is None:
+            raise ValueError(f"Consumer not found: {consumer_id}")
+        consumer_traits = json.loads(consumer.traits or "{}")
+        consumer_traits_string = (
+            "\n".join(f"{k}: {v}" for k, v in consumer_traits.items()) if consumer_traits else ""
+        )
+
+        product = get_product(db, product_id)
+        if product is None:
+            raise ValueError(f"Product not found: {product_id}")
+        if not product.image_name or not product.image_name.strip():
+            raise ValueError(f"Product {product_id} has no image (image_name required for ad generation)")
+        product_name = product.name
+        product_description = product.description
+        product_image_filename = product.image_name
+
+        product_image_blob_client = BlobClient.from_connection_string(
+            conn_str=os.getenv("AZURE_STORAGE_CONNECTION_STRING", "").strip(),
+            container_name="product-images",
+            blob_name=f"{product_image_filename}",
+        )
+        product_image_download = product_image_blob_client.download_blob()
+        product_image_bytes = product_image_download.readall()
+        base64_product_image = base64.b64encode(product_image_bytes).decode("utf-8")
+        product_image_type = product_image_blob_client.get_blob_properties().content_settings.content_type
+        product_image_filename = product_image_blob_client.get_blob_properties().name
+        product_image_data_url = f"data:{product_image_type};base64,{base64_product_image}"
+
+        script = await generate_ad_script(
+            product_name, product_description, product_image_data_url, consumer_traits_string, campaign_brief
+        )
+        update_ad_variant(db, ad_variant_id, AdVariantUpdate(meta=json.dumps({"script": script})))
+
+        ad_video_bytes = await generate_ad_video(
+            script, product_image_bytes, product_image_type, product_image_filename
+        )
+        blob_client = BlobClient.from_connection_string(
+            conn_str=os.getenv("AZURE_STORAGE_CONNECTION_STRING", "").strip(),
+            container_name="ad-videos",
+            blob_name=f"ad-videos/{uuid.uuid4().hex}.mp4",
+        )
+        blob_client.upload_blob(
+            ad_video_bytes, overwrite=True, content_settings={"content_type": "video/mp4"}, max_concurrency=4
+        )
+        media_url = blob_client.url
+        update_ad_variant(db, ad_variant_id, AdVariantUpdate(media_url=media_url, status="completed"))
+    except Exception:
+        # Error replaces meta entirely (script, if any, is not preserved)
+        update_ad_variant(
+            db,
+            ad_variant_id,
+            AdVariantUpdate(status="failed", meta=json.dumps({"error": traceback.format_exc()})),
+        )
+        raise
+    finally:
+        db.close()
+    return ad_variant_id
+
+
+async def generate_campaign_preview(
+    campaign_id: int, product_id: int, version_number: int
+) -> list:
+    """Generate up to 6 preview ad variants (one consumer per selected persona). Returns list of ad_variant IDs."""
+    factory = _get_session_factory()
+    db: Session = factory()
+    try:
+        campaign = get_campaign(db, campaign_id)
+        if campaign is None:
+            raise ValueError(f"Campaign not found: {campaign_id}")
+
+        personas = get_personas(db)
+        selected_personas = random.sample(personas, min(6, len(personas)))
+        created_ad_variant_ids = []
+        for persona in selected_personas:
+            consumers = get_consumers_by_persona_id(db, persona.id)
+            if not consumers:
+                continue
+            selected_consumer = random.choice(consumers)
+            ad_variant_id = await execute_ad_job(campaign_id, product_id, selected_consumer.id, version_number)
+            created_ad_variant_ids.append(ad_variant_id)
+        return created_ad_variant_ids
+    finally:
+        db.close()
+
+
+async def generate_campaign_ad_variants(
+    campaign_id: int, product_id: int, version_number: int, user_id: Optional[uuid.UUID] = None
+):
+    """Enqueue ad jobs for all consumers that don't yet have an ad variant for this campaign/version. Returns batch ID."""
+    factory = _get_session_factory()
+    db: Session = factory()
+    try:
+        consumers = get_all_consumers(db)
+        need_to_generate = []
+        for consumer in consumers:
+            existing = get_ad_variant_by_campaign_consumer_version(
+                db, campaign_id=campaign_id, consumer_id=consumer.id, version_number=version_number
+            )
+            if existing is None:
+                need_to_generate.append(consumer)
+
+        if not need_to_generate:
+            return None  # "No ad variants to generate"
+
+        batch_user_id = user_id if user_id is not None else uuid.uuid4()
+        ad_job_batch = create_ad_job_batch(
+            db,
+            AdJobBatchCreate(
+                user_id=batch_user_id,
+                status="pending",
+                total_jobs=len(need_to_generate),
+            ),
+        )
+        ad_job_batch_id = ad_job_batch.id
+        for consumer in need_to_generate:
+            input_json = json.dumps({
+                "campaign_id": campaign_id,
+                "product_id": product_id,
+                "consumer_id": consumer.id,
+                "version_number": version_number,
+            })
+            create_ad_job(
+                db,
+                AdJobCreate(
+                    batch_id=ad_job_batch_id,
+                    status="pending",
+                    input_json=input_json,
+                    attempt_count=0,
+                ),
+            )
+        return ad_job_batch_id
+    finally:
+        db.close()


### PR DESCRIPTION
## Changes

* Models: AdJob (batch_id, status, input/output JSON, lock fields, attempt_count), AdJobBatch (user_id, total/succeeded/failed counts, idempotency_key).
* API: CRUD for /ad-jobs and /ad-job-batches (list with filters, create batch + enqueue jobs).
* Poller: Polls pending jobs, claims with lock, runs execute_ad_job, updates status and batch progress; invalid input → failed without claiming. Config: AD_JOB_POLL_INTERVAL_SECONDS, AD_JOB_MAX_ATTEMPTS.
* Worker: execute_ad_job creates ad variant, loads campaign/consumer/product, generates script + video, uploads to Blob.
* Tests: test_ad_job_crud, test_ad_job_poller, test_ad_job_worker, test_blob_upload; conftest + pytest.ini.