### PR TITLE
Wire up frontend to backend from chat interface to make use of ad_generation service to create videos and show them to the user

### DIFF
--- a/backend/crud/ad_variant.py
+++ b/backend/crud/ad_variant.py
@@ -17,6 +17,7 @@ def get_ad_variants(
     campaign_id: Optional[int] = None,
     version_number: Optional[int] = None,
     status: Optional[str] = None,
+    is_preview: Optional[bool] = None,
 ) -> list[AdVariant]:
     """Return a list of ad variants with optional filters."""
     query = select(AdVariant)
@@ -26,6 +27,8 @@ def get_ad_variants(
         query = query.where(AdVariant.version_number == version_number)
     if status is not None:
         query = query.where(AdVariant.status == status)
+    if is_preview is not None:
+        query = query.where(AdVariant.is_preview == is_preview)
     query = query.order_by(AdVariant.id).offset(skip).limit(limit)
     return list(db.scalars(query).all())
 

--- a/backend/models/ad_variant.py
+++ b/backend/models/ad_variant.py
@@ -3,7 +3,7 @@
 from datetime import datetime, timezone
 from typing import Optional
 
-from sqlalchemy import Integer, String, DateTime
+from sqlalchemy import Boolean, Integer, String, DateTime
 from sqlalchemy.orm import Mapped, mapped_column
 
 from database import Base
@@ -24,6 +24,7 @@ class AdVariant(Base):
     updated_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
     published_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
     product_id: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    is_preview: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
 
     def __repr__(self) -> str:
         return f"<AdVariant(id={self.id}, campaign_id={self.campaign_id}, status='{self.status}')>"

--- a/backend/routes/ad_variants.py
+++ b/backend/routes/ad_variants.py
@@ -1,9 +1,13 @@
 """API routes for ad_variants — full CRUD endpoints."""
 
+import os
+from datetime import datetime, timedelta, timezone
 from typing import Optional
+from urllib.parse import urlsplit, urlunsplit
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
+from azure.storage.blob import BlobSasPermissions, generate_blob_sas
 
 from database import get_db
 from schemas.ad_variant import AdVariantCreate, AdVariantUpdate, AdVariantResponse
@@ -16,6 +20,67 @@ from crud.ad_variant import (
 )
 
 router = APIRouter()
+SAS_EXPIRY_HOURS = 1
+VIDEO_CONTAINER_NAME = "ad-videos"
+
+
+def _parse_conn_str(conn_str: str) -> tuple[str, str]:
+    """Extract account_name and account_key from an Azure Storage connection string."""
+    parts = dict(part.split("=", 1) for part in conn_str.split(";") if "=" in part)
+    return parts["AccountName"], parts["AccountKey"]
+
+
+def _extract_blob_name(media_url: str) -> Optional[str]:
+    """Extract blob path from a media URL when it points to the ad-videos container."""
+    try:
+        parsed = urlsplit(media_url)
+        if not parsed.scheme or not parsed.netloc:
+            return None
+        if ".blob.core.windows.net" not in parsed.netloc:
+            return None
+        path = parsed.path.lstrip("/")
+        if not path:
+            return None
+        container, sep, blob_name = path.partition("/")
+        if sep == "" or container != VIDEO_CONTAINER_NAME or not blob_name:
+            return None
+        return blob_name
+    except ValueError:
+        return None
+
+
+def _append_query(url: str, query_fragment: str) -> str:
+    """Append a query fragment while preserving existing query params."""
+    parsed = urlsplit(url)
+    merged_query = f"{parsed.query}&{query_fragment}" if parsed.query else query_fragment
+    return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, merged_query, parsed.fragment))
+
+
+def _sign_ad_variant(ad_variant) -> AdVariantResponse:
+    """Convert ORM ad variant to response with optional time-limited SAS on media_url."""
+    resp = AdVariantResponse.model_validate(ad_variant, from_attributes=True)
+    if not resp.media_url:
+        return resp
+
+    conn_str = os.getenv("AZURE_STORAGE_CONNECTION_STRING", "").strip()
+    if not conn_str:
+        return resp
+
+    blob_name = _extract_blob_name(resp.media_url)
+    if not blob_name:
+        return resp
+
+    account_name, account_key = _parse_conn_str(conn_str)
+    sas_token = generate_blob_sas(
+        account_name=account_name,
+        container_name=VIDEO_CONTAINER_NAME,
+        blob_name=blob_name,
+        account_key=account_key,
+        permission=BlobSasPermissions(read=True),
+        expiry=datetime.now(timezone.utc) + timedelta(hours=SAS_EXPIRY_HOURS),
+    )
+    resp.media_url = _append_query(resp.media_url, sas_token)
+    return resp
 
 
 @router.get("/", response_model=list[AdVariantResponse])
@@ -24,10 +89,19 @@ def list_ad_variants(
     limit: int = 100,
     campaign_id: Optional[int] = None,
     status: Optional[str] = None,
+    is_preview: Optional[bool] = None,
     db: Session = Depends(get_db),
 ):
-    """Get all ad variants, with optional filtering by campaign_id or status."""
-    return get_ad_variants(db, skip=skip, limit=limit, campaign_id=campaign_id, status=status)
+    """Get all ad variants, with optional filtering by campaign_id, status, or is_preview."""
+    variants = get_ad_variants(
+        db,
+        skip=skip,
+        limit=limit,
+        campaign_id=campaign_id,
+        status=status,
+        is_preview=is_preview,
+    )
+    return [_sign_ad_variant(v) for v in variants]
 
 
 @router.get("/{ad_variant_id}", response_model=AdVariantResponse)
@@ -36,7 +110,7 @@ def read_ad_variant(ad_variant_id: int, db: Session = Depends(get_db)):
     ad_variant = get_ad_variant(db, ad_variant_id)
     if ad_variant is None:
         raise HTTPException(status_code=404, detail="Ad variant not found")
-    return ad_variant
+    return _sign_ad_variant(ad_variant)
 
 
 @router.post("/", response_model=AdVariantResponse, status_code=201)

