### PR TITLE
Feat/product management ad generation

### DIFF
--- a/backend/routes/product.py
+++ b/backend/routes/product.py
@@ -1,9 +1,12 @@
-"""API routes for products — full CRUD endpoints (JWT-protected)."""
+"""API routes for products — full CRUD + image upload endpoints (JWT-protected)."""
 
+import os
+import uuid
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, File
 from sqlalchemy.orm import Session
+from azure.storage.blob import BlobClient, ContentSettings
 
 from database import get_db
 from dependencies import get_current_client_id
@@ -85,3 +88,64 @@ def remove_product(
     if product is None or product.business_client_id != client_id:
         raise HTTPException(status_code=404, detail="Product not found")
     delete_product(db, product_id)
+
+
+ALLOWED_IMAGE_TYPES = {
+    "image/jpeg": ".jpg",
+    "image/png": ".png",
+    "image/webp": ".webp",
+    "image/gif": ".gif",
+}
+MAX_IMAGE_SIZE = 10 * 1024 * 1024  # 10 MB
+
+
+@router.post("/{product_id}/upload-image", response_model=ProductResponse)
+async def upload_product_image(
+    product_id: int,
+    file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+    client_id: int = Depends(get_current_client_id),
+):
+    """Upload or replace a product image. Stores in Azure Blob Storage (product-images container)."""
+    product = get_product(db, product_id)
+    if product is None or product.business_client_id != client_id:
+        raise HTTPException(status_code=404, detail="Product not found")
+
+    content_type = file.content_type or ""
+    if content_type not in ALLOWED_IMAGE_TYPES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported image type: {content_type}. Allowed: {', '.join(ALLOWED_IMAGE_TYPES.keys())}",
+        )
+
+    image_bytes = await file.read()
+    if len(image_bytes) > MAX_IMAGE_SIZE:
+        raise HTTPException(status_code=400, detail="Image must be under 10 MB.")
+
+    ext = ALLOWED_IMAGE_TYPES[content_type]
+    blob_name = f"{uuid.uuid4().hex}{ext}"
+
+    conn_str = os.getenv("AZURE_STORAGE_CONNECTION_STRING", "").strip()
+    if not conn_str:
+        raise HTTPException(status_code=500, detail="Storage not configured.")
+
+    blob_client = BlobClient.from_connection_string(
+        conn_str=conn_str,
+        container_name="product-images",
+        blob_name=blob_name,
+    )
+    blob_client.upload_blob(
+        image_bytes,
+        overwrite=True,
+        content_settings=ContentSettings(content_type=content_type),
+    )
+
+    return update_product(
+        db,
+        product_id,
+        ProductUpdate(
+            name=product.name,
+            image_url=blob_client.url,
+            image_name=blob_name,
+        ),
+    )

--- a/backend/routes/product.py
+++ b/backend/routes/product.py
@@ -2,11 +2,18 @@
 
 import os
 import uuid
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, UploadFile, File
 from sqlalchemy.orm import Session
-from azure.storage.blob import BlobClient, ContentSettings
+from azure.storage.blob import (
+    BlobClient,
+    BlobSasPermissions,
+    ContainerClient,
+    ContentSettings,
+    generate_blob_sas,
+)
 
 from database import get_db
 from dependencies import get_current_client_id
