### PR TITLE
Fix ad generation: script API, image resize, logging, and tests

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,7 +1,16 @@
+import logging
 import os
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
+
+# Configure logging so logger.info(), etc. show in the terminal
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+    force=True,
+)
 from fastapi.middleware.cors import CORSMiddleware
 
 #  Worker routes

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,6 +11,7 @@ azure-identity>=1.15.0
 openai>=1.0.0
 xai-sdk>=0.1.0
 azure-storage-blob>=12.0.0
+Pillow>=10.0.0
 
 # Test dependencies
 pytest>=9.0.0

--- a/backend/tests/test_script_creation_worker.py
+++ b/backend/tests/test_script_creation_worker.py
@@ -87,8 +87,8 @@ async def test_generate_ad_script_returns_script_from_mock_client():
     """generate_ad_script calls the API and returns the script content."""
     fake_content = "Scene 1: Open on product. Scene 2: ..."
     mock_response = MagicMock()
-    mock_response.choices = [MagicMock()]
-    mock_response.output.content[0].text = fake_content
+    # Responses API shape: output is list of items, each with content list and text
+    mock_response.output = [MagicMock(content=[MagicMock(text=fake_content)])]
 
     mock_client = MagicMock()
     mock_client.responses.create = AsyncMock(return_value=mock_response)