--- a/backend/schemas/ad_variant.py
+++ b/backend/schemas/ad_variant.py
@@ -16,6 +16,7 @@ class AdVariantCreate(BaseModel):
     media_url: Optional[str] = None
     meta: Optional[str] = None
     version_number: int = 1
+    is_preview: bool = False
 
 
 class AdVariantUpdate(BaseModel):
@@ -28,6 +29,7 @@ class AdVariantUpdate(BaseModel):
     meta: Optional[str] = None
     version_number: Optional[int] = None
     published_at: Optional[datetime] = None
+    is_preview: Optional[bool] = None
 
 
 # ---------- Response schema ----------
@@ -42,6 +44,7 @@ class AdVariantResponse(BaseModel):
     media_url: Optional[str] = None
     meta: Optional[str] = None
     version_number: int
+    is_preview: bool
     created_at: datetime
     updated_at: datetime
     published_at: Optional[datetime] = None

--- a/backend/tests/test_ad_variants.py
+++ b/backend/tests/test_ad_variants.py
@@ -1,0 +1,143 @@
+"""Route tests for ad_variants media URL SAS signing behavior."""
+
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+_backend_dir = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_backend_dir))
+
+# Allow app to load when ALLOWED_ORIGINS is not set (e.g. CI)
+os.environ.setdefault("ALLOWED_ORIGINS", "http://localhost")
+
+from fastapi.testclient import TestClient
+
+from database import get_db
+from main import app
+
+
+def _variant(media_url: str | None) -> SimpleNamespace:
+    now = datetime.now(timezone.utc)
+    return SimpleNamespace(
+        id=10,
+        campaign_id=7,
+        consumer_id=3,
+        product_id=2,
+        status="completed",
+        media_url=media_url,
+        meta='{"script":"test"}',
+        version_number=1,
+        is_preview=True,
+        created_at=now,
+        updated_at=now,
+        published_at=None,
+    )
+
+
+def _client() -> TestClient:
+    def _override_get_db():
+        yield MagicMock()
+
+    app.dependency_overrides[get_db] = _override_get_db
+    return TestClient(app)
+
+
+def _clear_overrides():
+    app.dependency_overrides.clear()
+
+
+def test_list_ad_variants_signs_media_url(monkeypatch):
+    client = _client()
+    try:
+        monkeypatch.setenv(
+            "AZURE_STORAGE_CONNECTION_STRING",
+            "AccountName=testacct;AccountKey=secret;DefaultEndpointsProtocol=https",
+        )
+        monkeypatch.setattr(
+            "routes.ad_variants.get_ad_variants",
+            lambda *args, **kwargs: [
+                _variant("https://adgenticblob.blob.core.windows.net/ad-videos/ad-videos/8585e8.mp4"),
+            ],
+        )
+        monkeypatch.setattr(
+            "routes.ad_variants.generate_blob_sas",
+            lambda **kwargs: "sig=abc123",
+        )
+
+        res = client.get("/ad-variants/?campaign_id=7")
+        assert res.status_code == 200
+        body = res.json()
+        assert len(body) == 1
+        assert body[0]["media_url"].endswith("?sig=abc123")
+    finally:
+        client.close()
+        _clear_overrides()
+
+
+def test_read_ad_variant_does_not_sign_without_storage_config(monkeypatch):
+    client = _client()
+    try:
+        monkeypatch.delenv("AZURE_STORAGE_CONNECTION_STRING", raising=False)
+        raw_url = "https://adgenticblob.blob.core.windows.net/ad-videos/ad-videos/45a61c.mp4"
+        monkeypatch.setattr("routes.ad_variants.get_ad_variant", lambda *args, **kwargs: _variant(raw_url))
+
+        res = client.get("/ad-variants/10")
+        assert res.status_code == 200
+        body = res.json()
+        assert body["media_url"] == raw_url
+    finally:
+        client.close()
+        _clear_overrides()
+
+
+def test_list_ad_variants_appends_sas_to_existing_query(monkeypatch):
+    client = _client()
+    try:
+        monkeypatch.setenv(
+            "AZURE_STORAGE_CONNECTION_STRING",
+            "AccountName=testacct;AccountKey=secret;DefaultEndpointsProtocol=https",
+        )
+        monkeypatch.setattr(
+            "routes.ad_variants.get_ad_variants",
+            lambda *args, **kwargs: [
+                _variant("https://adgenticblob.blob.core.windows.net/ad-videos/ad-videos/145198.mp4?foo=bar"),
+            ],
+        )
+        monkeypatch.setattr(
+            "routes.ad_variants.generate_blob_sas",
+            lambda **kwargs: "sig=abc123",
+        )
+
+        res = client.get("/ad-variants/?campaign_id=7")
+        assert res.status_code == 200
+        body = res.json()
+        assert body[0]["media_url"].endswith("?foo=bar&sig=abc123")
+    finally:
+        client.close()
+        _clear_overrides()
+
+
+def test_read_ad_variant_leaves_non_azure_media_url_unchanged(monkeypatch):
+    client = _client()
+    try:
+        monkeypatch.setenv(
+            "AZURE_STORAGE_CONNECTION_STRING",
+            "AccountName=testacct;AccountKey=secret;DefaultEndpointsProtocol=https",
+        )
+        raw_url = "https://cdn.example.com/video.mp4"
+        monkeypatch.setattr("routes.ad_variants.get_ad_variant", lambda *args, **kwargs: _variant(raw_url))
+        monkeypatch.setattr(
+            "routes.ad_variants.generate_blob_sas",
+            lambda **kwargs: "sig=abc123",
+        )
+
+        res = client.get("/ad-variants/10")
+        assert res.status_code == 200
+        body = res.json()
+        assert body["media_url"] == raw_url
+    finally:
+        client.close()
+        _clear_overrides()

--- a/backend/workers/ad_job_worker/worker.py
+++ b/backend/workers/ad_job_worker/worker.py
@@ -79,7 +79,7 @@ def _brief_for_version(brief_json: Optional[str], version_number: int) -> str:
         return ""
 
 