@@ -21,6 +28,36 @@ from crud.product import (
 
 router = APIRouter()
 
+CONTAINER_NAME = "product-images"
+SAS_EXPIRY_HOURS = 1
+
+
+def _parse_conn_str(conn_str: str) -> tuple[str, str]:
+    """Extract account_name and account_key from an Azure Storage connection string."""
+    parts = dict(part.split("=", 1) for part in conn_str.split(";") if "=" in part)
+    return parts["AccountName"], parts["AccountKey"]
+
+
+def _sign_product(product) -> ProductResponse:
+    """Convert ORM product to response with a time-limited SAS URL for the image."""
+    resp = ProductResponse.model_validate(product, from_attributes=True)
+    if not resp.image_url or not resp.image_name:
+        return resp
+    conn_str = os.getenv("AZURE_STORAGE_CONNECTION_STRING", "").strip()
+    if not conn_str:
+        return resp
+    account_name, account_key = _parse_conn_str(conn_str)
+    sas_token = generate_blob_sas(
+        account_name=account_name,
+        container_name=CONTAINER_NAME,
+        blob_name=resp.image_name,
+        account_key=account_key,
+        permission=BlobSasPermissions(read=True),
+        expiry=datetime.now(timezone.utc) + timedelta(hours=SAS_EXPIRY_HOURS),
+    )
+    resp.image_url = f"{resp.image_url}?{sas_token}"
+    return resp
+
 
 @router.get("/", response_model=list[ProductResponse])
 def list_products(
@@ -31,13 +68,14 @@ def list_products(
     client_id: int = Depends(get_current_client_id),
 ):
     """Get all products for the authenticated client, with optional is_active filter."""
-    return get_products(
+    products = get_products(
         db,
         business_client_id=client_id,
         is_active=is_active,
         skip=skip,
         limit=limit,
     )
+    return [_sign_product(p) for p in products]
 
 
 @router.get("/{product_id}", response_model=ProductResponse)
@@ -50,7 +88,7 @@ def read_product(
     product = get_product(db, product_id)
     if product is None or product.business_client_id != client_id:
         raise HTTPException(status_code=404, detail="Product not found")
-    return product
+    return _sign_product(product)
 
 
 @router.post("/", response_model=ProductResponse, status_code=201)
@@ -60,7 +98,7 @@ def create_new_product(
     client_id: int = Depends(get_current_client_id),
 ):
     """Create a new product for the authenticated client."""
-    return create_product(db, client_id, data)
+    return _sign_product(create_product(db, client_id, data))
 
 
 @router.put("/{product_id}", response_model=ProductResponse)
@@ -74,7 +112,7 @@ def update_existing_product(
     product = get_product(db, product_id)
     if product is None or product.business_client_id != client_id:
         raise HTTPException(status_code=404, detail="Product not found")
-    return update_product(db, product_id, data)
+    return _sign_product(update_product(db, product_id, data))
 
 
 @router.delete("/{product_id}", status_code=204)
@@ -129,6 +167,13 @@ async def upload_product_image(
     if not conn_str:
         raise HTTPException(status_code=500, detail="Storage not configured.")
 
+    container = ContainerClient.from_connection_string(
+        conn_str=conn_str,
+        container_name="product-images",
+    )
+    if not container.exists():
+        container.create_container()
+
     blob_client = BlobClient.from_connection_string(
         conn_str=conn_str,
         container_name="product-images",
@@ -140,7 +185,7 @@ async def upload_product_image(
         content_settings=ContentSettings(content_type=content_type),
     )
 
-    return update_product(
+    updated = update_product(
         db,
         product_id,
         ProductUpdate(
@@ -149,3 +194,4 @@ async def upload_product_image(
             image_name=blob_name,
         ),
     )
+    return _sign_product(updated)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import { CampaignsPage } from './pages/CampaignsPage';
 import { CustomerDataPage } from './pages/CustomerDataPage';
 import { AllConsumersPage } from './pages/AllConsumersPage';
 import { SettingsPage } from './pages/SettingsPage';
+import { ProductsPage } from './pages/ProductsPage';
 import { UserProvider } from './contexts/UserContext';
 import { CompanyProvider } from './contexts/CompanyContext';
 import { ConsumerProvider } from './contexts/ConsumerContext';
@@ -38,6 +39,7 @@ export function App() {
                 <Route path="/onboarding" element={<OnboardingPage />} />
                 <Route path="/dashboard" element={<DashboardPage />} />
                 <Route path="/campaigns" element={<CampaignsPage />} />
+                <Route path="/products" element={<ProductsPage />} />
                 <Route path="/customer-data" element={<CustomerDataPage />} />
                 <Route path="/campaign/:id" element={<CampaignDetailPage />} />
                 <Route path="/generate" element={<GenerateAdsPage />} />

--- a/frontend/src/api/products.ts
+++ b/frontend/src/api/products.ts
@@ -1,0 +1,105 @@
+import { apiUrl, authHeaders } from './config';
+import type { Product, CreateProductPayload, UpdateProductPayload } from '../types';
+
+// ---------- API calls ----------
+
+export async function fetchProducts(
+  businessClientId: number,
+): Promise<Product[]> {
+  const params = new URLSearchParams({
+    business_client_id: String(businessClientId),
+  });
+
+  const res = await fetch(apiUrl(`/products/?${params.toString()}`), {
+    headers: authHeaders(),
+  });
+
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.detail || 'Failed to fetch products.');
+  }
+
+  return (await res.json()) as Product[];
+}
+
+export async function fetchProduct(productId: number): Promise<Product> {
+  const res = await fetch(apiUrl(`/products/${productId}`), {
+    headers: authHeaders(),
+  });
+
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.detail || 'Product not found.');
+  }
+
+  return (await res.json()) as Product;
+}
+
+export async function createProduct(
+  data: CreateProductPayload,
+): Promise<Product> {
+  const res = await fetch(apiUrl('/products/'), {
+    method: 'POST',
+    headers: authHeaders(),
+    body: JSON.stringify(data),
+  });
+
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.detail || 'Failed to create product.');
+  }
+
+  return (await res.json()) as Product;
+}
+
+export async function updateProduct(
+  productId: number,
+  data: UpdateProductPayload,
+): Promise<Product> {
+  const res = await fetch(apiUrl(`/products/${productId}`), {
+    method: 'PUT',
+    headers: authHeaders(),
+    body: JSON.stringify(data),
+  });
+
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.detail || 'Failed to update product.');
+  }
+
+  return (await res.json()) as Product;
+}
+
+export async function deleteProduct(productId: number): Promise<void> {
+  const res = await fetch(apiUrl(`/products/${productId}`), {
+    method: 'DELETE',
+    headers: authHeaders(),
+  });
+
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.detail || 'Failed to delete product.');
+  }
+}
+
+/** Upload or replace a product image (multipart). Returns updated product. */
+export async function uploadProductImage(
+  productId: number,
+  file: File,
+): Promise<Product> {
+  const formData = new FormData();
+  formData.append('file', file);
+
+  const res = await fetch(apiUrl(`/products/${productId}/upload-image`), {
+    method: 'POST',
+    headers: authHeaders(false), // no Content-Type — browser sets multipart boundary
+    body: formData,
+  });
+
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.detail || 'Failed to upload product image.');
+  }
+
+  return (await res.json()) as Product;
+}