--- a/backend/workers/ad_job_worker/service.py
+++ b/backend/workers/ad_job_worker/service.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter
+import logging
 
 from workers.ad_job_worker.worker import (
     execute_ad_job,
@@ -7,10 +8,10 @@ from workers.ad_job_worker.worker import (
 )
 
 router = APIRouter()
-
+logger = logging.getLogger(__name__)
 
 @router.post("/run-ad-job")
-async def run_job(campaign_id: int, product_id: int, consumer_id: int, version_number: int):
+async def run_ad_job(campaign_id: int, product_id: int, consumer_id: int, version_number: int):
     ad_variant_id = await execute_ad_job(campaign_id, product_id, consumer_id, version_number)
     return {"status": "completed", "ad_variant_id": ad_variant_id}
 
@@ -30,6 +31,7 @@ async def generate_campaign_ad_variants(campaign_id: int, product_id: int, versi
 
 @router.get("/hello")
 async def hello():
+    logger.info("Hello from Ad Job Worker!")
     return {
         "service": "Ad Job Worker",
         "message": "Hello from Ad Job Worker!",

--- a/backend/workers/ad_job_worker/worker.py
+++ b/backend/workers/ad_job_worker/worker.py
@@ -1,12 +1,14 @@
 import base64
+import io
 import json
 import os
 import random
 import traceback
 import uuid
 from typing import Optional
-
+import logging
 from dotenv import load_dotenv
+from PIL import Image, UnidentifiedImageError
 from sqlalchemy.orm import Session
 
 from database import _get_session_factory
@@ -29,6 +31,35 @@ from workers.ad_video_generation_worker.worker import generate_ad_video
 from azure.storage.blob import BlobClient, ContentSettings
 
 load_dotenv()
+logger = logging.getLogger(__name__)
+
+# Target size for product images (portrait, e.g. for short-form video).
+PRODUCT_IMAGE_WIDTH = 720
+PRODUCT_IMAGE_HEIGHT = 1280
+
+
+def _resize_product_image(image_bytes: bytes, content_type: str) -> tuple[bytes, str]:
+    """Resize product image to 720x1280. Returns (resized_bytes, content_type). On failure, returns original."""
+    try:
+        img = Image.open(io.BytesIO(image_bytes))
+        if img.mode in ("RGBA", "P"):
+            img = img.convert("RGBA")
+            out_format = "PNG"
+            out_content_type = "image/png"
+        else:
+            img = img.convert("RGB")
+            out_format = "JPEG"
+            out_content_type = "image/jpeg"
+        img = img.resize((PRODUCT_IMAGE_WIDTH, PRODUCT_IMAGE_HEIGHT), Image.Resampling.LANCZOS)
+        buf = io.BytesIO()
+        if out_format == "JPEG":
+            img.save(buf, format=out_format, quality=95)
+        else:
+            img.save(buf, format=out_format)
+        return buf.getvalue(), out_content_type
+    except (UnidentifiedImageError, OSError) as e:
+        logger.warning("Resize failed, using original image: %s", e)
+        return image_bytes, content_type
 
 
 def _brief_for_version(brief_json: Optional[str], version_number: int) -> str:
@@ -49,6 +80,10 @@ def _brief_for_version(brief_json: Optional[str], version_number: int) -> str:
 
 
 async def execute_ad_job(campaign_id: int, product_id: int, consumer_id: int, version_number: int) -> int:
+    logger.info(
+        "Executing ad job for campaign %s, product %s, consumer %s, version %s",
+        campaign_id, product_id, consumer_id, version_number,
+    )
     factory = _get_session_factory()
     db: Session = factory()
     ad_variant = create_ad_variant(
@@ -87,20 +122,27 @@ async def execute_ad_job(campaign_id: int, product_id: int, consumer_id: int, ve
         )
         product_image_download = product_image_blob_client.download_blob()
         product_image_bytes = product_image_download.readall()
-        base64_product_image = base64.b64encode(product_image_bytes).decode("utf-8")
         props = product_image_blob_client.get_blob_properties()
-        product_image_type = props.content_settings.content_type
+        product_image_type = props.content_settings.content_type or "image/png"
         product_image_filename = props.name
+        product_image_bytes, product_image_type = _resize_product_image(
+            product_image_bytes, product_image_type
+        )
+        base64_product_image = base64.b64encode(product_image_bytes).decode("utf-8")
         product_image_data_url = f"data:{product_image_type};base64,{base64_product_image}"
 
+        logger.info("Generating ad script")
         script = await generate_ad_script(
             product_name, product_description, product_image_data_url, consumer_traits_string, campaign_brief
         )
         update_ad_variant(db, ad_variant_id, AdVariantUpdate(meta=json.dumps({"script": script})))
+        logger.info("Finished generating ad script")
 
+        logger.info("Generating ad video")
         ad_video_bytes = await generate_ad_video(
             script, product_image_bytes, product_image_type, product_image_filename
         )
+        logger.info("Finished generating ad video")
         blob_client = BlobClient.from_connection_string(
             conn_str=os.getenv("AZURE_STORAGE_CONNECTION_STRING", "").strip(),
             container_name="ad-videos",

--- a/backend/workers/ad_video_generation_worker/worker.py
+++ b/backend/workers/ad_video_generation_worker/worker.py
@@ -1,11 +1,14 @@
 import asyncio
 import io
 import os
+import logging
 
 from dotenv import load_dotenv
 from openai import AsyncOpenAI
 
 load_dotenv()
+
+logger = logging.getLogger(__name__)
 
 POLL_INTERVAL_SECONDS = 5
 MAX_POLL_ATTEMPTS = 120  # 10 minutes at 5s interval
@@ -32,6 +35,7 @@ async def generate_ad_video(
     )
 
     job_id = creation_response.id
+    logger.info("Video generation job created: %s", job_id)
     job_status = creation_response
     attempt = 0
 
@@ -46,9 +50,10 @@ async def generate_ad_video(
                 f"Video generation job {job_id} did not complete within {MAX_POLL_ATTEMPTS * POLL_INTERVAL_SECONDS}s."
             )
         await asyncio.sleep(POLL_INTERVAL_SECONDS)
-        job_status = await video_client.videos.retrieve(id=job_id)
-
-    download_response = await video_client.videos.download_content(id=job_id)
+        # SDK expects positional job_id for retrieve and download_content
+        job_status = await video_client.videos.retrieve(job_id)
+    logger.info("Video generation job %s completed", job_id)
+    download_response = await video_client.videos.download_content(job_id)
     ad_video_bytes = await download_response.aread()
 
 

--- a/backend/workers/script_creation_worker/worker.py
+++ b/backend/workers/script_creation_worker/worker.py
@@ -79,11 +79,16 @@ async def generate_ad_script(
                 ]
             }
         ],
-        max_tokens=2000
+        max_output_tokens=2000
     )
 
-    script = response.output.content[0].text
-    
+    # Responses API: output is a list of items; each item has content (list) with text.
+    if not response.output or len(response.output) == 0:
+        raise ValueError("Script API returned no output")
+    first_output = response.output[0]
+    if not getattr(first_output, "content", None) or len(first_output.content) == 0:
+        raise ValueError("Script API returned output with no content")
+    script = first_output.content[0].text
     return script
 
 def batch_generate_ad_scripts(product_name: str, product_description: str, consumers: list["Consumer"], product_image_data_url: str, campaign_brief: str):


### PR DESCRIPTION
## Changes
* Script worker: Use Responses API max_output_tokens and response.output[0].content[0].text; add checks for empty output and raise clear ValueErrors instead of IndexError.
* Tests: Update script-creation mock to the new response shape so test_generate_ad_script_returns_script_from_mock_client passes.
* Product image resize: Resize to 720×1280 before script and video generation; on resize failure only catch UnidentifiedImageError and OSError, log a warning, and use the original image.
* Logging: Configure terminal logging in main.py; use module logger (not root logging) in ad_job_worker and ad_video_worker; add a comment for the video SDK job_id usage.