-async def execute_ad_job(campaign_id: int, product_id: int, consumer_id: int, version_number: int) -> int:
+async def execute_ad_job(campaign_id: int, product_id: int, consumer_id: int, version_number: int, is_preview: bool = False) -> int:
     logger.info(
         "Executing ad job for campaign %s, product %s, consumer %s, version %s",
         campaign_id, product_id, consumer_id, version_number,
@@ -88,7 +88,7 @@ async def execute_ad_job(campaign_id: int, product_id: int, consumer_id: int, ve
     db: Session = factory()
     ad_variant = create_ad_variant(
         db,
-        AdVariantCreate(campaign_id=campaign_id, consumer_id=consumer_id, status="Generating", version_number=version_number),
+        AdVariantCreate(campaign_id=campaign_id, consumer_id=consumer_id, status="Generating", version_number=version_number, is_preview=is_preview),
     )
     ad_variant_id = ad_variant.id
 
@@ -188,7 +188,7 @@ async def generate_campaign_preview(
             if not consumers:
                 continue
             selected_consumer = random.choice(consumers)
-            ad_variant_id = await execute_ad_job(campaign_id, product_id, selected_consumer.id, version_number)
+            ad_variant_id = await execute_ad_job(campaign_id, product_id, selected_consumer.id, version_number, is_preview=True)
             created_ad_variant_ids.append(ad_variant_id)
         return created_ad_variant_ids
     finally:
@@ -221,6 +221,7 @@ async def generate_campaign_ad_variants(
                 user_id=batch_user_id,
                 status="pending",
                 total_jobs=len(need_to_generate),
+                idempotency_key=None,
             ),
         )
         ad_job_batch_id = ad_job_batch.id

--- a/frontend/src/api/adGeneration.ts
+++ b/frontend/src/api/adGeneration.ts
@@ -1,0 +1,77 @@
+import { apiUrl, authHeaders } from './config';
+import type { AdVariant } from '../types';
+
+// ---------- Ad Generation ----------
+
+/** Trigger preview generation (synchronous — returns when all variants are done). */
+export async function generateCampaignPreview(
+  campaignId: number,
+  productId: number,
+  versionNumber: number,
+): Promise<{ status: string; ad_variant_ids: number[] }> {
+  const params = new URLSearchParams({
+    campaign_id: String(campaignId),
+    product_id: String(productId),
+    version_number: String(versionNumber),
+  });
+
+  const res = await fetch(apiUrl(`/ad-job-worker/generate-campaign-preview?${params}`), {
+    method: 'POST',
+    headers: authHeaders(),
+  });
+
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.detail || 'Failed to generate campaign preview.');
+  }
+
+  return res.json();
+}
+
+/** Trigger full ad generation (async — returns batch ID). */
+export async function generateCampaignAdVariants(
+  campaignId: number,
+  productId: number,
+  versionNumber: number,
+): Promise<{ status: string; batch_id?: string; message: string }> {
+  const params = new URLSearchParams({
+    campaign_id: String(campaignId),
+    product_id: String(productId),
+    version_number: String(versionNumber),
+  });
+
+  const res = await fetch(apiUrl(`/ad-job-worker/generate-campaign-ad-variants?${params}`), {
+    method: 'POST',
+    headers: authHeaders(),
+  });
+
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.detail || 'Failed to generate campaign ad variants.');
+  }
+
+  return res.json();
+}
+
+// ---------- Ad Variants ----------
+
+/** Fetch ad variants for a campaign, with optional filters. */
+export async function fetchAdVariants(
+  campaignId: number,
+  opts?: { status?: string; isPreview?: boolean },
+): Promise<AdVariant[]> {
+  const params = new URLSearchParams({ campaign_id: String(campaignId) });
+  if (opts?.status) params.set('status', opts.status);
+  if (opts?.isPreview !== undefined) params.set('is_preview', String(opts.isPreview));
+
+  const res = await fetch(apiUrl(`/ad-variants/?${params}`), {
+    headers: authHeaders(),
+  });
+
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.detail || 'Failed to fetch ad variants.');
+  }
+
+  return (await res.json()) as AdVariant[];
+}