--- a/frontend/src/components/campaigns/CreateCampaignModal.tsx
+++ b/frontend/src/components/campaigns/CreateCampaignModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { Card } from '../ui/Card';
 import { Button } from '../ui/Button';
 import { Input } from '../ui/Input';
@@ -9,14 +9,22 @@ import {
   CheckIcon,
   Loader2Icon,
   SparklesIcon,
+  PlusIcon,
+  SearchIcon,
+  PackageIcon,
+  ImageIcon,
 } from 'lucide-react';
 import { useCreateCampaign } from '../../hooks/useCampaigns';
+import { useProducts } from '../../hooks/useProducts';
+import type { Product } from '../../types';
 
 const platforms = [
-  { id: 'meta', label: 'Meta' },
+  { id: 'instagram', label: 'Instagram' },
+  { id: 'facebook', label: 'Facebook' },
   { id: 'tiktok', label: 'TikTok' },
   { id: 'youtube', label: 'YouTube' },
   { id: 'linkedin', label: 'LinkedIn' },
+  { id: 'X', label: 'Twitter' },
 ];
 
 const regions = [
@@ -25,6 +33,175 @@ const regions = [
   { id: 'apac', label: 'Asia Pacific' },
   { id: 'global', label: 'Global' },
 ];
+
+// ---------- Product Selector ----------
+
+function ProductSelector({
+  businessClientId,
+  selectedProduct,
+  onSelect,
+  error,
+  disabled,
+}: {
+  businessClientId: number;
+  selectedProduct: Product | null;
+  onSelect: (product: Product | null) => void;
+  error?: string;
+  disabled?: boolean;
+}) {
+  const { data: products = [], isLoading } = useProducts(businessClientId);
+  const [query, setQuery] = useState('');
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const filtered = products.filter(
+    (p) =>
+      p.name.toLowerCase().includes(query.toLowerCase()) ||
+      (p.description ?? '').toLowerCase().includes(query.toLowerCase()),
+  );
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, []);
+
+  // If a product is selected, show a chip instead of the search input
+  if (selectedProduct) {
+    return (
+      <div>
+        <label className="block text-sm font-medium text-slate-700 mb-1.5">
+          Product *
+        </label>
+        <div className="flex items-center gap-2 px-3 py-2 bg-blue-50 border border-blue-200 rounded-xl">
+          {selectedProduct.image_url ? (
+            <img
+              src={selectedProduct.image_url}
+              alt={selectedProduct.name}
+              className="w-8 h-8 rounded-lg object-cover flex-shrink-0"
+            />
+          ) : (
+            <div className="w-8 h-8 rounded-lg bg-slate-100 flex items-center justify-center flex-shrink-0">
+              <ImageIcon className="w-4 h-4 text-slate-400" />
+            </div>
+          )}
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium text-slate-900 truncate">
+              {selectedProduct.name}
+            </p>
+            {selectedProduct.description && (
+              <p className="text-xs text-slate-500 truncate">
+                {selectedProduct.description}
+              </p>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={() => !disabled && onSelect(null)}
+            disabled={disabled}
+            className="p-1 rounded-lg hover:bg-blue-100 transition-colors text-slate-500 hover:text-slate-700"
+          >
+            <XIcon className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div ref={containerRef} className="relative">
+      <label className="block text-sm font-medium text-slate-700 mb-1.5">
+        Product *
+      </label>
+      <div className="relative">
+        <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
+        <input
+          type="text"
+          placeholder="Search your products..."
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setIsOpen(true);
+          }}
+          onFocus={() => setIsOpen(true)}
+          disabled={disabled}
+          className={`
+            w-full pl-9 pr-4 py-2.5 bg-white border rounded-xl text-sm
+            focus:outline-none focus:ring-2 focus:ring-blue-500
+            disabled:opacity-50 disabled:cursor-not-allowed
+            ${error ? 'border-red-300' : 'border-slate-200'}
+          `}
+        />
+      </div>
+      {error && <p className="mt-1 text-xs text-red-500">{error}</p>}
+
+      {isOpen && (
+        <div className="absolute z-10 mt-1 w-full bg-white border border-slate-200 rounded-xl shadow-lg max-h-52 overflow-y-auto">
+          {isLoading && (
+            <div className="flex items-center gap-2 px-4 py-3 text-sm text-slate-500">
+              <Loader2Icon className="w-4 h-4 animate-spin" />
+              Loading products...
+            </div>
+          )}
+
+          {!isLoading && filtered.length === 0 && (
+            <div className="flex flex-col items-center gap-1 px-4 py-4 text-center">
+              <PackageIcon className="w-5 h-5 text-slate-300" />
+              <p className="text-sm text-slate-500">
+                {products.length === 0
+                  ? 'No products yet. Add one on the Products page.'
+                  : 'No products match your search.'}
+              </p>
+            </div>
+          )}
+
+          {!isLoading &&
+            filtered.map((product) => (
+              <button
+                key={product.id}
+                type="button"
+                onClick={() => {
+                  onSelect(product);
+                  setQuery('');
+                  setIsOpen(false);
+                }}
+                className="w-full flex items-center gap-3 px-4 py-2.5 hover:bg-slate-50 transition-colors text-left"
+              >
+                {product.image_url ? (
+                  <img
+                    src={product.image_url}
+                    alt={product.name}
+                    className="w-8 h-8 rounded-lg object-cover flex-shrink-0"
+                  />
+                ) : (
+                  <div className="w-8 h-8 rounded-lg bg-slate-100 flex items-center justify-center flex-shrink-0">
+                    <ImageIcon className="w-4 h-4 text-slate-400" />
+                  </div>
+                )}
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm font-medium text-slate-900 truncate">
+                    {product.name}
+                  </p>
+                  {product.description && (
+                    <p className="text-xs text-slate-500 truncate">
+                      {product.description}
+                    </p>
+                  )}
+                </div>
+              </button>
+            ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------- Main Modal ----------
 
 interface CreateCampaignModalProps {
   businessClientId: number;
@@ -37,9 +214,9 @@ export function CreateCampaignModal({ businessClientId, onClose }: CreateCampaig
   const [isAutofilling, setIsAutofilling] = useState(false);
   const [customGoal, setCustomGoal] = useState('');
   const [errors, setErrors] = useState<Record<string, string>>({});
+  const [selectedProduct, setSelectedProduct] = useState<Product | null>(null);
   const [newCampaign, setNewCampaign] = useState({
     name: '',
-    product: '',
     targetAudience: '',
     goal: '',
     platforms: [] as string[],
@@ -74,7 +251,7 @@ export function CreateCampaignModal({ businessClientId, onClose }: CreateCampaig
   const handleCreateCampaign = () => {
     const newErrors: Record<string, string> = {};
     if (!newCampaign.name) newErrors.name = 'Campaign name is required';
-    if (!newCampaign.product) newErrors.product = 'Product/Service is required';
+    if (!selectedProduct) newErrors.product = 'Please select a product';
     if (!newCampaign.targetAudience)
       newErrors.targetAudience = 'Target audience is required';
     if (Object.keys(newErrors).length > 0) {
@@ -86,7 +263,8 @@ export function CreateCampaignModal({ businessClientId, onClose }: CreateCampaig
       {
         business_client_id: businessClientId,
         name: newCampaign.name,
-        product_context: newCampaign.product,
+        product_context: selectedProduct!.name,
+        product_ids: JSON.stringify([selectedProduct!.id]),
         target_audience: newCampaign.targetAudience,
         goal: newCampaign.goal === 'other' ? customGoal || 'other' : newCampaign.goal || null,
       },
@@ -149,13 +327,16 @@ export function CreateCampaignModal({ businessClientId, onClose }: CreateCampaig
             disabled={isCreating}
           />
 
-          <Input
-            label="Product / Service *"
-            placeholder="What are you advertising?"
-            value={newCampaign.product}
-            onChange={(e) =>
-              setNewCampaign({ ...newCampaign, product: e.target.value })
-            }
+          <ProductSelector
+            businessClientId={businessClientId}
+            selectedProduct={selectedProduct}
+            onSelect={(p) => {
+              setSelectedProduct(p);
+              setErrors((prev) => {
+                const { product: _, ...rest } = prev;
+                return rest;
+              });
+            }}
             error={errors.product}
             disabled={isCreating}
           />
@@ -257,7 +438,7 @@ export function CreateCampaignModal({ businessClientId, onClose }: CreateCampaig
           </Button>
           <Button
             onClick={handleCreateCampaign}
-            leftIcon={isCreating ? undefined : <SparklesIcon className="w-4 h-4" />}
+            leftIcon={isCreating ? undefined : <PlusIcon className="w-4 h-4" />}
             isLoading={isCreating}
             disabled={isCreating}
           >

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -5,6 +5,7 @@ import { useCompany } from '../../contexts/CompanyContext';
 import {
   LayoutDashboardIcon,
   FolderIcon,
+  PackageIcon,
   SparklesIcon,
   ChevronLeftIcon,
   LogOutIcon,
@@ -22,6 +23,11 @@ const navItems = [
     path: '/campaigns',
     label: 'Campaigns',
     icon: FolderIcon
+  },
+  {
+    path: '/products',
+    label: 'Products',
+    icon: PackageIcon
   },
   {
     path: '/generate',

--- a/frontend/src/hooks/useProducts.ts
+++ b/frontend/src/hooks/useProducts.ts
@@ -1,0 +1,67 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  fetchProducts,
+  createProduct,
+  updateProduct,
+  deleteProduct,
+  uploadProductImage,
+} from '../api/products';
+import type { CreateProductPayload, UpdateProductPayload } from '../types';
+
+export const PRODUCTS_KEY = ['products'] as const;
+
+/** Fetch all products for a business client. */
+export function useProducts(businessClientId: number | undefined) {
+  return useQuery({
+    queryKey: [...PRODUCTS_KEY, businessClientId],
+    queryFn: () => fetchProducts(businessClientId!),
+    enabled: !!businessClientId,
+    staleTime: 30_000,
+  });
+}
+
+/** Create a new product. Invalidates the products list on success. */
+export function useCreateProduct() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: CreateProductPayload) => createProduct(data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: PRODUCTS_KEY });
+    },
+  });
+}
+
+/** Update an existing product. Invalidates the products list on success. */
+export function useUpdateProduct() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ productId, data }: { productId: number; data: UpdateProductPayload }) =>
+      updateProduct(productId, data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: PRODUCTS_KEY });
+    },
+  });
+}
+
+/** Delete a product. Invalidates the products list on success. */
+export function useDeleteProduct() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (productId: number) => deleteProduct(productId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: PRODUCTS_KEY });
+    },
+  });
+}
+
+/** Upload or replace a product image. Invalidates the products list on success. */
+export function useUploadProductImage() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ productId, file }: { productId: number; file: File }) =>
+      uploadProductImage(productId, file),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: PRODUCTS_KEY });
+    },
+  });
+}

