### PR TITLE
Feat/gmm pipeline

### DIFF
--- a/backend/scripts/persist_persona_vectors.py
+++ b/backend/scripts/persist_persona_vectors.py
@@ -1,0 +1,76 @@
+"""
+One-off migration script: write GMM seed vectors into dbo.personas.
+
+Reads the canonical seed matrix from seeds.py and stores each persona's
+seed vector as a JSON array in the feature_vector column, keyed by name.
+
+Pre-requisite — add the column to your DB before running:
+    ALTER TABLE dbo.personas ADD feature_vector NVARCHAR(MAX) NULL;
+
+Run from backend/ directory:
+    python scripts/persist_persona_vectors.py
+
+Safe to re-run: existing feature_vector values are overwritten with the
+current seeds.py values (idempotent).
+"""
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from sqlalchemy import text
+
+from database import _get_session_factory
+from services.gmm_persona_assignment.seeds import PERSONA_NAMES, get_seed_matrix
+
+
+def main() -> None:
+    seed_matrix = get_seed_matrix() # (NUM_PERSONAS, FEATURE_DIM)
+
+    session_factory = _get_session_factory()
+    db = session_factory()
+
+    try:
+        updated = 0
+        missing = []
+
+        for i, name in enumerate(PERSONA_NAMES):
+            vector_json = json.dumps(seed_matrix[i].tolist())
+            rows_affected = db.execute(
+                text(
+                    "UPDATE dbo.personas "
+                    "SET feature_vector = :vec "
+                    "WHERE name = :name"
+                ),
+                {"vec": vector_json, "name": name},
+            ).rowcount
+
+            if rows_affected == 0:
+                missing.append(name)
+            else:
+                updated += 1
+                print(f"  ✓ {name}")
+
+        if missing:
+            db.rollback()
+            print(f"\nERROR: {len(missing)} persona(s) not found in DB:")
+            for m in missing:
+                print(f"  - {m}")
+            print("\nRollback complete. Seed personas into dbo.personas first.")
+            sys.exit(1)
+
+        db.commit()
+        print(f"\nDone. Updated {updated} persona(s).")
+
+    except Exception as exc:
+        db.rollback()
+        print(f"\nERROR: {exc}")
+        raise
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/services/consumer_persona_processor/service.py
+++ b/backend/services/consumer_persona_processor/service.py
@@ -1,29 +1,46 @@
-"""Batch processor for assigning personas to consumers."""
+"""Batch processor for assigning personas to consumers.
+
+Assignment strategy (in order):
+  1. GMM batch — vectorize all eligible consumers, fit once, assign.
+     Consumers with confidence >= GMM_CONFIDENCE_THRESHOLD are done.
+  2. LLM fallback — remaining consumers (low confidence, GMM persona not
+     in DB, or batch too small) go through the original LLM path.
+
+Thresholds:
+  GMM_CONFIDENCE_THRESHOLD  — minimum GMM confidence to accept without LLM. 
+  Must stay in sync with LOW_CONFIDENCE_MARK in gmm_persona_assignment/service.py.
+"""
 
 import asyncio
 import json
 import logging
 from datetime import datetime, timezone
 
+import numpy as np
 from openai import AsyncOpenAI
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from models.consumer import Consumer
 from models.persona import Persona
+from services.gmm_persona_assignment.model import MIN_SAMPLES, fit_and_predict
+from services.gmm_persona_assignment.seeds import PERSONA_NAMES
+from services.gmm_persona_assignment.vectorizer import encode_traits
 from services.persona_assignment.service import assign_persona
 
 logger = logging.getLogger(__name__)
 
 _MAX_CONCURRENT_LLM_CALLS = 10
+GMM_CONFIDENCE_THRESHOLD = 0.60
 
 
 class PersonaProcessingResult(BaseModel):
     """Summary of a batch processing run."""
     processed: int
     failed: int
-    skipped: int       # already assigned
-    low_confidence: int
+    skipped: int # already assigned
+    low_confidence: int # LLM assignments below 0.5 confidence
+    gmm_assigned: int # consumers assigned by GMM (confidence >= threshold)
     errors: list[str]
 
 
@@ -34,13 +51,7 @@ async def _process_one(
     openai_client: AsyncOpenAI,
     semaphore: asyncio.Semaphore,
 ) -> dict:
-    """Process a single consumer and return a result dict.
-
-    Never raises — all errors are captured and returned in the result.
-    """
-    if consumer.primary_persona_id is not None:
-        return {"status": "skipped"}
-
+    """LLM assignment for a single consumer. Never raises."""
     if not consumer.traits:
         return {
             "status": "failed",
@@ -69,7 +80,7 @@ async def _process_one(
                 consumer.secondary_persona_id = secondary.id
 
         logger.info(
-            "Consumer %d → '%s' (confidence=%.2f)",
+            "Consumer %d → '%s' via LLM (confidence=%.2f)",
             consumer.id,
             assignment.primary_persona_name,
             assignment.primary_confidence,
@@ -80,7 +91,7 @@ async def _process_one(
         }
 
     except Exception as exc:
-        logger.error("Failed to assign persona for consumer %d: %s", consumer.id, exc)
+        logger.error("LLM failed for consumer %d: %s", consumer.id, exc)
         return {
             "status": "failed",
             "error": f"Consumer {consumer.id}: {exc}",
@@ -92,11 +103,12 @@ async def process_consumer_personas(
     consumer_ids: list[int],
     openai_client: AsyncOpenAI,
 ) -> PersonaProcessingResult:
-    """Assign personas to a batch of consumers concurrently.
+    """Assign personas to a batch of consumers.
 
-    - Skips consumers that already have a primary persona assigned (idempotent).
-    - Treats consumers with no traits data as failures and records them in the result.
-    - Up to _MAX_CONCURRENT_LLM_CALLS LLM calls run in parallel.
+    Runs GMM first; consumers with confidence < GMM_CONFIDENCE_THRESHOLD
+    (or when GMM cannot run) fall back to the LLM path.
+
+    - Skips consumers that already have a primary persona (idempotent).
     - A single db.commit() is issued after all processing completes.
     """
     personas: list[Persona] = db.query(Persona).all()
@@ -108,10 +120,9 @@ async def process_consumer_personas(
     found_ids = {c.id for c in consumers}
 
     result = PersonaProcessingResult(
-        processed=0, failed=0, skipped=0, low_confidence=0, errors=[]
+        processed=0, failed=0, skipped=0, low_confidence=0, gmm_assigned=0, errors=[]
     )
 
-    # Count IDs that don't exist in the DB up front
     for cid in consumer_ids:
         if cid not in found_ids:
             result.failed += 1
@@ -120,26 +131,90 @@ async def process_consumer_personas(
     if not consumers:
         return result
 
-    semaphore = asyncio.Semaphore(_MAX_CONCURRENT_LLM_CALLS)
-    outcomes = await asyncio.gather(
-        *[
-            _process_one(consumer, persona_lookup, personas, openai_client, semaphore)
-            for consumer in consumers
-        ]
-    )
+    # --- pre-classify ---
+    already_assigned = [c for c in consumers if c.primary_persona_id is not None]
+    eligible = [c for c in consumers if c.primary_persona_id is None]
+    no_traits = [c for c in eligible if not c.traits]
+    vectorizable = [c for c in eligible if c.traits]
 
-    for outcome in outcomes:
-        status = outcome["status"]
-        if status == "processed":
-            result.processed += 1
-            if outcome.get("low_confidence"):
-                result.low_confidence += 1
-        elif status == "skipped":
-            result.skipped += 1
-        else:
-            result.failed += 1
-            result.errors.append(outcome["error"])
+    result.skipped += len(already_assigned)
 
+    for consumer in no_traits:
+        result.failed += 1
+        result.errors.append(f"Consumer {consumer.id}: no traits data")
+
+    # --- GMM batch pass ---
+    llm_candidates: list[Consumer] = []
+
+    if len(vectorizable) >= MIN_SAMPLES:
+        try:
+            X = np.stack([encode_traits(json.loads(c.traits)) for c in vectorizable])
+            proba, _ = fit_and_predict(X)
+            now = datetime.now(timezone.utc)
+
+            for i, consumer in enumerate(vectorizable):
+                confidence = float(np.max(proba[i]))
+
+                if confidence < GMM_CONFIDENCE_THRESHOLD:
+                    llm_candidates.append(consumer)
+                    continue
+
+                component_idx = int(np.argmax(proba[i]))
+                persona_name = PERSONA_NAMES[component_idx]
+                primary = persona_lookup.get(persona_name)
+
+                if primary is None:
+                    # Persona not seeded into this DB — fall through to LLM.
+                    llm_candidates.append(consumer)
+                    continue
+
+                consumer.primary_persona_id = primary.id
+                consumer.persona_confidence = confidence
+                consumer.persona_assigned_at = now
+
+                sorted_idx = np.argsort(proba[i])[::-1]
+                if len(sorted_idx) > 1 and proba[i][sorted_idx[1]] >= 0.25:
+                    secondary_name = PERSONA_NAMES[sorted_idx[1]]
+                    secondary = persona_lookup.get(secondary_name)
+                    if secondary:
+                        consumer.secondary_persona_id = secondary.id
+
+                result.processed += 1
+                result.gmm_assigned += 1
+                logger.info(
+                    "Consumer %d → '%s' via GMM (confidence=%.2f)",
+                    consumer.id,
+                    persona_name,
+                    confidence,
+                )
+
+        except Exception as exc:
+            logger.error("GMM batch failed: %s — routing all to LLM", exc)
+            llm_candidates = vectorizable
+    else:
+        # Too few consumers to fit GMM — go straight to LLM.
+        llm_candidates = vectorizable
+
+    # --- LLM pass for remaining consumers ---
+    if llm_candidates:
+        semaphore = asyncio.Semaphore(_MAX_CONCURRENT_LLM_CALLS)
+        outcomes = await asyncio.gather(
+            *[
+                _process_one(consumer, persona_lookup, personas, openai_client, semaphore)
+                for consumer in llm_candidates
+            ]
+        )
+        for outcome in outcomes:
+            status = outcome["status"]
+            if status == "processed":
+                result.processed += 1
+                if outcome.get("low_confidence"):
+                    result.low_confidence += 1
+            else:
+                result.failed += 1
+                result.errors.append(outcome["error"])
+
+    # --- single commit ---
     try:
         db.add_all(consumers)
         db.commit()

--- a/backend/services/gmm_persona_assignment/model.py
+++ b/backend/services/gmm_persona_assignment/model.py
@@ -1,0 +1,105 @@
+"""
+GMM persona assignment - ML pipeline.
+
+No DB access. Takes a raw feature matrix with NaNs, runs:
+  IterativeImputer (MICE) -> StandardScaler -> apply_weights -> GaussianMixture
+
+Public API:
+  fit_and_predict(X) -> fit fresh, return (proba_matrix, FittedModel)
+  predict(X, fitted) -> predict on new data with an already-fitted pipeline
+
+Critical invariant: seeds must pass through the same fitted StandardScaler and apply_weights before being used as means_init, so they live in the same space as the training data.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from sklearn.experimental import enable_iterative_imputer  # noqa: F401 — side-effect import
+from sklearn.impute import IterativeImputer
+from sklearn.mixture import GaussianMixture
+from sklearn.preprocessing import StandardScaler
+
+from .seeds import NUM_PERSONAS, get_seed_matrix
+from .vectorizer import FEATURE_DIM, apply_weights
+
+# Minimum samples needed to fit a GMM with NUM_PERSONAS components.
+# Below this, sklearn raises; caller should route to LLM fallback.
+MIN_SAMPLES = NUM_PERSONAS
+
+
+@dataclass
+class FittedModel:
+    """Fitted pipeline artifacts — imputer, scaler, and trained GMM."""
+    imputer: IterativeImputer
+    scaler: StandardScaler
+    gmm: GaussianMixture
+
+
+def fit_and_predict(X: np.ndarray) -> tuple[np.ndarray, FittedModel]:
+    """Fit the full pipeline on X and return soft assignment probabilities.
+
+    Fits from scratch on every call — no artifact persistence in v1.
+
+    Args:
+        X: (n_samples, FEATURE_DIM) float64. np.nan for missing values.
+           Must have at least MIN_SAMPLES rows.
+
+    Returns:
+        proba: (n_samples, NUM_PERSONAS) float64. Rows sum to 1.0.
+        fitted: Fitted pipeline for optional reuse via predict().
+
+    Raises:
+        ValueError: if X has wrong shape or too few rows.
+    """
+    if X.ndim != 2 or X.shape[1] != FEATURE_DIM:
+        raise ValueError(f"X must have shape (n, {FEATURE_DIM}), got {X.shape}")
+    if X.shape[0] < MIN_SAMPLES:
+        raise ValueError(
+            f"Need at least {MIN_SAMPLES} samples to fit GMM; got {X.shape[0]}. "
+            "Route these consumers to LLM fallback instead."
+        )
+
+    imputer = IterativeImputer(random_state=42, max_iter=10)
+    X_imp = imputer.fit_transform(X)
+
+    scaler = StandardScaler()
+    X_scaled = scaler.fit_transform(X_imp)
+    X_weighted = apply_weights(X_scaled)
+
+    # Seeds have no NaNs — skip imputer, but must go through the fitted scaler
+    # so they live in the same space as X_weighted.
+    seeds_weighted = apply_weights(scaler.transform(get_seed_matrix()))
+
+    gmm = GaussianMixture(
+        n_components=NUM_PERSONAS,
+        covariance_type="diag",
+        means_init=seeds_weighted,
+        n_init=1, # warm start makes multiple inits redundant
+        max_iter=100,
+        random_state=42,
+    )
+    gmm.fit(X_weighted)
+
+    fitted = FittedModel(imputer=imputer, scaler=scaler, gmm=gmm)
+    return gmm.predict_proba(X_weighted), fitted
+
+
+def predict(X: np.ndarray, fitted: FittedModel) -> np.ndarray:
+    """Predict soft assignments on new data using an already-fitted pipeline.
+
+    Args:
+        X: (n_samples, FEATURE_DIM) float64. np.nan for missing values.
+        fitted: FittedModel returned by fit_and_predict().
+
+    Returns:
+        proba: (n_samples, NUM_PERSONAS) float64. Rows sum to 1.0.
+    """
+    if X.ndim != 2 or X.shape[1] != FEATURE_DIM:
+        raise ValueError(f"X must have shape (n, {FEATURE_DIM}), got {X.shape}")
+
+    X_imp = fitted.imputer.transform(X)
+    X_scaled = fitted.scaler.transform(X_imp)
+    X_weighted = apply_weights(X_scaled)
+    return fitted.gmm.predict_proba(X_weighted)

--- a/backend/services/gmm_persona_assignment/service.py
+++ b/backend/services/gmm_persona_assignment/service.py
@@ -1,0 +1,172 @@
+"""
+GMM persona assignment — DB orchestration layer.
+
+Fetches consumers from the DB, vectorizes their traits, runs the ML
+pipeline, and writes primary/secondary persona assignments back.
+
+Public API:
+  run_gmm_assignment(db, ...)  — main entry point
+
+Thresholds (tunable):
+  SECONDARY_THRESHOLD -> minimum probability to write a secondary persona
+  LOW_CONFIDENCE_MARK -> boundary reported in GMMAssignmentResult.low_confidence 
+    (also the LLM fallback threshold used by the processor)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+import numpy as np
+from sqlalchemy.orm import Session
+
+from models.consumer import Consumer
+from models.persona import Persona
+
+from .model import MIN_SAMPLES, fit_and_predict
+from .seeds import NUM_PERSONAS, PERSONA_NAMES
+from .vectorizer import encode_traits
+
+logger = logging.getLogger(__name__)
+
+SECONDARY_THRESHOLD: float = 0.25
+LOW_CONFIDENCE_MARK: float = 0.60
+
+
+@dataclass
+class GMMAssignmentResult:
+    """Summary returned by run_gmm_assignment."""
+    assigned: int = 0
+    low_confidence: int = 0 # assigned but confidence < LOW_CONFIDENCE_MARK
+    skipped: int = 0 # already had a persona; reassign_existing=False
+    failed: int = 0 # missing traits or DB lookup error
+    errors: list[str] = field(default_factory=list)
+    persona_distribution: dict[str, int] = field(default_factory=dict)
+
+
+def _load_persona_map(db: Session) -> dict[int, str]:
+    """Map GMM component index (0-NUM_PERSONAS-1) -> persona UUID.
+
+    Queries dbo.personas by name using PERSONA_NAMES order.
+    Raises ValueError if any canonical persona is absent from the DB.
+    """
+    component_to_id: dict[int, str] = {}
+    for i, name in enumerate(PERSONA_NAMES):
+        persona = db.query(Persona).filter(Persona.name == name).first()
+        if persona is None:
+            raise ValueError(
+                f"Persona '{name}' not found in DB. "
+                "Seed personas before running GMM assignment."
+            )
+        component_to_id[i] = persona.id
+    return component_to_id
+
+
+def run_gmm_assignment(
+    db: Session,
+    business_client_id: int | None = None,
+    reassign_existing: bool = False,
+) -> GMMAssignmentResult:
+    """Assign personas to consumers using the GMM pipeline.
+
+    Args:
+        db: -> Active SQLAlchemy session.
+        business_client_id: -> Scope to one client, or None for all clients.
+        reassign_existing: -> If False (default), consumers with a primary persona already set are skipped.
+
+    Returns:
+        GMMAssignmentResult with counts and per-persona distribution.
+
+    Raises:
+        ValueError: if canonical personas are missing from the DB.
+        Exception: re-raises DB commit failures after rollback.
+    """
+    result = GMMAssignmentResult()
+
+    component_to_id = _load_persona_map(db)
+    component_to_name = {i: PERSONA_NAMES[i] for i in range(NUM_PERSONAS)}
+
+    # --- fetch consumers ---
+    query = db.query(Consumer)
+    if business_client_id is not None:
+        query = query.filter(Consumer.business_client_id == business_client_id)
+    if not reassign_existing:
+        query = query.filter(Consumer.primary_persona_id.is_(None))
+    consumers = query.all()
+
+    if not consumers:
+        return result
+
+    # --- pre-classify ---
+    vectorizable: list[Consumer] = []
+    for consumer in consumers:
+        if not consumer.traits:
+            result.failed += 1
+            result.errors.append(f"Consumer {consumer.id}: no traits data")
+        else:
+            vectorizable.append(consumer)
+
+    if len(vectorizable) < MIN_SAMPLES:
+        # Too few samples for GMM — mark all as failed rather than crash.
+        for consumer in vectorizable:
+            result.failed += 1
+            result.errors.append(
+                f"Consumer {consumer.id}: batch too small for GMM "
+                f"(need {MIN_SAMPLES}, got {len(vectorizable)})"
+            )
+        logger.warning(
+            "Batch too small for GMM (%d < %d). No assignments made.",
+            len(vectorizable),
+            MIN_SAMPLES,
+        )
+        return result
+
+    # --- vectorize -> fit -> assign ---
+    X = np.stack([encode_traits(json.loads(c.traits)) for c in vectorizable])
+    proba, _ = fit_and_predict(X)
+
+    now = datetime.now(timezone.utc)
+
+    for i, consumer in enumerate(vectorizable):
+        row = proba[i]
+        primary_idx = int(np.argmax(row))
+        confidence = float(row[primary_idx])
+
+        consumer.primary_persona_id = component_to_id[primary_idx]
+        consumer.persona_confidence = confidence
+        consumer.persona_assigned_at = now
+
+        # Secondary: second-highest component, only if above threshold
+        sorted_indices = np.argsort(row)[::-1]
+        if len(sorted_indices) > 1 and row[sorted_indices[1]] >= SECONDARY_THRESHOLD:
+            consumer.secondary_persona_id = component_to_id[sorted_indices[1]]
+        else:
+            consumer.secondary_persona_id = None
+
+        result.assigned += 1
+        if confidence < LOW_CONFIDENCE_MARK:
+            result.low_confidence += 1
+
+        name = component_to_name[primary_idx]
+        result.persona_distribution[name] = result.persona_distribution.get(name, 0) + 1
+
+        logger.info(
+            "Consumer %d -> '%s' (confidence=%.2f)",
+            consumer.id,
+            name,
+            confidence,
+        )
+
+    # --- single commit ---
+    try:
+        db.add_all(vectorizable)
+        db.commit()
+    except Exception as exc:
+        db.rollback()
+        logger.error("Failed to commit GMM assignments: %s", exc)
+        raise
+
+    return result

--- a/backend/tests/test_gmm_model.py
+++ b/backend/tests/test_gmm_model.py
@@ -1,0 +1,201 @@
+"""Unit tests for gmm_persona_assignment/model.py.
+
+Tests the ML pipeline contract: shape, probability validity, imputation,
+and the warm-start invariant. No DB required.
+
+Run from backend/ directory:
+    python -m pytest tests/test_gmm_model.py -v
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import numpy as np
+import pytest
+
+from services.gmm_persona_assignment.model import (
+    MIN_SAMPLES,
+    FittedModel,
+    fit_and_predict,
+    predict,
+)
+from services.gmm_persona_assignment.seeds import NUM_PERSONAS, get_seed_matrix
+from services.gmm_persona_assignment.vectorizer import FEATURE_DIM
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _synthetic_X(n: int, nan_fraction: float = 0.0, seed: int = 0) -> np.ndarray:
+    """Generate a random (n, FEATURE_DIM) matrix with optional NaN injection."""
+    rng = np.random.default_rng(seed)
+    X = rng.uniform(0.0, 1.0, size=(n, FEATURE_DIM))
+    if nan_fraction > 0.0:
+        mask = rng.random(X.shape) < nan_fraction
+        X[mask] = np.nan
+    return X
+
+
+# ---------------------------------------------------------------------------
+# fit_and_predict: shape and probability contracts
+# ---------------------------------------------------------------------------
+
+def test_output_shape_is_n_by_num_personas():
+    X = _synthetic_X(20)
+    proba, fitted = fit_and_predict(X)
+    assert proba.shape == (20, NUM_PERSONAS)
+    assert isinstance(fitted, FittedModel)
+
+
+def test_rows_sum_to_one():
+    X = _synthetic_X(20)
+    proba, _ = fit_and_predict(X)
+    np.testing.assert_allclose(proba.sum(axis=1), np.ones(20), atol=1e-6)
+
+
+def test_probabilities_are_non_negative():
+    X = _synthetic_X(20)
+    proba, _ = fit_and_predict(X)
+    assert np.all(proba >= 0.0)
+
+
+def test_probabilities_are_at_most_one():
+    X = _synthetic_X(20)
+    proba, _ = fit_and_predict(X)
+    assert np.all(proba <= 1.0 + 1e-9)
+
+
+# ---------------------------------------------------------------------------
+# fit_and_predict: imputation with NaNs
+# ---------------------------------------------------------------------------
+
+def test_runs_with_40_percent_nan():
+    X = _synthetic_X(30, nan_fraction=0.40)
+    proba, _ = fit_and_predict(X)
+    assert proba.shape == (30, NUM_PERSONAS)
+    np.testing.assert_allclose(proba.sum(axis=1), np.ones(30), atol=1e-6)
+
+
+
+def test_fully_present_and_nan_batches_give_same_shape():
+    X_full = _synthetic_X(20)
+    X_nan = _synthetic_X(20, nan_fraction=0.30)
+    proba_full, _ = fit_and_predict(X_full)
+    proba_nan, _ = fit_and_predict(X_nan)
+    assert proba_full.shape == proba_nan.shape
+
+
+# ---------------------------------------------------------------------------
+# fit_and_predict: input validation
+# ---------------------------------------------------------------------------
+
+def test_wrong_feature_dim_raises():
+    X = np.ones((10, FEATURE_DIM - 1))
+    with pytest.raises(ValueError, match=str(FEATURE_DIM)):
+        fit_and_predict(X)
+
+
+def test_1d_input_raises():
+    X = np.ones(FEATURE_DIM)
+    with pytest.raises(ValueError):
+        fit_and_predict(X)
+
+
+def test_too_few_samples_raises():
+    X = _synthetic_X(MIN_SAMPLES - 1)
+    with pytest.raises(ValueError, match=str(MIN_SAMPLES)):
+        fit_and_predict(X)
+
+
+def test_exactly_min_samples_succeeds():
+    X = _synthetic_X(MIN_SAMPLES)
+    proba, _ = fit_and_predict(X)
+    assert proba.shape == (MIN_SAMPLES, NUM_PERSONAS)
+
+
+# ---------------------------------------------------------------------------
+# predict: uses fitted pipeline on new data
+# ---------------------------------------------------------------------------
+
+def test_predict_output_shape():
+    X_train = _synthetic_X(30)
+    _, fitted = fit_and_predict(X_train)
+
+    X_new = _synthetic_X(5, seed=99)
+    proba = predict(X_new, fitted)
+    assert proba.shape == (5, NUM_PERSONAS)
+
+
+def test_predict_rows_sum_to_one():
+    X_train = _synthetic_X(30)
+    _, fitted = fit_and_predict(X_train)
+
+    X_new = _synthetic_X(10, seed=7)
+    proba = predict(X_new, fitted)
+    np.testing.assert_allclose(proba.sum(axis=1), np.ones(10), atol=1e-6)
+
+
+def test_predict_handles_nan_input():
+    X_train = _synthetic_X(30)
+    _, fitted = fit_and_predict(X_train)
+
+    X_new = _synthetic_X(5, nan_fraction=0.50, seed=42)
+    proba = predict(X_new, fitted)
+    assert proba.shape == (5, NUM_PERSONAS)
+    np.testing.assert_allclose(proba.sum(axis=1), np.ones(5), atol=1e-6)
+
+
+def test_predict_wrong_shape_raises():
+    X_train = _synthetic_X(30)
+    _, fitted = fit_and_predict(X_train)
+
+    X_bad = np.ones((5, FEATURE_DIM + 1))
+    with pytest.raises(ValueError):
+        predict(X_bad, fitted)
+
+
+# ---------------------------------------------------------------------------
+# Warm-start sanity: seeds can be recovered from their own cluster
+# ---------------------------------------------------------------------------
+
+def test_seed_matrix_shape():
+    seeds = get_seed_matrix()
+    assert seeds.shape == (NUM_PERSONAS, FEATURE_DIM)
+
+
+def test_seeds_are_assigned_to_distinct_components():
+    """When data is generated tightly around each seed, each seed
+    should map to a distinct GMM component after fitting."""
+    rng = np.random.default_rng(0)
+    seeds = get_seed_matrix()
+
+    # Generate n_per_cluster samples per persona, each a small perturbation of the seed
+    n_per_cluster = 15
+    rows = []
+    labels = []
+    for k, seed in enumerate(seeds):
+        noise = rng.normal(0, 0.03, size=(n_per_cluster, FEATURE_DIM))
+        cluster = np.clip(seed + noise, 0.0, 1.0)
+        rows.append(cluster)
+        labels.extend([k] * n_per_cluster)
+
+    X = np.vstack(rows)
+    proba, _ = fit_and_predict(X)
+    assigned = np.argmax(proba, axis=1)
+
+    # Each true-label group should predominantly map to a single component
+    for k in range(NUM_PERSONAS):
+        mask = np.array(labels) == k
+        dominant_component = np.bincount(assigned[mask]).argmax()
+        purity = np.mean(assigned[mask] == dominant_component)
+        assert purity >= 0.6, (
+            f"Persona {k}: GMM purity {purity:.2f} < 0.6. "
+            "Warm-start may not be working correctly."
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/backend/tests/test_gmm_vectorizer.py
+++ b/backend/tests/test_gmm_vectorizer.py
@@ -1,0 +1,266 @@
+"""Unit tests for gmm_persona_assignment/vectorizer.py.
+
+No DB, no sklearn — pure input/output checks.
+
+Run from backend/ directory:
+    python -m pytest tests/test_gmm_vectorizer.py -v
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import numpy as np
+import pytest
+
+from services.gmm_persona_assignment.vectorizer import (
+    FEATURE_DIM,
+    FEATURE_WEIGHTS,
+    F_AGE,
+    F_AI_FAVORABILITY,
+    F_AGREEABLENESS,
+    F_CONSCIENTIOUSNESS,
+    F_DECISION_MAKING,
+    F_DEVICE_DESKTOP,
+    F_DEVICE_MOBILE,
+    F_DEVICE_TABLET,
+    F_EDUCATION,
+    F_GENDER_FEMALE,
+    F_GENDER_MALE,
+    F_GENDER_NONBINARY,
+    F_HOMEOWNERSHIP,
+    F_INCOME,
+    F_NEUROTICISM,
+    F_OPENNESS,
+    F_SOCIABILITY,
+    F_THOUGHT_PROCESS,
+    apply_weights,
+    encode_traits,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _full_traits() -> dict:
+    return {
+        "age": 40,
+        "income_range": "high",
+        "education": "graduate",
+        "homeownership": "owner",
+        "sociability": 0.7,
+        "decision_making": 0.3,
+        "thought_process": 0.6,
+        "openness": 0.8,
+        "conscientiousness": 0.9,
+        "agreeableness": 0.5,
+        "neuroticism": 0.2,
+        "ai_favorability": "positive",
+        "gender": "female",
+        "device": "mobile",
+    }
+
+
+# ---------------------------------------------------------------------------
+# encode_traits: known inputs
+# ---------------------------------------------------------------------------
+
+def test_full_traits_encodes_correct_values():
+    v = encode_traits(_full_traits())
+
+    assert v.shape == (FEATURE_DIM,)
+    assert v[F_AGE] == pytest.approx((40 - 18) / (80 - 18))
+    assert v[F_INCOME] == pytest.approx(2 / 3)
+    assert v[F_EDUCATION] == pytest.approx(1.0)
+    assert v[F_HOMEOWNERSHIP] == pytest.approx(1.0)
+    assert v[F_SOCIABILITY] == pytest.approx(0.7)
+    assert v[F_DECISION_MAKING] == pytest.approx(0.3)
+    assert v[F_THOUGHT_PROCESS] == pytest.approx(0.6)
+    assert v[F_OPENNESS] == pytest.approx(0.8)
+    assert v[F_CONSCIENTIOUSNESS] == pytest.approx(0.9)
+    assert v[F_AGREEABLENESS] == pytest.approx(0.5)
+    assert v[F_NEUROTICISM] == pytest.approx(0.2)
+    assert v[F_AI_FAVORABILITY] == pytest.approx(2 / 3)
+
+
+def test_gender_female_one_hot():
+    v = encode_traits({"gender": "female"})
+    assert v[F_GENDER_MALE] == pytest.approx(0.0)
+    assert v[F_GENDER_FEMALE] == pytest.approx(1.0)
+    assert v[F_GENDER_NONBINARY] == pytest.approx(0.0)
+
+
+def test_gender_male_one_hot():
+    v = encode_traits({"gender": "male"})
+    assert v[F_GENDER_MALE] == pytest.approx(1.0)
+    assert v[F_GENDER_FEMALE] == pytest.approx(0.0)
+    assert v[F_GENDER_NONBINARY] == pytest.approx(0.0)
+
+
+def test_gender_nonbinary_one_hot():
+    v = encode_traits({"gender": "non-binary"})
+    assert v[F_GENDER_MALE] == pytest.approx(0.0)
+    assert v[F_GENDER_FEMALE] == pytest.approx(0.0)
+    assert v[F_GENDER_NONBINARY] == pytest.approx(1.0)
+
+
+def test_device_mobile_one_hot():
+    v = encode_traits({"device": "mobile"})
+    assert v[F_DEVICE_MOBILE] == pytest.approx(1.0)
+    assert v[F_DEVICE_DESKTOP] == pytest.approx(0.0)
+    assert v[F_DEVICE_TABLET] == pytest.approx(0.0)
+
+
+def test_device_desktop_one_hot():
+    v = encode_traits({"device": "desktop"})
+    assert v[F_DEVICE_MOBILE] == pytest.approx(0.0)
+    assert v[F_DEVICE_DESKTOP] == pytest.approx(1.0)
+    assert v[F_DEVICE_TABLET] == pytest.approx(0.0)
+
+
+def test_device_tablet_one_hot():
+    v = encode_traits({"device": "tablet"})
+    assert v[F_DEVICE_MOBILE] == pytest.approx(0.0)
+    assert v[F_DEVICE_DESKTOP] == pytest.approx(0.0)
+    assert v[F_DEVICE_TABLET] == pytest.approx(1.0)
+
+
+def test_homeownership_renter():
+    v = encode_traits({"homeownership": "renter"})
+    assert v[F_HOMEOWNERSHIP] == pytest.approx(0.0)
+
+
+def test_age_boundary_min():
+    v = encode_traits({"age": 18})
+    assert v[F_AGE] == pytest.approx(0.0)
+
+
+def test_age_boundary_max():
+    v = encode_traits({"age": 80})
+    assert v[F_AGE] == pytest.approx(1.0)
+
+
+def test_age_clipped_below_min():
+    v = encode_traits({"age": 5})
+    assert v[F_AGE] == pytest.approx(0.0)
+
+
+def test_age_clipped_above_max():
+    v = encode_traits({"age": 150})
+    assert v[F_AGE] == pytest.approx(1.0)
+
+
+def test_income_ordinal_values():
+    assert encode_traits({"income_range": "low"})[F_INCOME] == pytest.approx(0.0)
+    assert encode_traits({"income_range": "mid"})[F_INCOME] == pytest.approx(1 / 3)
+    assert encode_traits({"income_range": "high"})[F_INCOME] == pytest.approx(2 / 3)
+    assert encode_traits({"income_range": "very_high"})[F_INCOME] == pytest.approx(1.0)
+
+
+def test_education_ordinal_values():
+    assert encode_traits({"education": "high_school"})[F_EDUCATION] == pytest.approx(0.0)
+    assert encode_traits({"education": "some_college"})[F_EDUCATION] == pytest.approx(1 / 3)
+    assert encode_traits({"education": "bachelors"})[F_EDUCATION] == pytest.approx(2 / 3)
+    assert encode_traits({"education": "graduate"})[F_EDUCATION] == pytest.approx(1.0)
+
+
+def test_ai_favorability_ordinal_values():
+    assert encode_traits({"ai_favorability": "negative"})[F_AI_FAVORABILITY] == pytest.approx(0.0)
+    assert encode_traits({"ai_favorability": "neutral"})[F_AI_FAVORABILITY] == pytest.approx(1 / 3)
+    assert encode_traits({"ai_favorability": "positive"})[F_AI_FAVORABILITY] == pytest.approx(2 / 3)
+    assert encode_traits({"ai_favorability": "enthusiast"})[F_AI_FAVORABILITY] == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# encode_traits: missing and invalid values → NaN
+# ---------------------------------------------------------------------------
+
+def test_empty_dict_is_all_nan():
+    v = encode_traits({})
+    assert v.shape == (FEATURE_DIM,)
+    assert np.all(np.isnan(v))
+
+
+def test_missing_age_is_nan():
+    v = encode_traits({"income_range": "mid"})
+    assert np.isnan(v[F_AGE])
+    assert not np.isnan(v[F_INCOME])
+
+
+def test_unknown_income_is_nan():
+    v = encode_traits({"income_range": "wealthy"})
+    assert np.isnan(v[F_INCOME])
+
+
+def test_unknown_education_is_nan():
+    v = encode_traits({"education": "phd"})
+    assert np.isnan(v[F_EDUCATION])
+
+
+def test_unknown_ai_favorability_is_nan():
+    v = encode_traits({"ai_favorability": "meh"})
+    assert np.isnan(v[F_AI_FAVORABILITY])
+
+
+def test_unknown_gender_leaves_all_nan():
+    v = encode_traits({"gender": "unknown"})
+    assert np.isnan(v[F_GENDER_MALE])
+    assert np.isnan(v[F_GENDER_FEMALE])
+    assert np.isnan(v[F_GENDER_NONBINARY])
+
+
+def test_unknown_device_leaves_all_nan():
+    v = encode_traits({"device": "smartwatch"})
+    assert np.isnan(v[F_DEVICE_MOBILE])
+    assert np.isnan(v[F_DEVICE_DESKTOP])
+    assert np.isnan(v[F_DEVICE_TABLET])
+
+
+def test_non_numeric_age_is_nan():
+    v = encode_traits({"age": "old"})
+    assert np.isnan(v[F_AGE])
+
+
+def test_none_age_is_nan():
+    v = encode_traits({"age": None})
+    assert np.isnan(v[F_AGE])
+
+
+def test_psychographic_out_of_range_is_clipped():
+    # Values outside [0, 1] should clamp, not produce NaN or error.
+    v = encode_traits({"sociability": 1.5, "neuroticism": -0.3})
+    assert v[F_SOCIABILITY] == pytest.approx(1.0)
+    assert v[F_NEUROTICISM] == pytest.approx(0.0)
+
+
+def test_unknown_fields_are_ignored():
+    v = encode_traits({"zodiac": "scorpio", "favorite_color": "blue"})
+    assert np.all(np.isnan(v))
+
+
+# ---------------------------------------------------------------------------
+# apply_weights
+# ---------------------------------------------------------------------------
+
+def test_apply_weights_shape_preserved():
+    X = np.ones((5, FEATURE_DIM), dtype=np.float64)
+    result = apply_weights(X)
+    assert result.shape == (5, FEATURE_DIM)
+
+
+def test_apply_weights_scales_correctly():
+    X = np.ones((1, FEATURE_DIM), dtype=np.float64)
+    result = apply_weights(X)
+    np.testing.assert_allclose(result[0], FEATURE_WEIGHTS)
+
+
+def test_apply_weights_zero_row_stays_zero():
+    X = np.zeros((3, FEATURE_DIM), dtype=np.float64)
+    result = apply_weights(X)
+    assert np.all(result == 0.0)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## GMM Persona Assignment Pipeline                                      
                                                                          
  Replaces LLM-only persona assignment with a Gaussian Mixture Model that 
  runs first on every batch. The LLM is kept as a fallback for            
  low-confidence cases (< 60%).                                           
                                                                          
  **What changed**
  - `model.py` — ML pipeline: impute → scale → weight → GMM fit → soft    
  probabilities                                             
  - `service.py` — DB layer: fetches consumers, runs model, writes        
  assignments in one commit                                               
  - `consumer_persona_processor/service.py` — GMM runs first, LLM fallback
   for confidence < 0.60                      
  - `persist_persona_vectors.py` — one-off script to write seed vectors   
  into `dbo.personas`                                       
  - 45 new tests covering encoding contracts, pipeline shape/probability  
  invariants, and imputation                                                                                                     
                                             