--- a/frontend/src/components/generate/AdVariantCard.tsx
+++ b/frontend/src/components/generate/AdVariantCard.tsx
@@ -1,0 +1,114 @@
+import { CheckIcon, LoaderIcon, AlertCircleIcon, VideoIcon, FileTextIcon } from 'lucide-react';
+import type { AdVariant, AdVariantScript } from '../../types';
+
+interface AdVariantCardProps {
+  variant: AdVariant;
+  isSelected: boolean;
+  onToggle: (variantId: string) => void;
+}
+
+const statusConfig = {
+  Generating: { label: 'Generating', bg: 'bg-amber-50', text: 'text-amber-700', icon: LoaderIcon, animate: true },
+  completed: { label: 'Completed', bg: 'bg-emerald-50', text: 'text-emerald-700', icon: CheckIcon, animate: false },
+  failed: { label: 'Failed', bg: 'bg-red-50', text: 'text-red-700', icon: AlertCircleIcon, animate: false },
+} as const;
+
+function parseScript(meta: string | null): AdVariantScript {
+  if (!meta) return {};
+  try {
+    return JSON.parse(meta) as AdVariantScript;
+  } catch {
+    return {};
+  }
+}
+
+export function AdVariantCard({ variant, isSelected, onToggle }: AdVariantCardProps) {
+  const id = String(variant.id);
+  const config = statusConfig[variant.status] ?? statusConfig.Generating;
+  const StatusIcon = config.icon;
+  const parsed = parseScript(variant.meta);
+
+  return (
+    <div
+      className={`rounded-xl border overflow-hidden transition-all cursor-pointer fade-up ${
+        isSelected
+          ? 'border-blue-500 ring-1 ring-blue-500 shadow-md'
+          : 'border-slate-200 hover:border-slate-300 hover:shadow-sm'
+      }`}
+      onClick={() => onToggle(id)}
+    >
+      {/* Media area */}
+      <div className="relative aspect-[9/16] max-h-[280px] bg-slate-900">
+        {variant.status === 'completed' && variant.media_url ? (
+          <video
+            src={variant.media_url}
+            className="w-full h-full object-contain"
+            controls
+            preload="metadata"
+            onClick={(e) => e.stopPropagation()}
+          />
+        ) : variant.status === 'Generating' ? (
+          <div className="w-full h-full flex flex-col items-center justify-center gap-3">
+            <LoaderIcon className="w-8 h-8 text-amber-400 animate-spin" />
+            <span className="text-xs text-slate-400">Generating video...</span>
+          </div>
+        ) : variant.status === 'failed' ? (
+          <div className="w-full h-full flex flex-col items-center justify-center gap-3">
+            <AlertCircleIcon className="w-8 h-8 text-red-400" />
+            <span className="text-xs text-red-300">Generation failed</span>
+          </div>
+        ) : (
+          <div className="w-full h-full flex items-center justify-center">
+            <VideoIcon className="w-8 h-8 text-slate-600" />
+          </div>
+        )}
+
+        {/* Status badge */}
+        <div className={`absolute top-2 right-2 px-2 py-0.5 rounded-full text-[10px] font-semibold flex items-center gap-1 ${config.bg} ${config.text}`}>
+          <StatusIcon className={`w-2.5 h-2.5 ${config.animate ? 'animate-spin' : ''}`} />
+          {config.label}
+        </div>
+
+        {/* Selection checkbox */}
+        <div className="absolute top-2 left-2">
+          <div
+            className={`w-5 h-5 rounded border-2 flex items-center justify-center transition-colors ${
+              isSelected
+                ? 'bg-blue-600 border-blue-600'
+                : 'border-white/80 bg-black/20 backdrop-blur-sm'
+            }`}
+          >
+            {isSelected && <CheckIcon className="w-3 h-3 text-white" />}
+          </div>
+        </div>
+      </div>
+
+      {/* Info area */}
+      <div className="p-3 bg-white">
+        <div className="flex items-center gap-1.5 mb-1.5">
+          <span className="px-1.5 py-0.5 rounded text-[9px] font-semibold bg-slate-100 text-slate-600">
+            v{variant.version_number}
+          </span>
+          <span className="px-1.5 py-0.5 rounded text-[9px] font-semibold bg-blue-50 text-blue-600">
+            ID #{variant.id}
+          </span>
+        </div>
+
+        {parsed.script ? (
+          <div className="flex items-start gap-1.5">
+            <FileTextIcon className="w-3.5 h-3.5 text-slate-400 mt-0.5 flex-shrink-0" />
+            <p className="text-xs text-slate-600 line-clamp-4 leading-relaxed">
+              {parsed.script}
+            </p>
+          </div>
+        ) : parsed.error ? (
+          <p className="text-xs text-red-500 line-clamp-3">
+            Error: {parsed.error.slice(0, 150)}...
+          </p>
+        ) : (
+          <p className="text-xs text-slate-400 italic">No script yet</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/generate/ChatHeader.tsx
+++ b/frontend/src/components/generate/ChatHeader.tsx
@@ -3,7 +3,7 @@ import { Badge } from '../ui/Badge';
 import { CampaignSelector } from './CampaignSelector';
 import { VersionPopover } from './VersionPopover';
 import type { Campaign } from '../../types';
-import type { Phase, PersonaGroup, Version } from './types';
+import type { Phase, Version } from './types';
 import { countActiveFilters } from '../../hooks/useFilterState';
 import type { FilterState } from '../../hooks/useFilterState';
 
@@ -19,7 +19,7 @@ interface ChatHeaderProps {
   filterState: FilterState;
   showFilterPanel: boolean;
   onToggleFilterPanel: () => void;
-  personaGroups: PersonaGroup[];
+  variantCount: number;
 }
 
 export function ChatHeader({
@@ -34,10 +34,10 @@ export function ChatHeader({
   filterState,
   showFilterPanel,
   onToggleFilterPanel,
-  personaGroups,
+  variantCount,
 }: ChatHeaderProps) {
   const activeFilterCount = countActiveFilters(filterState);
-  const totalVariants = personaGroups.reduce((sum, g) => sum + g.variants.length, 0);
+  const totalVariants = variantCount;
 
   return (
     <header className="border-b border-slate-100 px-4 py-2.5 flex-shrink-0">

--- a/frontend/src/components/generate/ChatPanel.tsx
+++ b/frontend/src/components/generate/ChatPanel.tsx
@@ -4,7 +4,7 @@ import { FilterPanel } from './FilterPanel';
 import { ChatMessageList } from './ChatMessageList';
 import { ChatInput } from './ChatInput';
 import type { Campaign, ChatMessage } from '../../types';
-import type { Phase, PersonaGroup, Version } from './types';
+import type { Phase, Version } from './types';
 import type { FilterState, FilterAction } from '../../hooks/useFilterState';
 
 interface ChatPanelProps {
@@ -36,7 +36,7 @@ interface ChatPanelProps {
   // AI state
   isAiLoading?: boolean;
   // Layout
-  personaGroups: PersonaGroup[];
+  variantCount: number;
   style?: React.CSSProperties;
   className?: string;
 }
@@ -62,7 +62,7 @@ export function ChatPanel({
   selectedVariantCount,
   onClearSelection,
   isAiLoading,
-  personaGroups,
+  variantCount,
   style,
   className,
 }: ChatPanelProps) {
@@ -85,7 +85,7 @@ export function ChatPanel({
         filterState={filterState}
         showFilterPanel={showFilterPanel}
         onToggleFilterPanel={() => setShowFilterPanel((v) => !v)}
-        personaGroups={personaGroups}
+        variantCount={variantCount}
       />
 
       {/* Filter panel only in idle phase — results panel owns filters after generation */}

--- a/frontend/src/components/generate/GeneratingView.tsx
+++ b/frontend/src/components/generate/GeneratingView.tsx
@@ -1,13 +1,12 @@
-import { BrainIcon, UsersIcon } from 'lucide-react';
-import type { PersonaGroup } from './types';
+import { BrainIcon } from 'lucide-react';
 import { progressMessages } from './mockData';
 
 interface GeneratingViewProps {
   progressIdx: number;
-  personaGroups: PersonaGroup[];
+  variantCount?: number;
 }
 
-export function GeneratingView({ progressIdx, personaGroups }: GeneratingViewProps) {
+export function GeneratingView({ progressIdx, variantCount = 6 }: GeneratingViewProps) {
   return (
     <div className="flex-1 flex flex-col items-center justify-center p-8 fade-up">
       <div className="mb-10 text-center">
@@ -21,46 +20,17 @@ export function GeneratingView({ progressIdx, personaGroups }: GeneratingViewPro
           {progressMessages[progressIdx]}
         </p>
       </div>
-      <div className="w-full max-w-2xl space-y-4">
-        {personaGroups.map((group, i) => (
+      <div className="w-full max-w-2xl grid grid-cols-3 gap-4">
+        {Array.from({ length: variantCount }).map((_, i) => (
           <div
-            key={group.id}
+            key={i}
             className="deal-in"
-            style={{ animationDelay: `${i * 400}ms` }}
+            style={{ animationDelay: `${i * 200}ms` }}
           >
-            <div className="bg-white rounded-2xl border border-slate-200 p-5 shadow-sm overflow-hidden relative">
-              <div
-                className={`absolute inset-0 ${group.colorBg} color-fill`}
-                style={{
-                  animationDelay: `${i * 400 + 600}ms`,
-                  animationFillMode: 'forwards',
-                  opacity: 0.5,
-                }}
-              />
-              <div className="relative z-10">
-                <div className="flex items-center gap-3 mb-3">
-                  <div className={`w-10 h-10 rounded-xl ${group.color} flex items-center justify-center`}>
-                    <UsersIcon className="w-5 h-5 text-white" />
-                  </div>
-                  <div>
-                    <div className="h-4 w-36 shimmer-bg rounded mb-1.5" />
-                    <div className="h-3 w-48 shimmer-bg rounded" />
-                  </div>
-                </div>
-                <div className="grid grid-cols-4 gap-3">
-                  {Array.from({ length: group.variants.length }).map((_, j) => (
-                    <div
-                      key={j}
-                      className="deal-in"
-                      style={{ animationDelay: `${i * 400 + 800 + j * 150}ms` }}
-                    >
-                      <div className="aspect-[4/3] shimmer-bg rounded-lg" />
-                      <div className="mt-2 h-3 w-full shimmer-bg rounded" />
-                      <div className="mt-1 h-2.5 w-2/3 shimmer-bg rounded" />
-                    </div>
-                  ))}
-                </div>
-              </div>
+            <div className="bg-white rounded-2xl border border-slate-200 p-4 shadow-sm overflow-hidden">
+              <div className="aspect-[9/16] max-h-[180px] shimmer-bg rounded-lg mb-3" />
+              <div className="h-3 w-full shimmer-bg rounded mb-2" />
+              <div className="h-2.5 w-2/3 shimmer-bg rounded" />
             </div>
           </div>
         ))}

--- a/frontend/src/components/generate/ResultsPanel.tsx
+++ b/frontend/src/components/generate/ResultsPanel.tsx
@@ -1,8 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import {
   MessageSquareIcon,
-  CopyIcon,
-  EyeOffIcon,
   Trash2Icon,
   XIcon,
   SlidersHorizontalIcon,
@@ -11,9 +9,10 @@ import {
 } from 'lucide-react';
 import { Button } from '../ui/Button';
 import { FilterControls } from './FilterControls';
-import { PersonaGroupCard } from './PersonaGroupCard';
+import { AdVariantCard } from './AdVariantCard';
 import { GeneratingView } from './GeneratingView';
-import type { Phase, PersonaGroup } from './types';
+import type { Phase } from './types';
+import type { AdVariant } from '../../types';
 import type { FilterState, FilterAction } from '../../hooks/useFilterState';
 import { countActiveFilters } from '../../hooks/useFilterState';
 
@@ -21,21 +20,15 @@ interface ResultsPanelProps {
   phase: Phase;
   filterState: FilterState;
   filterDispatch: React.Dispatch<FilterAction>;
-  personaGroups: PersonaGroup[];
+  adVariants: AdVariant[];
   progressIdx: number;
   // Selection
   selectedVariants: Set<string>;
   onVariantToggle: (variantId: string) => void;
-  onGroupSelect: (group: PersonaGroup) => void;
   onClearSelection: () => void;
   // Actions
   onReviseSelected: () => void;
-  onDuplicateSelected: () => void;
-  onExcludeSelected: () => void;
   onDeleteSelected: () => void;
-  // Expand state
-  expandedGroups: Set<string>;
-  onToggleGroup: (groupId: string) => void;
   // Filters
   onApplyFilters?: () => void;
 }
@@ -44,18 +37,13 @@ export function ResultsPanel({
   phase,
   filterState,
   filterDispatch,
-  personaGroups,
+  adVariants,
   progressIdx,
   selectedVariants,
   onVariantToggle,
-  onGroupSelect,
   onClearSelection,
   onReviseSelected,
-  onDuplicateSelected,
-  onExcludeSelected,
   onDeleteSelected,
-  expandedGroups,
-  onToggleGroup,
   onApplyFilters,
 }: ResultsPanelProps) {
   const rightPanelRef = useRef<HTMLDivElement>(null);
@@ -83,7 +71,7 @@ export function ResultsPanel({
     <div ref={rightPanelRef} className="flex-1 flex flex-col h-full overflow-hidden min-w-0">
       {/* GENERATING */}
       {phase === 'generating' && (
-        <GeneratingView progressIdx={progressIdx} personaGroups={personaGroups} />
+        <GeneratingView progressIdx={progressIdx} variantCount={6} />
       )}
 
       {/* RESULTS */}
@@ -149,22 +137,6 @@ export function ResultsPanel({
                 </Button>
                 <Button
                   size="sm"
-                  variant="secondary"
-                  leftIcon={<CopyIcon className="w-3.5 h-3.5" />}
-                  onClick={onDuplicateSelected}
-                >
-                  Duplicate
-                </Button>
-                <Button
-                  size="sm"
-                  variant="secondary"
-                  leftIcon={<EyeOffIcon className="w-3.5 h-3.5" />}
-                  onClick={onExcludeSelected}
-                >
-                  Exclude
-                </Button>
-                <Button
-                  size="sm"
                   variant="ghost"
                   className="text-red-600 hover:text-red-700 hover:bg-red-50"
                   leftIcon={<Trash2Icon className="w-3.5 h-3.5" />}
@@ -184,21 +156,27 @@ export function ResultsPanel({
             </div>
           )}
 
-          {/* Grouped Variants */}
-          <div className="flex-1 overflow-y-auto p-5 space-y-4">
-            {personaGroups.map((group, gi) => (
-              <PersonaGroupCard
-                key={group.id}
-                group={group}
-                isExpanded={expandedGroups.has(group.id)}
-                onToggle={onToggleGroup}
-                selectedVariants={selectedVariants}
-                onVariantToggle={onVariantToggle}
-                onGroupSelect={onGroupSelect}
-                variantCols={variantCols}
-                animationDelay={gi * 100}
-              />
-            ))}
+          {/* Variant grid */}
+          <div className="flex-1 overflow-y-auto p-5">
+            {adVariants.length === 0 ? (
+              <div className="flex items-center justify-center h-full text-sm text-slate-400">
+                No ad variants found for this campaign.
+              </div>
+            ) : (
+              <div
+                className="grid gap-4"
+                style={{ gridTemplateColumns: `repeat(${variantCols}, minmax(0, 1fr))` }}
+              >
+                {adVariants.map((variant) => (
+                  <AdVariantCard
+                    key={variant.id}
+                    variant={variant}
+                    isSelected={selectedVariants.has(String(variant.id))}
+                    onToggle={onVariantToggle}
+                  />
+                ))}
+              </div>
+            )}
           </div>
         </>
       )}

--- a/frontend/src/components/generate/index.ts
+++ b/frontend/src/components/generate/index.ts
@@ -1,4 +1,5 @@
 export { FilterControls } from './FilterControls';
+export { AdVariantCard } from './AdVariantCard';
 export { VariantCard } from './VariantCard';
 export { PersonaGroupCard } from './PersonaGroupCard';
 export { GeneratingView } from './GeneratingView';

--- a/frontend/src/hooks/useAdGeneration.ts
+++ b/frontend/src/hooks/useAdGeneration.ts
@@ -1,0 +1,56 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  generateCampaignPreview,
+  generateCampaignAdVariants,
+  fetchAdVariants,
+} from '../api/adGeneration';
+import { updateCampaign } from '../api/campaigns';
+import type { UpdateCampaignPayload } from '../types';
+
+export const AD_VARIANTS_KEY = ['ad-variants'] as const;
+
+/** Fetch preview ad variants for a campaign. Polls every `refetchInterval` ms when enabled. */
+export function usePreviewVariants(campaignId: number | undefined, enabled: boolean, refetchInterval?: number) {
+  return useQuery({
+    queryKey: [...AD_VARIANTS_KEY, campaignId, 'preview'],
+    queryFn: () => fetchAdVariants(campaignId!, { isPreview: true }),
+    enabled: !!campaignId && enabled,
+    refetchInterval: refetchInterval || false,
+  });
+}
+
+/** Trigger preview generation. Returns ad_variant_ids on success. */
+export function useGeneratePreview() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (params: { campaignId: number; productId: number; versionNumber: number }) =>
+      generateCampaignPreview(params.campaignId, params.productId, params.versionNumber),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: AD_VARIANTS_KEY });
+    },
+  });
+}
+
+/** Trigger full ad generation. Returns batch_id on success. */
+export function useGenerateFullAds() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (params: { campaignId: number; productId: number; versionNumber: number }) =>
+      generateCampaignAdVariants(params.campaignId, params.productId, params.versionNumber),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: AD_VARIANTS_KEY });
+    },
+  });
+}
+
+/** Update campaign (e.g., to save brief). */
+export function useUpdateCampaign() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (params: { campaignId: number; data: UpdateCampaignPayload }) =>
+      updateCampaign(params.campaignId, params.data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['campaigns'] });
+    },
+  });
+}

--- a/frontend/src/hooks/useChatMessages.ts
+++ b/frontend/src/hooks/useChatMessages.ts
@@ -9,6 +9,12 @@ import type { ChatCompletionRequest, ChatCompletionResponse } from '../api/chat'
 import type { ChatMessage, ChatMessagePayload } from '../types';
 
 export const CHAT_MESSAGES_KEY = ['chatMessages'] as const;
+let optimisticMessageId = -1;
+
+function getNextOptimisticId(): number {
+  optimisticMessageId -= 1;
+  return optimisticMessageId;
+}
 
 /** Fetch all chat messages for a campaign. */
 export function useChatMessages(campaignId: number | undefined) {
@@ -37,7 +43,7 @@ export function useSendChatMessage() {
 
       // Optimistic message with a temporary negative id
       const optimistic: ChatMessage = {
-        id: -Date.now(),
+        id: getNextOptimisticId(),
         campaign_id: data.campaign_id,
         business_client_id: 0,
         role: data.role,
@@ -83,7 +89,7 @@ export function useChatCompletion() {
 
       // Optimistically append the user message
       const optimisticUser: ChatMessage = {
-        id: -Date.now(),
+        id: getNextOptimisticId(),
         campaign_id: data.campaign_id,
         business_client_id: 0,
         role: 'user',

--- a/frontend/src/pages/GenerateAdsPage.tsx
+++ b/frontend/src/pages/GenerateAdsPage.tsx
@@ -3,16 +3,14 @@ import { useCompany } from '../contexts/CompanyContext';
 import { useUser } from '../contexts/UserContext';
 import { Sidebar } from '../components/layout/Sidebar';
 import { ChatPanel, ResultsPanel } from '../components/generate';
-import type { Phase, Version, PersonaGroup } from '../components/generate';
+import type { Phase, Version } from '../components/generate';
 import type { Campaign, ChatMessage } from '../types';
 import { useFilterState } from '../hooks/useFilterState';
 import { useResizablePanel } from '../hooks/useResizablePanel';
 import { useCampaigns } from '../hooks/useCampaigns';
 import { useChatMessages, useSendChatMessage, useChatCompletion } from '../hooks/useChatMessages';
-import {
-  personaGroups as mockPersonaGroups,
-  mockVersionHistory,
-} from '../components/generate/mockData';
+import { useGeneratePreview, usePreviewVariants, useUpdateCampaign } from '../hooks/useAdGeneration';
+import { mockVersionHistory } from '../components/generate/mockData';
 
 // ─── Constants ──────────────────────────────────────────────────
 
@@ -27,16 +25,6 @@ const WELCOME_MESSAGE: ChatMessage = {
   timestamp: new Date().toISOString(),
 };
 
-// ─── Helpers ─────────────────────────────────────────────────────
-
-function getSelectedGroupNames(selectedIds: Set<string>, groups: PersonaGroup[]): string[] {
-  const names: string[] = [];
-  for (const g of groups) {
-    if (g.variants.some((v) => selectedIds.has(v.id))) names.push(g.name);
-  }
-  return names;
-}
-
 // ─── Main Component ──────────────────────────────────────────────
 
 export function GenerateAdsPage() {
@@ -47,6 +35,8 @@ export function GenerateAdsPage() {
   // ─── Data hooks ──────────────────────────────────────────────
   const { data: campaigns = [], isLoading: isCampaignsLoading } = useCampaigns(businessClientId);
   const [filterState, filterDispatch] = useFilterState();
+  const generatePreview = useGeneratePreview();
+  const updateCampaign = useUpdateCampaign();
 
   // ─── Core state ──────────────────────────────────────────────
   const [phase, setPhase] = useState<Phase>('idle');
@@ -57,7 +47,14 @@ export function GenerateAdsPage() {
   // Campaign & version state
   const [activeCampaignId, setActiveCampaignId] = useState<number | undefined>(undefined);
   const [activeVersion, setActiveVersion] = useState<Version>(mockVersionHistory[0]);
-  const [versionCounter, setVersionCounter] = useState(3);
+  const [versionCounter, setVersionCounter] = useState(1);
+
+  // ─── Preview variants (poll while generating) ──────────────
+  const { data: previewVariants = [] } = usePreviewVariants(
+    activeCampaignId,
+    phase === 'generating' || phase === 'results',
+    phase === 'generating' ? 5000 : undefined, // poll every 5s while generating
+  );
 
   // ─── Chat messages (persisted via API) ────────────────────────
   const { data: serverMessages = [] } = useChatMessages(activeCampaignId);
@@ -95,7 +92,6 @@ export function GenerateAdsPage() {
   });
 
   // Variants state
-  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set(['young-pros']));
   const [selectedVariants, setSelectedVariants] = useState<Set<string>>(new Set());
 
   // ─── Resizable panel ────────────────────────────────────────
@@ -127,26 +123,26 @@ export function GenerateAdsPage() {
     return () => clearInterval(interval);
   }, [phase]);
 
-  // ─── Auto-transition from generating to results ─────────────
+  // ─── Auto-transition: generating → results when preview completes ─
   useEffect(() => {
     if (phase !== 'generating') return;
-    const timer = setTimeout(() => {
-      setPhase('results');
-      const newV = versionCounter + 1;
-      setVersionCounter(newV);
-      const newVersion: Version = {
-        id: `v${newV}`,
-        label: `v${newV}`,
-        timestamp: new Date().toLocaleString('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' }),
-        variantCount: mockPersonaGroups.reduce((s, g) => s + g.variants.length, 0),
-      };
-      setActiveVersion(newVersion);
-      sendAssistantMessage(
-        `Done! I've generated 10 ad variants across 3 persona groups (${newVersion.label}). Use the controls to refine, or tell me what to change.`,
-      );
-    }, 4000);
-    return () => clearTimeout(timer);
-  }, [phase, versionCounter, activeCampaignId]);
+    // Transition once we have at least one completed preview variant
+    const completedCount = previewVariants.filter((v) => v.status === 'completed').length;
+    if (completedCount === 0) return;
+
+    setPhase('results');
+    const newVersion: Version = {
+      id: `v${versionCounter}`,
+      label: `v${versionCounter}`,
+      timestamp: new Date().toLocaleString('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' }),
+      variantCount: completedCount,
+    };
+    setActiveVersion(newVersion);
+    setVersionCounter((v) => v + 1);
+    sendAssistantMessage(
+      `Done! I've generated ${completedCount} preview ad variant${completedCount > 1 ? 's' : ''} (${newVersion.label}). Review them on the right, or tell me what to change.`,
+    );
+  }, [phase, previewVariants]);
 
   // ─── Handlers ───────────────────────────────────────────────
 
@@ -172,10 +168,25 @@ export function GenerateAdsPage() {
     });
   };
 
-  const handleApprovePlan = (_planMessage: ChatMessage) => {
+  const handleApprovePlan = (planMessage: ChatMessage) => {
     if (!activeCampaignId) return;
 
-    // Persist a plan_response message indicating approval
+    const activeCampaign = campaigns.find((c) => c.id === activeCampaignId);
+    if (!activeCampaign) return;
+
+    // Extract product_id from campaign's product_ids JSON
+    let productId: number | null = null;
+    try {
+      const ids = JSON.parse(activeCampaign.product_ids || '[]');
+      if (Array.isArray(ids) && ids.length > 0) productId = ids[0];
+    } catch { /* no product_ids */ }
+
+    if (!productId) {
+      sendAssistantMessage('This campaign has no product linked. Please add a product in the Campaigns page first.');
+      return;
+    }
+
+    // Persist approval message
     sendMessage.mutate({
       campaign_id: activeCampaignId,
       role: 'user',
@@ -183,11 +194,33 @@ export function GenerateAdsPage() {
       content: 'Approved',
     });
 
+    // Save the plan as the campaign brief for this version
+    const newVersion = versionCounter;
+    const briefContent = planMessage.content;
+    const existingBrief = activeCampaign.brief ? JSON.parse(activeCampaign.brief) : {};
+    existingBrief[String(newVersion)] = briefContent;
+
+    updateCampaign.mutate({
+      campaignId: activeCampaignId,
+      data: { brief: JSON.stringify(existingBrief) },
+    });
+
     // Confirm in chat and start generating
     sendAssistantMessage(
-      'Plan approved! Starting ad generation — this may take a moment...',
+      'Plan approved! Starting ad generation — this may take a few minutes...',
     );
     setPhase('generating');
+
+    // Trigger preview generation
+    generatePreview.mutate(
+      { campaignId: activeCampaignId, productId, versionNumber: newVersion },
+      {
+        onError: (err) => {
+          setPhase('idle');
+          sendAssistantMessage(`Generation failed: ${(err as Error).message}. Please try again.`);
+        },
+      },
+    );
   };
 
   const handleDeclinePlan = (_planMessage: ChatMessage) => {
@@ -220,20 +253,8 @@ export function GenerateAdsPage() {
   };
 
   const handleReviseSelected = () => {
-    const groupNames = getSelectedGroupNames(selectedVariants, mockPersonaGroups);
     const count = selectedVariants.size;
-    const groupLabel = groupNames.length === 1 ? `in ${groupNames[0]}` : `across ${groupNames.join(', ')}`;
-    setInput(`Revise ${count} selected variant${count > 1 ? 's' : ''} ${groupLabel}: `);
-  };
-
-  const handleDuplicateSelected = () => {
-    sendAssistantMessage(`Duplicated ${selectedVariants.size} variant${selectedVariants.size > 1 ? 's' : ''}. You can find the copies in each persona group.`);
-    setSelectedVariants(new Set());
-  };
-
-  const handleExcludeSelected = () => {
-    sendAssistantMessage(`Marked ${selectedVariants.size} variant${selectedVariants.size > 1 ? 's' : ''} as excluded from export.`);
-    setSelectedVariants(new Set());
+    setInput(`Revise ${count} selected variant${count > 1 ? 's' : ''}: `);
   };
 
   const handleDeleteSelected = () => {
@@ -241,27 +262,10 @@ export function GenerateAdsPage() {
     setSelectedVariants(new Set());
   };
 
-  const toggleGroup = (groupId: string) => {
-    setExpandedGroups((prev) => {
-      const n = new Set(prev);
-      n.has(groupId) ? n.delete(groupId) : n.add(groupId);
-      return n;
-    });
-  };
-
   const toggleVariant = (variantId: string) => {
     setSelectedVariants((prev) => {
       const n = new Set(prev);
       n.has(variantId) ? n.delete(variantId) : n.add(variantId);
-      return n;
-    });
-  };
-
-  const toggleGroupSelect = (group: PersonaGroup) => {
-    const allSelected = group.variants.every((v) => selectedVariants.has(v.id));
-    setSelectedVariants((prev) => {
-      const n = new Set(prev);
-      group.variants.forEach((v) => { allSelected ? n.delete(v.id) : n.add(v.id); });
       return n;
     });
   };
@@ -301,7 +305,7 @@ export function GenerateAdsPage() {
           selectedVariantCount={selectedVariants.size}
           onClearSelection={() => { setSelectedVariants(new Set()); setInput(''); }}
           isAiLoading={chatCompletion.isPending}
-          personaGroups={mockPersonaGroups}
+          variantCount={previewVariants.length}
           className={phase === 'idle' ? 'flex-1' : 'flex-shrink-0'}
           style={phase !== 'idle' ? { width: chatPanelWidth } : undefined}
         />
@@ -333,18 +337,13 @@ export function GenerateAdsPage() {
             phase={phase}
             filterState={filterState}
             filterDispatch={filterDispatch}
-            personaGroups={mockPersonaGroups}
+            adVariants={previewVariants}
             progressIdx={progressIdx}
             selectedVariants={selectedVariants}
             onVariantToggle={toggleVariant}
-            onGroupSelect={toggleGroupSelect}
             onClearSelection={() => setSelectedVariants(new Set())}
             onReviseSelected={handleReviseSelected}
-            onDuplicateSelected={handleDuplicateSelected}
-            onExcludeSelected={handleExcludeSelected}
             onDeleteSelected={handleDeleteSelected}
-            expandedGroups={expandedGroups}
-            onToggleGroup={toggleGroup}
             onApplyFilters={() => {
               sendAssistantMessage('Preferences updated! Regenerating variants with your new settings...');
               setPhase('generating');

--- a/frontend/src/types/adVariant.ts
+++ b/frontend/src/types/adVariant.ts
@@ -1,0 +1,21 @@
+/** Shape returned by GET /ad-variants */
+export interface AdVariant {
+  id: number;
+  campaign_id: number;
+  consumer_id: number | null;
+  product_id: number | null;
+  status: 'Generating' | 'completed' | 'failed';
+  media_url: string | null;
+  meta: string | null;
+  version_number: number;
+  is_preview: boolean;
+  created_at: string;
+  updated_at: string;
+  published_at: string | null;
+}
+
+/** Parsed script stored in AdVariant.meta JSON */
+export interface AdVariantScript {
+  script?: string;
+  error?: string;
+}

--- a/frontend/src/types/campaign.ts
+++ b/frontend/src/types/campaign.ts
@@ -43,4 +43,5 @@ export interface UpdateCampaignPayload {
     target_audience?: string | null;
     product_context?: string | null;
     product_ids?: string | null;
+    brief?: string | null;
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,3 +1,4 @@
+export * from './adVariant';
 export * from './auth';
 export * from './consumer';
 export * from './campaign';


### PR DESCRIPTION
Added wiring logic to allow users to generate videos and see the generated ads in the results panel. Made changes to the results panel to use a new ad_variant card component, and on the backend, the main thing was adding a 1 hour-limited SAS url for the videos to be display-able on the frontend. 