--- a/frontend/src/pages/ProductsPage.tsx
+++ b/frontend/src/pages/ProductsPage.tsx
@@ -1,0 +1,438 @@
+import { useState, useRef } from 'react';
+import { Sidebar } from '../components/layout/Sidebar';
+import { Card } from '../components/ui/Card';
+import { Button } from '../components/ui/Button';
+import { Input } from '../components/ui/Input';
+import { Textarea } from '../components/ui/Textarea';
+import {
+  PlusIcon,
+  SearchIcon,
+  PackageIcon,
+  Loader2Icon,
+  AlertCircleIcon,
+  XIcon,
+  ImageIcon,
+  TrashIcon,
+  UploadIcon,
+  ExternalLinkIcon,
+} from 'lucide-react';
+
+import { useUser } from '../contexts/UserContext';
+import {
+  useProducts,
+  useCreateProduct,
+  useDeleteProduct,
+  useUploadProductImage,
+} from '../hooks/useProducts';
+import type { Product } from '../types';
+
+// ---------- Product Card ----------
+
+function ProductCard({
+  product,
+  onDelete,
+  onUploadImage,
+}: {
+  product: Product;
+  onDelete: (p: Product) => void;
+  onUploadImage: (p: Product) => void;
+}) {
+  return (
+    <Card variant="default" padding="none" className="overflow-hidden group">
+      {/* Image area */}
+      <div className="h-40 bg-slate-100 flex items-center justify-center relative">
+        {product.image_url ? (
+          <img
+            src={product.image_url}
+            alt={product.name}
+            className="w-full h-full object-cover"
+          />
+        ) : (
+          <div className="flex flex-col items-center gap-2 text-slate-400">
+            <ImageIcon className="w-8 h-8" />
+            <span className="text-xs">No image</span>
+          </div>
+        )}
+        {/* Upload overlay on hover */}
+        <button
+          onClick={() => onUploadImage(product)}
+          className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center gap-2 text-white text-sm font-medium"
+        >
+          <UploadIcon className="w-4 h-4" />
+          {product.image_url ? 'Replace Image' : 'Upload Image'}
+        </button>
+      </div>
+
+      {/* Info */}
+      <div className="p-4">
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0 flex-1">
+            <h3 className="font-semibold text-slate-900 text-sm truncate">
+              {product.name}
+            </h3>
+            {product.description && (
+              <p className="text-xs text-slate-500 mt-1 line-clamp-2">
+                {product.description}
+              </p>
+            )}
+          </div>
+          {product.image_url && (
+            <span className="flex-shrink-0 px-1.5 py-0.5 bg-green-50 text-green-600 text-[10px] font-medium rounded">
+              Image
+            </span>
+          )}
+        </div>
+
+        {product.product_link && (
+          <a
+            href={product.product_link}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 text-xs text-blue-600 hover:text-blue-700 mt-2"
+          >
+            <ExternalLinkIcon className="w-3 h-3" />
+            Product link
+          </a>
+        )}
+
+        <div className="flex items-center gap-2 mt-3 pt-3 border-t border-slate-100">
+          <button
+            onClick={() => onUploadImage(product)}
+            className="flex items-center gap-1 px-2 py-1 text-xs text-slate-600 hover:bg-slate-100 rounded-lg transition-colors"
+          >
+            <ImageIcon className="w-3 h-3" />
+            {product.image_url ? 'Replace' : 'Add'} Image
+          </button>
+          <div className="flex-1" />
+          <button
+            onClick={() => onDelete(product)}
+            className="p-1 text-slate-400 hover:text-red-500 rounded-lg hover:bg-red-50 transition-colors"
+          >
+            <TrashIcon className="w-3.5 h-3.5" />
+          </button>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+// ---------- Create Product Modal ----------
+
+function CreateProductModal({ onClose }: { onClose: () => void }) {
+  const createMutation = useCreateProduct();
+  const [form, setForm] = useState({
+    name: '',
+    description: '',
+    product_link: '',
+  });
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const isCreating = createMutation.isPending;
+
+  const handleCreate = () => {
+    const newErrors: Record<string, string> = {};
+    if (!form.name.trim()) newErrors.name = 'Product name is required';
+    if (Object.keys(newErrors).length > 0) {
+      setErrors(newErrors);
+      return;
+    }
+
+    createMutation.mutate(
+      {
+        name: form.name.trim(),
+        description: form.description.trim() || null,
+        product_link: form.product_link.trim() || null,
+      },
+      { onSuccess: onClose },
+    );
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div
+        className="absolute inset-0 bg-slate-900/50 backdrop-blur-sm"
+        onClick={() => !isCreating && onClose()}
+      />
+
+      <Card
+        variant="elevated"
+        padding="lg"
+        className="relative w-full max-w-md"
+      >
+        <div className="flex items-center justify-between mb-6">
+          <h2 className="text-xl font-semibold text-slate-900">Add Product</h2>
+          <button
+            onClick={onClose}
+            className="p-1 rounded-lg hover:bg-slate-100 transition-colors"
+            disabled={isCreating}
+          >
+            <XIcon className="w-5 h-5 text-slate-500" />
+          </button>
+        </div>
+
+        <div className="space-y-4">
+          <Input
+            label="Product Name *"
+            placeholder="e.g., AirPods Pro 2"
+            value={form.name}
+            onChange={(e) => setForm({ ...form, name: e.target.value })}
+            error={errors.name}
+            disabled={isCreating}
+          />
+
+          <Textarea
+            label="Description"
+            placeholder="Brief description of the product..."
+            rows={3}
+            value={form.description}
+            onChange={(e) => setForm({ ...form, description: e.target.value })}
+            disabled={isCreating}
+          />
+
+          <Input
+            label="Product Link"
+            placeholder="https://example.com/product"
+            value={form.product_link}
+            onChange={(e) => setForm({ ...form, product_link: e.target.value })}
+            disabled={isCreating}
+          />
+
+          <p className="text-xs text-slate-500">
+            You can upload a product image after creating the product.
+          </p>
+        </div>
+
+        {createMutation.isError && (
+          <p className="mt-4 text-sm text-red-600 bg-red-50 rounded-lg px-3 py-2">
+            {(createMutation.error as Error).message}
+          </p>
+        )}
+
+        <div className="flex items-center justify-end gap-3 mt-6 pt-6 border-t border-slate-100">
+          <Button variant="ghost" onClick={onClose} disabled={isCreating}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleCreate}
+            leftIcon={<PlusIcon className="w-4 h-4" />}
+            isLoading={isCreating}
+          >
+            {isCreating ? 'Creating...' : 'Add Product'}
+          </Button>
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+// ---------- Delete Confirmation Modal ----------
+
+function DeleteProductModal({
+  product,
+  onClose,
+  onConfirm,
+  isLoading,
+}: {
+  product: Product;
+  onClose: () => void;
+  onConfirm: () => void;
+  isLoading: boolean;
+}) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-slate-900/50 backdrop-blur-sm" onClick={onClose} />
+      <Card variant="elevated" padding="lg" className="relative w-full max-w-sm">
+        <h2 className="text-lg font-semibold text-slate-900 mb-2">Delete Product</h2>
+        <p className="text-sm text-slate-600 mb-6">
+          Are you sure you want to delete <strong>{product.name}</strong>? This action cannot be undone.
+        </p>
+        <div className="flex justify-end gap-3">
+          <Button variant="ghost" onClick={onClose} disabled={isLoading}>Cancel</Button>
+          <Button variant="danger" onClick={onConfirm} isLoading={isLoading}>
+            Delete
+          </Button>
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+// ---------- Main Page ----------
+
+export function ProductsPage() {
+  const { user } = useUser();
+  const businessClientId = user?.client_id;
+
+  const { data: products = [], isLoading, isError, error } = useProducts(businessClientId);
+  const deleteMutation = useDeleteProduct();
+  const uploadMutation = useUploadProductImage();
+
+  const [searchQuery, setSearchQuery] = useState('');
+  const [showCreateModal, setShowCreateModal] = useState(false);
+  const [productToDelete, setProductToDelete] = useState<Product | null>(null);
+
+  // Hidden file input for image uploads
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [uploadTargetProduct, setUploadTargetProduct] = useState<Product | null>(null);
+
+  const filteredProducts = products.filter((p) =>
+    p.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+    (p.description ?? '').toLowerCase().includes(searchQuery.toLowerCase()),
+  );
+
+  const handleUploadImage = (product: Product) => {
+    setUploadTargetProduct(product);
+    fileInputRef.current?.click();
+  };
+
+  const handleFileSelected = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file || !uploadTargetProduct) return;
+
+    uploadMutation.mutate(
+      { productId: uploadTargetProduct.id, file },
+      {
+        onSettled: () => {
+          setUploadTargetProduct(null);
+          if (fileInputRef.current) fileInputRef.current.value = '';
+        },
+      },
+    );
+  };
+
+  const handleConfirmDelete = () => {
+    if (!productToDelete) return;
+    deleteMutation.mutate(productToDelete.id, {
+      onSuccess: () => setProductToDelete(null),
+    });
+  };
+
+  return (
+    <div className="flex min-h-screen bg-slate-50">
+      <Sidebar />
+
+      <main className="ml-64 flex-1 p-8">
+        {/* Header */}
+        <div className="flex items-center justify-between mb-8">
+          <div>
+            <h1 className="text-2xl font-bold text-slate-900">Products</h1>
+            <p className="text-sm text-slate-500 mt-1">
+              Manage the products and services you advertise
+            </p>
+          </div>
+          <Button
+            leftIcon={<PlusIcon className="w-4 h-4" />}
+            onClick={() => setShowCreateModal(true)}
+          >
+            Add Product
+          </Button>
+        </div>
+
+        {/* Search */}
+        <div className="relative max-w-sm mb-6">
+          <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
+          <input
+            type="text"
+            placeholder="Search products..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="w-full pl-9 pr-4 py-2 bg-white border border-slate-200 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+
+        {/* Upload status banner */}
+        {uploadMutation.isPending && (
+          <div className="mb-4 flex items-center gap-2 bg-blue-50 border border-blue-200 rounded-xl px-4 py-3 text-sm text-blue-700">
+            <Loader2Icon className="w-4 h-4 animate-spin" />
+            Uploading image for {uploadTargetProduct?.name}...
+          </div>
+        )}
+
+        {/* Loading state */}
+        {isLoading && (
+          <div className="flex flex-col items-center justify-center py-24 text-slate-400">
+            <Loader2Icon className="w-8 h-8 animate-spin mb-3" />
+            <p className="text-sm">Loading products...</p>
+          </div>
+        )}
+
+        {/* Error state */}
+        {isError && (
+          <div className="flex flex-col items-center justify-center py-24 text-center">
+            <div className="w-14 h-14 bg-red-50 rounded-full flex items-center justify-center mb-4">
+              <AlertCircleIcon className="w-7 h-7 text-red-500" />
+            </div>
+            <h2 className="text-lg font-semibold text-slate-900 mb-1">Failed to load products</h2>
+            <p className="text-sm text-slate-500">{(error as Error).message}</p>
+          </div>
+        )}
+
+        {/* Empty state */}
+        {!isLoading && !isError && products.length === 0 && (
+          <div className="flex flex-col items-center justify-center py-24 text-center">
+            <div className="w-20 h-20 bg-slate-100 rounded-full flex items-center justify-center mb-6">
+              <PackageIcon className="w-9 h-9 text-slate-400" />
+            </div>
+            <h2 className="text-xl font-semibold text-slate-900 mb-2">No products yet</h2>
+            <p className="text-slate-500 mb-8 max-w-sm text-sm">
+              Add your first product to start creating campaigns and generating ads.
+            </p>
+            <Button
+              leftIcon={<PlusIcon className="w-4 h-4" />}
+              onClick={() => setShowCreateModal(true)}
+            >
+              Add your first product
+            </Button>
+          </div>
+        )}
+
+        {/* No search results */}
+        {!isLoading && !isError && products.length > 0 && filteredProducts.length === 0 && (
+          <div className="flex flex-col items-center justify-center py-24 text-center">
+            <div className="w-14 h-14 bg-slate-100 rounded-full flex items-center justify-center mb-4">
+              <SearchIcon className="w-7 h-7 text-slate-400" />
+            </div>
+            <h2 className="text-lg font-semibold text-slate-900 mb-1">No products match your search</h2>
+            <p className="text-sm text-slate-500">Try a different search term.</p>
+          </div>
+        )}
+
+        {/* Product grid */}
+        {!isLoading && !isError && filteredProducts.length > 0 && (
+          <div className="grid grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
+            {filteredProducts.map((product) => (
+              <ProductCard
+                key={product.id}
+                product={product}
+                onDelete={setProductToDelete}
+                onUploadImage={handleUploadImage}
+              />
+            ))}
+          </div>
+        )}
+
+        {/* Hidden file input for image uploads */}
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/jpeg,image/png,image/webp,image/gif"
+          className="hidden"
+          onChange={handleFileSelected}
+        />
+
+        {/* Modals */}
+        {showCreateModal && (
+          <CreateProductModal onClose={() => setShowCreateModal(false)} />
+        )}
+
+        {productToDelete && (
+          <DeleteProductModal
+            product={productToDelete}
+            isLoading={deleteMutation.isPending}
+            onClose={() => setProductToDelete(null)}
+            onConfirm={handleConfirmDelete}
+          />
+        )}
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -4,3 +4,4 @@ export * from './campaign';
 export * from './chat';
 export * from './health';
 export * from './persona';
+export * from './product';

--- a/frontend/src/types/product.ts
+++ b/frontend/src/types/product.ts
@@ -1,0 +1,32 @@
+/** Shape returned by GET /products and GET /products/:id */
+export interface Product {
+    id: number;
+    business_client_id: number;
+    name: string;
+    description: string | null;
+    image_url: string | null;
+    image_name: string | null;
+    product_link: string | null;
+    product_metadata: string | null;
+    is_active: boolean | null;
+    created_at: string | null;
+    updated_at: string | null;
+}
+
+/** Payload for POST /products (JSON body — image uploaded separately via multipart) */
+export interface CreateProductPayload {
+    name: string;
+    description?: string | null;
+    product_link?: string | null;
+    product_metadata?: string | null;
+    is_active?: boolean | null;
+}
+
+/** Payload for PUT /products/:id */
+export interface UpdateProductPayload {
+    name?: string;
+    description?: string | null;
+    product_link?: string | null;
+    product_metadata?: string | null;
+    is_active?: boolean | null;
+}


### PR DESCRIPTION
Added a product creation feature: Requires users to create products to be used and synced with specific campaigns, this is so that we have context on what kinds of products we are looking at as far as ad generation is concerned and that way we have consistency. 

Backend was largely done, what was added was a route for image upload, and frontend API layer wiring, with query hooks, and integration into the campaign creation modal.
