### PR TITLE
Add agent resources documentation set

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Operational index for **Adgentic AI**: an AI-assisted system for business owners to **generate, deploy, and track** social ads (see [README.md](README.md) for architecture diagram and service list).
 
-**Agent resources** (prompts, checklists, domain notes, and other material for AI/human agents) live in [`agent_resources/`](agent_resources/). **Lookup tables** (API paths, env vars, routes, DB tables) are in [`agent_resources/references/`](agent_resources/references/). **Design docs for major changes** go in [`agent_resources/design-docs/`](agent_resources/design-docs/) *before* implementation—see [Major changes (design doc first)](#major-changes-design-doc-first). **Task-specific execution plans** (steps, acceptance criteria, file pointers) live in [`exec-plans/`](exec-plans/)—see [Execution plans (task details)](#execution-plans-task-details).
+**Agent resources** (prompts, checklists, domain notes, and other material for AI/human agents) live in [`agent_resources/`](agent_resources/). **Lookup tables** (API paths, env vars, routes, DB tables) are in [`agent_resources/references/`](agent_resources/references/). **Design docs for major changes** go in [`agent_resources/design-docs/`](agent_resources/design-docs/) *before* implementation—see [Major changes (design doc first)](#major-changes-design-doc-first). **Task-specific execution plans** (steps, acceptance criteria, file pointers) live in [`exec-plans/`](exec-plans/)—see [Execution plans (task details)](#execution-plans-task-details). For broader **review-first** expectations with AI tooling, see [CLAUDE.md](CLAUDE.md) (complements this file).
 
 ---
 
@@ -73,6 +73,8 @@ Root `package.json` has no real test script; **CI** is the source of truth: `.gi
 
 **Agents and contributors:** for **major** work (new features, cross-cutting refactors, auth/schema/job pipeline changes, new integrations), **do not start implementation** until a design doc exists in [`agent_resources/design-docs/`](agent_resources/design-docs/).
 
+**Exceptions:** A maintainer may **explicitly waive** the design-doc requirement in an issue, PR, or chat (e.g. time-bound hotfix); note the waiver and risk in the PR. If an **exec-plan is silent** but the change is **clearly major**, **stop and confirm** with the human before coding.
+
 1. **Read** any matching file in [`exec-plans/`](exec-plans/) for this work, plus [agent_resources/ARCHITECTURE.md](agent_resources/ARCHITECTURE.md), [PRODUCT.md](agent_resources/PRODUCT.md), and the relevant [BACKEND.md](agent_resources/BACKEND.md) / [FRONTEND.md](agent_resources/FRONTEND.md) sections so the design matches house patterns.
 2. **Add** a new Markdown file under `agent_resources/design-docs/` (naming and outline: [design-docs/README.md](agent_resources/design-docs/README.md)).
 3. **Cover** problem, goals/non-goals, proposed behavior, API/DB impacts, alternatives, rollout, and test plan.
@@ -80,6 +82,8 @@ Root `package.json` has no real test script; **CI** is the source of truth: `.gi
 5. **Implement** in code, then update the design doc or PR with what actually shipped.
 
 Small, low-risk edits can skip this folder.
+
+This section is the repo-specific **design-doc gate**; [CLAUDE.md](CLAUDE.md) covers broader review workflow for large or risky work.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,110 @@
+# Agent / contributor map
+
+Operational index for **Adgentic AI**: an AI-assisted system for business owners to **generate, deploy, and track** social ads (see [README.md](README.md) for architecture diagram and service list).
+
+**Agent resources** (prompts, checklists, domain notes, and other material for AI/human agents) live in [`agent_resources/`](agent_resources/). **Lookup tables** (API paths, env vars, routes, DB tables) are in [`agent_resources/references/`](agent_resources/references/). **Design docs for major changes** go in [`agent_resources/design-docs/`](agent_resources/design-docs/) *before* implementation—see [Major changes (design doc first)](#major-changes-design-doc-first). **Task-specific execution plans** (steps, acceptance criteria, file pointers) live in [`exec-plans/`](exec-plans/)—see [Execution plans (task details)](#execution-plans-task-details).
+
+---
+
+## Execution plans (task details)
+
+**Agents:** when you are given work—especially a ticket, issue, or chat that points at this repo—**look in [`exec-plans/`](exec-plans/) first** for Markdown files that describe *this* task.
+
+1. **Search** `exec-plans/` for a file whose name or title matches the assignment (or open the path your human referenced).
+2. **Follow** the plan’s steps, constraints, and **definition of done**; treat that doc as authoritative for scope unless the user overrides it in chat.
+3. **Cross-check** with [`agent_resources/`](agent_resources/) for system context (architecture, product rules, API lookups)—exec plans are *task* detail; agent resources are *system* reference.
+4. **Major structural work** may still require a [design doc](#major-changes-design-doc-first) in `agent_resources/design-docs/` before coding; the exec plan should say so if applicable.
+
+If `exec-plans/` has no file for your task, proceed from the user’s instructions and the main docs in `agent_resources/`.
+
+Convention and layout: [exec-plans/README.md](exec-plans/README.md).
+
+---
+
+## Run the app
+
+| Path | Command | Notes |
+|------|---------|--------|
+| **Backend (local)** | `cd backend && python3 -m venv venv && source venv/bin/activate && pip install -r requirements.txt && python3 main.py` | API + docs: `http://localhost:8000` (`/docs`). Copy `backend/.env.example` → `backend/.env`. |
+| **Frontend (local)** | `cd frontend && npm install && npm run dev` | Dev server (Vite; default port per Vite, often `5173`). Copy `frontend/.env` if your team uses one. |
+| **Docker (repo Makefile)** | `make up` | Intended: backend `:8000`, frontend `:3000` per [README.md](README.md). Requires working `docker-compose` setup. |
+
+---
+
+## Tests, lint, typecheck
+
+| What | Where | Command |
+|------|--------|---------|
+| **Backend tests** | `backend/` | `python -m pytest tests -v` (use env vars like CI: `JWT_SECRET`, `DB_CONNECTION_STRING`, `ALLOWED_ORIGINS` — see [.github/workflows/run-tests.yml](.github/workflows/run-tests.yml)) |
+| **Frontend lint** | `frontend/` | `npm run lint` |
+| **Frontend build** | `frontend/` | `npm run build` (also exercised in CI) |
+| **Frontend typecheck** | `frontend/` | `npx tsc --noEmit` (no dedicated npm script today) |
+
+Root `package.json` has no real test script; **CI** is the source of truth: `.github/workflows/run-tests.yml`, `lint.yaml`, `frontend-build.yaml`, `backend-build.yaml`.
+
+---
+
+## Directories (ownership)
+
+| Area | Role |
+|------|------|
+| `agent_resources/` | Agent-oriented docs and assets (not application runtime code). |
+| `agent_resources/design-docs/` | Design write-ups for **major** changes; create **before** implementation. |
+| `exec-plans/` | **Task-level** plans: steps, acceptance criteria; agents read these when completing assigned work. |
+| `frontend/` | Vite + React UI (`src/`), Tailwind, client API usage. |
+| `backend/` | FastAPI app: `main.py`, `routes/`, `services/`, `workers/`, `models/`, `crud/`, `schemas/`, `tests/`, `scripts/`. |
+| `.github/workflows/` | PR checks (pytest, ESLint, builds). |
+| `Makefile`, `docker-compose.yml` | Local orchestration helpers. |
+| `render.yaml` | Deployment wiring for the API (treat as infra). |
+
+---
+
+## Do not touch casually
+
+- **`backend/.env`, `frontend/.env`, secrets, API keys** — never commit; mirror `backend/.env.example` patterns.
+- **`backend/main.py` lifespan / background tasks** — affects pollers and process-wide behavior; coordinate before changing.
+- **Auth (`routes/auth.py`, JWT dependencies, `dependencies.py`)** — security-sensitive; require tests and review.
+- **`render.yaml` / production URLs** — infra; avoid drive-by edits.
+- **Database URL / Azure / blob config** — breaking changes affect all environments.
+
+---
+
+## Major changes (design doc first)
+
+**Agents and contributors:** for **major** work (new features, cross-cutting refactors, auth/schema/job pipeline changes, new integrations), **do not start implementation** until a design doc exists in [`agent_resources/design-docs/`](agent_resources/design-docs/).
+
+1. **Read** any matching file in [`exec-plans/`](exec-plans/) for this work, plus [agent_resources/ARCHITECTURE.md](agent_resources/ARCHITECTURE.md), [PRODUCT.md](agent_resources/PRODUCT.md), and the relevant [BACKEND.md](agent_resources/BACKEND.md) / [FRONTEND.md](agent_resources/FRONTEND.md) sections so the design matches house patterns.
+2. **Add** a new Markdown file under `agent_resources/design-docs/` (naming and outline: [design-docs/README.md](agent_resources/design-docs/README.md)).
+3. **Cover** problem, goals/non-goals, proposed behavior, API/DB impacts, alternatives, rollout, and test plan.
+4. **Pause** for human review or explicit approval when the project workflow requires it (see [CLAUDE.md](CLAUDE.md) for review-heavy work).
+5. **Implement** in code, then update the design doc or PR with what actually shipped.
+
+Small, low-risk edits can skip this folder.
+
+---
+
+## Making changes safely
+
+1. Scope small PRs; match existing patterns in the package you edit (`frontend` vs `backend`).
+2. Run **backend pytest** and **frontend lint + build** (and `tsc --noEmit` for TS changes).
+3. Add or update **tests** for backend logic (`backend/tests/`); keep CI green.
+4. For API or schema changes, update **FastAPI routes + Pydantic schemas** together and check callers.
+
+---
+
+## Deeper documentation
+
+| Doc | Contents |
+|-----|----------|
+| [README.md](README.md) | Product overview, architecture, Docker/Make quick start, tech stack. |
+| [agent_resources/ARCHITECTURE.md](agent_resources/ARCHITECTURE.md) | System shape, data flows, deployment. |
+| [agent_resources/PRODUCT.md](agent_resources/PRODUCT.md) | Product behavior, journeys, domain terms. |
+| [agent_resources/BACKEND.md](agent_resources/BACKEND.md) | FastAPI layers, auth, jobs, API conventions. |
+| [agent_resources/FRONTEND.md](agent_resources/FRONTEND.md) | Vite/React structure, state, styling, pitfalls. |
+| [agent_resources/TESTING.md](agent_resources/TESTING.md) | Test pyramid, pytest, CI, fixtures. |
+| [agent_resources/references/](agent_resources/references/) | Lookup tables (API, env, routes, DB, CI). |
+| [agent_resources/design-docs/](agent_resources/design-docs/) | Design docs for major changes (before implementation). |
+| [exec-plans/](exec-plans/) | Task execution plans (read before implementing assigned work). |
+| [backend/README.md](backend/README.md) | Backend runbook, ports, worker route prefixes. |
+| [frontend/README.md](frontend/README.md) | Vite-oriented notes (may be generic template text). |
+| [CLAUDE.md](CLAUDE.md) | AI/review workflow expectations for large changes. |

--- a/agent_resources/ARCHITECTURE.md
+++ b/agent_resources/ARCHITECTURE.md
@@ -48,7 +48,7 @@ flowchart LR
 - **`frontend/`** — SPA (Vite + React). Calls the FastAPI backend for auth, resources, and chat-style features.
 - **`backend/`** — One **FastAPI** application (`main.py`) that exposes:
   - **Resource APIs** under paths like `/auth`, `/campaigns`, `/ad-jobs`, `/consumers`, `/personas`, `/products`, `/chat/...`, etc.
-  - **Lightweight worker HTTP stubs** (e.g. `/ad-job-worker`, `/ad-post-worker`) used as service boundaries / health-style endpoints; heavy work is not necessarily isolated in separate processes here.
+  - **Worker HTTP routes** under `/ad-job-worker` and `/ad-post-worker`: includes **hello-style** endpoints and **generation triggers** (e.g. **`POST /ad-job-worker/run-ad-job`** runs the full pipeline **in-process**, not a separate worker service). Heavy work is still **not** isolated in another deployable here.
 - **In-process orchestration** — On startup, the app starts an **asyncio background poller** (`services/ad_job_poller`) that watches the database for **pending ad jobs**, claims them, and runs **`execute_ad_job`** in `workers/ad_job_worker` (script → moderation → video → blob upload).
 
 There is **no separate message broker** (e.g. Redis/RabbitMQ) in the current dependency set: **the SQL `ad_jobs` table is the queue**, with **row-level locking** (`locked_at` / `locked_by`) so multiple API instances can poll safely.
@@ -59,7 +59,7 @@ There is **no separate message broker** (e.g. Redis/RabbitMQ) in the current dep
 
 ### 1. Interactive dashboard and CRUD
 
-Browser → **FastAPI routes** (`routes/*`) → **SQLAlchemy** sessions (`get_db`) → **CRUD** + **Pydantic schemas** → JSON responses. Authenticated routes use **`JWT_SECRET`**-signed bearer tokens (`dependencies.py`).
+Browser → **FastAPI routes** (`routes/*`) → **SQLAlchemy** sessions (`get_db`) → **CRUD** + **Pydantic schemas** → JSON responses. Routes that use **`get_current_client_id`** validate **`JWT_SECRET`**-signed bearer tokens (`dependencies.py`). **Not every resource route is JWT-scoped today** (e.g. parts of **`/campaigns`**); see [BACKEND.md](./BACKEND.md).
 
 ### 2. Product images
 

--- a/agent_resources/ARCHITECTURE.md
+++ b/agent_resources/ARCHITECTURE.md
@@ -1,0 +1,148 @@
+# Architecture (high level)
+
+This document answers: **“How is this system put together?”** It reflects the **code in this repository** today. The [root README](../README.md) also describes a **broader multi-service vision** (Node gateways, Celery, separate analytics, etc.); those pieces are not all present as separate deployables in this repo yet—see [README vs this repo](#readme-vs-this-repo) below.
+
+---
+
+## What the system does overall
+
+**Adgentic AI** helps business users **create, manage, and iterate on social-style video ads**: campaigns and products are stored in a database, **consumer personas** and traits drive targeting, and a pipeline **generates scripts, moderates them, renders short video**, and **stores assets** for the UI to show. Auth is JWT-based; the dashboard talks to one HTTP API.
+
+---
+
+## Major components and how they interact
+
+```mermaid
+flowchart LR
+  subgraph client [Client]
+    UI[Frontend - Vite React]
+  end
+
+  subgraph api [Backend - FastAPI single process]
+    HTTP[REST routes - auth CRUD chat]
+    POLL[Ad job poller - asyncio loop]
+    W[In-process workers - script mod video]
+  end
+
+  subgraph data [Data and assets]
+    DB[(SQL database - SQLAlchemy)]
+    BLOB[Azure Blob Storage]
+  end
+
+  subgraph ext [External APIs]
+    OAI[OpenAI-compatible APIs]
+    XAI[xAI - script generation]
+  end
+
+  UI -->|HTTPS JSON JWT| HTTP
+  HTTP --> DB
+  HTTP --> BLOB
+  POLL --> DB
+  POLL --> W
+  W --> DB
+  W --> BLOB
+  W --> OAI
+  W --> XAI
+```
+
+- **`frontend/`** — SPA (Vite + React). Calls the FastAPI backend for auth, resources, and chat-style features.
+- **`backend/`** — One **FastAPI** application (`main.py`) that exposes:
+  - **Resource APIs** under paths like `/auth`, `/campaigns`, `/ad-jobs`, `/consumers`, `/personas`, `/products`, `/chat/...`, etc.
+  - **Lightweight worker HTTP stubs** (e.g. `/ad-job-worker`, `/ad-post-worker`) used as service boundaries / health-style endpoints; heavy work is not necessarily isolated in separate processes here.
+- **In-process orchestration** — On startup, the app starts an **asyncio background poller** (`services/ad_job_poller`) that watches the database for **pending ad jobs**, claims them, and runs **`execute_ad_job`** in `workers/ad_job_worker` (script → moderation → video → blob upload).
+
+There is **no separate message broker** (e.g. Redis/RabbitMQ) in the current dependency set: **the SQL `ad_jobs` table is the queue**, with **row-level locking** (`locked_at` / `locked_by`) so multiple API instances can poll safely.
+
+---
+
+## Major data flows
+
+### 1. Interactive dashboard and CRUD
+
+Browser → **FastAPI routes** (`routes/*`) → **SQLAlchemy** sessions (`get_db`) → **CRUD** + **Pydantic schemas** → JSON responses. Authenticated routes use **`JWT_SECRET`**-signed bearer tokens (`dependencies.py`).
+
+### 2. Product images
+
+Uploads flow through **`routes/product.py`**: files land in Azure Blob (**`product-images`** container). Ad generation later **downloads** the same blob by `image_name` when building a variant.
+
+### 3. Persona / consumer enrichment
+
+Operations such as persona assignment use **`get_openai_client()`** and **`services/consumer_persona_processor`** / **`services/persona_assignment`** — LLM calls over **OpenAI’s client**, backed by **`OPENAI_API_KEY`** (see `core/openai_client.py` and consumers route).
+
+### 4. Ad generation pipeline (async, DB-driven)
+
+1. Something (e.g. campaign flow) creates **`ad_job` rows** and an **`ad_job_batch`** with JSON **`input_json`** (campaign / product / consumer / version).
+2. The **poller** picks pending jobs, **claims** one atomically, and runs **`execute_ad_job`**:
+   - Creates / updates **`ad_variant`** rows (status, `meta`, `media_url`).
+   - Loads campaign, consumer traits, product; **downloads product image** from Blob.
+   - **`generate_ad_script`** — uses **xAI SDK** (`xai_sdk`) and env such as **`SCRIPT_*`** (see `workers/script_creation_worker`).
+   - **`evaluate_script`** — moderation pass via an **OpenAI-compatible** client (`workers/script_moderation_worker`).
+   - **`generate_ad_video`** — **OpenAI video API** (`AsyncOpenAI` + **`VIDEO_API_KEY`**), polls until complete.
+   - Uploads MP4 to **`ad-videos`** container; stores URL on the variant.
+
+Failures are recorded on the variant **`meta`** (e.g. error trace) and statuses move to **`failed`** where applicable.
+
+---
+
+## Key services, storage, and integrations
+
+| Kind | Implementation in repo |
+|------|-------------------------|
+| **HTTP API** | FastAPI `main.py`, routers under `backend/routes/`, workers’ `service.py` routers |
+| **Background jobs** | `services/ad_job_poller/service.py` + `workers/ad_job_worker/` (no Celery worker process in tree) |
+| **Database** | SQLAlchemy; URL from **`DB_CONNECTION_STRING`** / **`DB_PASSWORD`**, or **Azure AD** path via **`USE_AZURE_AD`** + **`DB_ODBC_CONNECTION_STRING`** (`database.py`) |
+| **Blob storage** | **Azure Storage** — **`AZURE_STORAGE_CONNECTION_STRING`**; containers e.g. **`product-images`**, **`ad-videos`** |
+| **Caches** | None required for core flow; clients may be cached in-process (e.g. OpenAI client LRU) |
+| **Queues** | **Database** (`ad_jobs` + locks), not a separate queue service |
+| **LLM / media APIs** | **OpenAI** (chat, video, some moderation paths), **xAI** (script generation SDK), env-driven keys/URLs (`backend/.env.example`) |
+
+---
+
+## Deployment shape (high level)
+
+- **API** — [Render](https://render.com) **Docker web service** defined in [`render.yaml`](../render.yaml): build context is **`backend/`**, typical branch **`main`**.
+- **Local / team** — [`docker-compose.yml`](../docker-compose.yml) and [`Makefile`](../Makefile) describe bringing up backend/frontend together; exact container layout may drift from local `npm run dev` + `python main.py`.
+- **Frontend** — Built as a **Vite** app (`frontend/`); CI runs **`npm run build`**. Production hosting for the static/SSR asset is not fully described in `render.yaml` in this snippet—confirm with team docs or infra.
+
+---
+
+## Important constraints and invariants
+
+1. **`ALLOWED_ORIGINS`** must be set at process start (CORS middleware reads it eagerly).
+2. **`JWT_SECRET`** must be set for any JWT issuance or verification path.
+3. **Ad jobs** rely on **atomic claims** in the DB; do not remove locking without a replacement concurrency story.
+4. **One poller task per process** is started in **`main.py` lifespan**; horizontal scaling adds more processes, each with its own poller—safe **if** DB claiming stays atomic.
+5. **Script → video** coupling: the script format is **contractual** for the video generator (structured beats/time ranges); changing prompts or format requires **end-to-end** checks.
+6. **Azure** is assumed for **blob** paths used in production flows; local/dev may mock or skip some integrations (tests use SQLite and env stubs per CI).
+
+---
+
+## README vs this repo
+
+The [root README](../README.md) lists **Node API gateways**, **Celery**, **multiple Python services**, **Next.js** frontends, etc. In **this repository as checked in**, the main application surface is:
+
+- **Python FastAPI** backend (single service entrypoint),
+- **Vite + React** frontend,
+
+with **DB-backed job processing** instead of a visible Celery deployment in code. Treat the README as **product + target architecture**; treat this file + `backend/main.py` as **what runs today**.
+
+---
+
+## Links to deeper docs
+
+| Document | Use |
+|----------|-----|
+| [AGENTS.md](../AGENTS.md) | How to run, test, lint, directory map, safety |
+| [PRODUCT.md](./PRODUCT.md) | Product behavior and business rules |
+| [BACKEND.md](./BACKEND.md) | Backend layers, auth, jobs, API conventions |
+| [FRONTEND.md](./FRONTEND.md) | Frontend structure and house style |
+| [TESTING.md](./TESTING.md) | How to validate changes |
+| [references/](./references/) | Lookup: API paths, env vars, routes, tables, CI |
+| [design-docs/](./design-docs/) | Design write-ups for major changes (before implementation) |
+| [README.md](../README.md) | Product narrative, diagram, setup, Docker/Make |
+| [backend/README.md](../backend/README.md) | Backend ports, worker route prefixes, local run |
+| [CLAUDE.md](../CLAUDE.md) | Review workflow for large or risky changes |
+| [backend/main.py](../backend/main.py) | Authoritative router list and lifespan (poller) |
+| [backend/.env.example](../backend/.env.example) | Required env vars for integrations |
+
+Further notes live under [`agent_resources/`](./) (this folder).

--- a/agent_resources/BACKEND.md
+++ b/agent_resources/BACKEND.md
@@ -1,0 +1,167 @@
+# Backend guide
+
+This document answers: **“How do I change backend behavior without breaking structure?”** It describes the **FastAPI** app under **`backend/`** as implemented today.
+
+---
+
+## Service structure (physical layout)
+
+The backend is a **single deployable** (one `main.py`, one uvicorn process) with **modular packages**:
+
+| Area | Responsibility |
+|------|----------------|
+| **`main.py`** | App factory: middleware, **router includes**, **`lifespan`** (starts background poller). |
+| **`routes/`** | HTTP API: path handlers, `Depends`, map to `crud` and/or `services`. |
+| **`services/`** | Domain orchestration **without** owning HTTP: chat AI, persona processing, ad job **poller**, stubs (e.g. scheduler placeholder). |
+| **`crud/`** | Persistence helpers: SQLAlchemy **`Session`** in, ORM out; **commit/refresh** patterns. |
+| **`models/`** | SQLAlchemy ORM (`DeclarativeBase`), `dbo` schema, table definitions. |
+| **`schemas/`** | Pydantic v2 models: request bodies, responses (`model_config = {"from_attributes": True}` where needed). |
+| **`workers/`** | **Pipelines** and optional **HTTP sub-routers**: `worker.py` (core logic), `service.py` (FastAPI `APIRouter` for worker endpoints). |
+| **`core/`** | Shared infrastructure clients (e.g. **`get_openai_client`**). |
+| **`database.py`** | Engine/session factory, **`get_db`** dependency, Azure AD vs URL auth. |
+| **`dependencies.py`** | **`get_current_client_id`** (JWT bearer). |
+| **`scripts/`** | One-off maintenance (seeding, vectors)—not part of request path. |
+| **`tests/`** | **`pytest`**, `conftest` fixtures. |
+
+**Naming rule of thumb:** If it **`await`**s LLMs, runs long loops, or coordinates multiple CRUD calls for one use case, put it in **`services/`** or **`workers/`**. If it is mostly **`select` / `insert` / `update`**, put it in **`crud/`**.
+
+---
+
+## Request lifecycle
+
+1. **Uvicorn** dispatches to FastAPI.
+2. **CORS** runs first (`ALLOWED_ORIGINS` read at import time from **`os.environ`**—must be set).
+3. **Router** matches path (prefixes set in `main.py`, e.g. `/auth`, `/campaigns`, `/consumers`).
+4. **Dependencies:**
+   - **`get_db`**: opens a **`Session`**, **`yield`**, **`close`** in `finally`.
+   - **`get_current_client_id`**: validates **`Authorization: Bearer`**, decodes JWT (`JWT_SECRET`, HS256), returns **`int`** client id or **401**.
+5. Handler runs: validates with **`schemas`**, calls **`crud`** / **`services`**.
+6. Response: Pydantic **`response_model`** or plain dict; **`HTTPException`** becomes JSON error with **`detail`**.
+
+**Background work:** The **`lifespan`** context starts **`run_poller()`** as an **`asyncio` task**; it is **not** tied to a single HTTP request.
+
+---
+
+## Domain / service / “repository” boundaries
+
+| Layer | Should | Should not |
+|--------|--------|------------|
+| **`routes/`** | Parse HTTP, auth dependency, status codes, call one orchestration entry. | Embed SQL or multi-step business rules inline (keep thin). |
+| **`services/`** | Coordinate CRUD + external APIs; reusable across routes/poller. | Duplicate CRUD that belongs in **`crud/`**. |
+| **`crud/`** | Encapsulate queries and transactions for one aggregate/table family. | Call HTTP or LLM clients directly (keep side effects in services/workers). |
+| **`workers/`** | End-to-end side-effect pipelines (generate script → moderate → video → blob). | Register routes here **except** via each worker’s **`service.py`** router included from `main` or mounted pattern. |
+| **`schemas/`** | I/O shapes, field constraints (`Field(max_length=…)`). | Import ORM models as types for DB writes (use **`model_dump()`** at boundary). |
+
+**Crossing boundaries:** Pass **IDs and plain dicts/dataclasses** between layers; avoid leaking **`Session`** outside `crud`/`routes`/services that are designed to manage it.
+
+---
+
+## DB access patterns
+
+- **Engine:** Created lazily in **`database.py`** (`_get_engine` / `_get_session_factory`) so imports work in CI without DB.
+- **SQL Server:** Models use **`schema="dbo"`**; some columns use **`UNIQUEIDENTIFIER`** for UUIDs (jobs/batches).
+- **Session per request:** **`get_db`** yields one **`Session`**; routes/services should **not** share sessions across threads.
+- **CRUD style:** `db.add` → `commit` → `refresh` on create; `db.get` / `select` + `scalars` for reads; **`model_dump(exclude_unset=True)`** for patches.
+- **Auth-aware queries:** Prefer **`crud`** functions that take **`client_id`** (e.g. **`get_consumers(db, client_id=…)`**) and use **`filter_owned_consumer_ids`** where bulk operations must be scoped.
+
+**Lazy engine caveat:** First DB use may fail fast with a clear error if **`DB_CONNECTION_STRING`** (or Azure AD env) is missing.
+
+---
+
+## Background jobs
+
+| Mechanism | Behavior |
+|-----------|----------|
+| **Ad job poller** | **`services/ad_job_poller/service.py`**: infinite loop (cancellable), **`AD_JOB_POLL_INTERVAL_SECONDS`**, loads pending **`ad_jobs`**, **`claim_ad_job`**, **`await execute_ad_job`**, updates job + **`increment_ad_job_batch_progress`**. |
+| **Enqueue** | **`workers/ad_job_worker/worker.py`** — **`generate_campaign_ad_variants`** creates batch + rows; HTTP **`POST .../generate-campaign-ad-variants`** triggers enqueue. |
+| **Synchronous run** | **`POST /ad-job-worker/run-ad-job`** runs **`execute_ad_job`** in-process without queue (for ops/debug). |
+
+There is **no Celery/Redis** queue in this repo: **the database is the queue**.
+
+---
+
+## External integrations
+
+| Integration | Where | Config (typical) |
+|-------------|--------|------------------|
+| **Azure Blob** | Product images, ad videos, SAS helpers in routes | **`AZURE_STORAGE_CONNECTION_STRING`** |
+| **Azure SQL / ODBC** | **`database.py`** | **`DB_CONNECTION_STRING`**, **`DB_PASSWORD`**, or **`USE_AZURE_AD`** + **`DB_ODBC_CONNECTION_STRING`** |
+| **OpenAI-compatible** | Chat, moderation, video worker, shared **`AsyncOpenAI`** | **`OPENAI_API_KEY`**, **`SCRIPT_*`**, **`VIDEO_API_KEY`** |
+| **xAI SDK** | Script creation | **`xai_sdk`** + env used in **`script_creation_worker`** |
+
+Client singletons: **`get_openai_client`** is **`lru_cache`**’d; tests can **`cache_clear()`**.
+
+---
+
+## Auth / authz model
+
+- **Authentication:** **JWT** in **`dependencies.py`**: Bearer token, **`sub`** = client id, **7-day** expiry from **`create_access_token`** (`routes/auth.py`).
+- **Signup/signin:** **`passlib`** bcrypt; tokens returned to client.
+- **Authorization:** **Inconsistent by module**—treat this as a **known structural gap**:
+  - **Strong:** **`consumers`**, **`products`**, **`chat_*`**, **`personas`** list (JWT required; consumers/products scoped by **`client_id`**).
+  - **Weak:** **`campaigns`** CRUD uses **`business_client_id` query param** on list and **no JWT** on several endpoints—**any caller who knows an id can read/update** unless network layer restricts access. **New work** should align campaigns (and similar) with **`get_current_client_id`** and **ownership checks** in **`crud`** or route.
+
+**Pattern to move toward:** **`client_id: int = Depends(get_current_client_id)`** + **`crud`** functions that enforce **`Model.business_client_id == client_id`** on every read/write.
+
+---
+
+## Validation and error handling
+
+- **Input:** **Pydantic** schemas on route bodies; FastAPI returns **422** on validation failure.
+- **App errors:** Raise **`HTTPException(status_code=…, detail=…)`** with **string** or structured **`detail`** (FastAPI serializes).
+- **DB integrity:** e.g. **`IntegrityError`** in **`consumers`** CSV path—catch and map to a **409** or clear message.
+- **Workers/poller:** **`execute_ad_job`** catches exceptions, sets **`ad_variant`** to **`failed`** with traceback in **`meta`**, re-raises; poller marks **`ad_job`** failed and increments batch **`failed_jobs`**. Invalid **`input_json`** → job **failed** without bumping **`attempt_count`** (parse before claim).
+
+There is **no** global exception handler in `main.py` for logging/masking—**add carefully** if you introduce one (preserve **`HTTPException`** behavior).
+
+---
+
+## API conventions
+
+- **Prefixes:** Set in **`main.py`** (`/auth`, `/campaigns`, …). **OpenAPI** at **`/docs`**.
+- **REST style:** **GET list/detail**, **POST create**, **PUT update**, **DELETE** with **204** where appropriate.
+- **Worker routes:** Under **`/ad-job-worker`**, **`/ad-post-worker`** (hello + generation endpoints).
+- **Response models:** Prefer **`response_model=…`** for stable JSON shapes.
+- **Query params:** Filtering/skip/limit on list endpoints; some use **optional** `status`, **`batch_id`**, **`is_preview`** (variants).
+
+When adding endpoints: **register router in `main.py`**, add **`tags`**, and mirror **frontend `api/*.ts`** paths (`/api` strip in Vite proxy).
+
+---
+
+## Migration rules
+
+- **No Alembic (or other) migration package** is checked in under **`backend/`**. Schema is assumed to match **`models/`** (likely applied manually or via external tooling).
+- **Rules until migrations exist:**
+  1. **Any new column/table** → update **`models/`** + coordinate **DB change** in the shared environment (script or DBA).
+  2. **Do not** change **`models/`** in ways that **drift** from production without a **deploy order** (migration first, then code, or feature flags).
+  3. Prefer **nullable new columns** or **defaults** for zero-downtime rollouts.
+  4. If you introduce **Alembic**, add it under **`backend/`**, document **`alembic upgrade head`** in [AGENTS.md](../AGENTS.md), and treat revisions as **required** for schema changes.
+
+---
+
+## Idempotency and concurrency
+
+| Concern | Current behavior |
+|---------|------------------|
+| **Ad job claiming** | **`claim_ad_job`** uses **`UPDATE … WHERE locked_at IS NULL AND status = 'pending'`** and increments **`attempt_count`**—**one winner** per claim. |
+| **Poller concurrency** | Multiple processes = multiple pollers; **safe** if DB supports the atomic update (SQL Server does). |
+| **Retries** | **`get_pending_ad_jobs`** excludes rows with **`attempt_count >= max_attempts`** (env **`AD_JOB_MAX_ATTEMPTS`**, default **3**). |
+| **Lock release** | **`release_job_lock`** can return job to **`pending`** for retry (optional **`worker_id`** check). |
+| **Batch idempotency** | **`ad_job_batches.idempotency_key`** exists in schema but **`generate_campaign_ad_variants`** passes **`None`** today—**not enforced**; duplicate enqueue calls can create **duplicate batches**. |
+| **Variant uniqueness** | Batch generation **skips** consumers who already have a variant for **(campaign, version)**; races could still double-create if two enqueues run **before** variants exist—mitigate with **transaction** or **unique constraint** if product requires hard guarantees. |
+
+**Safe change checklist for jobs:** touch **`crud/ad_job.py`**, **`ad_job_poller`**, and **`workers/ad_job_worker`** together; add **`tests/test_ad_job_poller.py`** / **`test_ad_job_crud.py`** scenarios.
+
+---
+
+## Related docs
+
+| Doc | Purpose |
+|-----|---------|
+| [ARCHITECTURE.md](./ARCHITECTURE.md) | System-wide data flow and deployment. |
+| [PRODUCT.md](./PRODUCT.md) | Business behavior the backend should implement. |
+| [TESTING.md](./TESTING.md) | pytest, fixtures, CI workflows. |
+| [references/](./references/) | HTTP paths, env vars, tables (lookup). |
+| [design-docs/](./design-docs/) | Major changes: write design here before coding. |
+| [backend/README.md](../backend/README.md) | Runbook, ports, worker prefixes. |
+| [AGENTS.md](../AGENTS.md) | How to run the repo and CI summary. |

--- a/agent_resources/FRONTEND.md
+++ b/agent_resources/FRONTEND.md
@@ -1,0 +1,164 @@
+# Frontend guide
+
+This document answers: **“How do I make frontend changes in the house style?”** It describes the **`frontend/`** Vite + React app as implemented today.
+
+---
+
+## Framework and app structure
+
+| Piece | Choice |
+|--------|--------|
+| **Bundler / dev** | [Vite](https://vitejs.dev/) 5 (`npm run dev`, `npm run build`) |
+| **UI library** | React 18 |
+| **Language** | TypeScript (`strict` in `tsconfig.json`; `src/` only) |
+| **Entry** | `index.html` → `src/index.tsx` → `src/App.tsx` |
+
+**`src/` layout (mental model)**
+
+| Path | Purpose |
+|------|---------|
+| `pages/` | Route-level screens (compose layout + data hooks). |
+| `components/layout/` | App chrome (e.g. `Sidebar`). |
+| `components/ui/` | Reusable primitives (`Button`, `Input`, `Card`, `Select`, …). |
+| `components/campaigns/` | Campaign-specific UI (tables, modals, analytics). |
+| `components/generate/` | Generate / chat / variants experience; `index.ts` re-exports. |
+| `api/` | Plain `fetch` wrappers — **no data caching here**. |
+| `hooks/` | TanStack Query hooks (`use*`) + small UI hooks (`useFilterState`, `useResizablePanel`). |
+| `contexts/` | React context providers (user, company shell, consumers, personas, sidebar, theme). |
+| `types/` | Shared TS types aligned with API payloads. |
+| `utils/` | Cross-cutting helpers (e.g. `auth.ts`). |
+
+**Dependency note:** `@emotion/react` is listed in `package.json` but **not used** in `src/` today; prefer **Tailwind** for styling unless you intentionally introduce Emotion.
+
+---
+
+## Routing structure
+
+- **Router:** `react-router-dom` **`HashRouter`** (URLs look like `/#/dashboard`, not `/dashboard`). This avoids server rewrite configuration for SPAs but changes deep-linking and analytics expectations.
+- **Scroll restoration:** `ScrollToTop` in `App.tsx` scrolls to `(0,0)` on pathname change.
+- **Route table:** All routes are declared in **`src/App.tsx`** (`<Routes>` / `<Route>`). Add new pages there and place the component under `pages/`.
+
+**Main paths (non-exhaustive):** `/` (landing), `/sign-in`, `/sign-up`, `/onboarding`, `/dashboard`, `/workspace`, `/campaigns`, `/campaign/:id`, `/generate`, `/products`, `/customer-data`, `/all-consumers`, `/settings`, `/profile`, marketing pages (`/features`, `/pricing`, …).
+
+---
+
+## State management
+
+| Layer | Use for |
+|--------|---------|
+| **TanStack React Query v5** | **Server state**: fetching, caching, mutations, invalidation, polling (`refetchInterval`). Default `QueryClient` is created inline in `App.tsx` (no custom defaults file yet). |
+| **React Context** | **Auth-derived and UI shell state**: `UserProvider` (profile from API), `CompanyProvider` (derived “company profile” + local overrides), `ConsumerProvider`, `PersonasProvider`, `SidebarProvider`, `ThemeProvider` (`light` / `dark`). |
+| **Local `useState` / `useRef`** | Form fields, modals, combobox open state, panel sizing — keep **close to the component** unless reused. |
+
+**Conventions**
+
+- Export **stable query keys** from hooks (e.g. `CAMPAIGNS_KEY`, `PROFILE_KEY`, `AD_VARIANTS_KEY`) and reuse them in `invalidateQueries`.
+- Use `enabled: !!id` (or similar) so queries **do not fire** until required IDs exist.
+- After mutations, **`invalidateQueries`** for every list/detail that should refresh (house style today; optimistic updates are rare).
+
+---
+
+## Data-fetching patterns
+
+1. **`src/api/config.ts`** — `API_BASE_URL` is **`/api`** when **`isLocal`** is true (`VITE_ENV` unset or **`local`** per `ENV || 'local'`), otherwise **`VITE_API_URL`** (or `/api` fallback). **`apiUrl(path)`** prefixes paths. **`authHeaders()`** adds `Authorization: Bearer …` from `localStorage` and optional `Content-Type: application/json`.
+2. **Vite proxy** — `vite.config.ts` proxies **`/api` → backend** (`VITE_API_URL` or `http://localhost:8000`), rewriting `/api` off the path so FastAPI sees `/campaigns`, `/auth`, etc.
+3. **`src/api/*.ts`** — One module per domain (`auth`, `campaigns`, `products`, …). Functions **`throw Error`** with message from `body.detail` when `!res.ok`.
+4. **`src/hooks/use*.ts`** — Wrap API calls with **`useQuery` / `useMutation`**. Prefer **`isLoading` / `isPending` / `isError` / `error`** from React Query in UI instead of re-implementing loading flags.
+
+**Auth session:** `storeSession` / `clearSession` in `api/auth.ts` use **`localStorage`** keys (`adgentic_token`, etc.). `useProfile` is **disabled** when there is no token (`enabled: !!getToken()`).
+
+---
+
+## Component conventions
+
+- **Pages** own routing concerns and **compose** sections; they should stay **thin** — delegate lists and forms to `components/*`.
+- **Icons:** **`lucide-react`** (e.g. `Loader2Icon` for spinners).
+- **Primitives:** Prefer **`components/ui/*`** (`Button` supports `isLoading`, `variant`, `size`, focus ring classes) before adding one-off `<button>` styles.
+- **Barrel files:** `components/generate/index.ts` re-exports; follow the same pattern when a folder grows many entry points.
+- **Exports:** Context hook + provider live in the same file; **`react-refresh/only-export-components`** may require an eslint disable when exporting both (see `UserContext.tsx`).
+
+---
+
+## Styling system
+
+- **Tailwind CSS 3** with **`tailwind.config.js`** mapping theme colors to **CSS variables** (`bg-background`, `text-foreground`, `border-border`, `text-muted-foreground`, etc.).
+- **`src/index.css`** defines `:root` and **`.dark`** token sets, font imports (**Inter**, **Playfair Display**), and global `html, body, #root` height/background.
+- **Dark mode:** `darkMode: 'class'`; **`ThemeProvider`** toggles `document.documentElement.classList` and persists **`localStorage`** key `theme`.
+- **Persona / marketing accents:** Extra variables (e.g. `--persona-accent`) for feature-specific theming.
+
+**House style:** Use **semantic Tailwind tokens** (`bg-card`, `border-border`) over raw hex in new code so light/dark stays coherent.
+
+---
+
+## Form handling
+
+There is **no** shared form library (no React Hook Form in dependencies). Typical pattern:
+
+- **Controlled inputs** with `useState` (and sometimes module-level **`inputClass` / `labelClass`** strings shared inside one file, e.g. `CreateCampaignModal.tsx`).
+- **Validation:** Inline checks before submit; surface errors via **local state** (`error`, `fieldErrors`) or **toast-less** message text (project-dependent).
+- **Submit:** Call **`useMutation`**’s `mutate` / `mutateAsync`; use mutation **`isPending`** to disable buttons and show **`Loader2Icon`**.
+- **Complex pickers:** Pattern of **ref + `mousedown` outside** to close dropdowns (see product selector in campaign modal).
+
+When adding a large form, consider introducing **React Hook Form** + **Zod** in a **single** feature first and document the pattern here — until then, match existing modals.
+
+---
+
+## Error and loading patterns
+
+| Situation | House approach |
+|-----------|----------------|
+| **Initial fetch** | `useQuery` → `isLoading`, `isError`, `error`; optional **`retry: false`** for auth (`useProfile`). |
+| **Mutations** | `isPending` / `isError` on `useMutation`; `Loader2Icon` + disabled controls. |
+| **API errors** | `fetch` helpers throw **`Error`**: in mutations, handle with **`onError`** or inline `try/catch` if using `mutateAsync`. |
+| **Long-running backend jobs** | `useCampaignAdVariants` / `usePreviewVariants` support **`refetchInterval`** to poll until variants reach a terminal status. |
+
+**`Button`:** Use **`isLoading`** prop for consistent disabled + spinner behavior.
+
+---
+
+## Accessibility expectations
+
+- **Partial today:** Many icon-only controls use **`aria-label`** (theme toggle, send message, close filters). Prefer **labels** or **`aria-label`** on any non-text control.
+- **Focus:** Shared `Button` uses **`focus:ring-2`** / **`focus:ring-offset-2`**; custom interactive divs should get **`tabIndex`**, **`onKeyDown`**, and visible focus if they behave like buttons.
+- **Language:** `index.html` sets **`<html lang="en">`**.
+- **New work:** Meet **WCAG contrast** using theme tokens; don’t rely on color alone for errors (add text); keep **heading order** sensible on marketing pages.
+
+---
+
+## Frontend testing strategy
+
+**Today:** `package.json` has **no** `test` script — CI runs **`npm run lint`** and **`npm run build`** only ([`.github/workflows/lint.yaml`](../.github/workflows/lint.yaml), [`frontend-build.yaml`](../.github/workflows/frontend-build.yaml)).
+
+**Recommended direction (not yet wired):**
+
+1. **Vitest** + **React Testing Library** for components and hooks (with **MSW** or mocked `fetch` for `api/*`).
+2. **One golden test** per critical flow (sign-in, create campaign, generate page happy path) before large refactors.
+3. Keep **`typecheck`** in habit: `npx tsc --noEmit` locally (see [AGENTS.md](../AGENTS.md)).
+
+Until tests exist, rely on **manual smoke** on `/#/…` routes and **lint + build** in CI.
+
+---
+
+## Common pitfalls
+
+1. **`HashRouter` URLs** — Links must use **`HashRouter`’s paths** (`/#/dashboard`). Plain `<a href="/dashboard">` can hit the server and404.
+2. **`VITE_ENV` and API base** — If `VITE_ENV` is not **`local`**, **`API_BASE_URL`** expects **`VITE_API_URL`**; misconfiguration causes silent wrong host or CORS issues.
+3. **Duplicated hook names** — `useUpdateCampaign` exists in both **`useCampaigns.ts`** and **`useAdGeneration.ts`** with different **`invalidateQueries`** behavior. Import from the **correct** module for your feature.
+4. **Query key drift** — Sub-keys (`status`, `isPreview`) change cache identity; after API changes, ensure **`invalidateQueries`** matches the keys your lists use.
+5. **Auth and `enabled`** — Queries that need auth should stay **`enabled: !!businessClientId`** (or similar) so they don’t 401 before profile loads.
+6. **`.next` in repo** — ESLint ignores **`.next`**; if present locally, it’s **not** the Vite app — don’t edit generated chunks.
+7. **SAS video URLs** — Backend may return **time-limited** URLs; UI should **refetch** variant data if playback expires (see [PRODUCT.md](./PRODUCT.md)).
+8. **Theme flash** — `ThemeProvider` reads `localStorage` in `useEffect`; expect a possible **first-paint** theme mismatch before hydration-style adjustment.
+
+---
+
+## Related docs
+
+| Doc | Purpose |
+|-----|---------|
+| [ARCHITECTURE.md](./ARCHITECTURE.md) | How frontend fits in the full system. |
+| [PRODUCT.md](./PRODUCT.md) | Product behavior the UI should reflect. |
+| [BACKEND.md](./BACKEND.md) | API and auth patterns the client calls. |
+| [TESTING.md](./TESTING.md) | Lint, build, and future frontend tests. |
+| [references/frontend.md](./references/frontend.md) | Hash routes, query keys, storage keys (lookup). |
+| [AGENTS.md](../AGENTS.md) | Commands: `npm run dev`, `lint`, `build`, `tsc`. |

--- a/agent_resources/PRODUCT.md
+++ b/agent_resources/PRODUCT.md
@@ -1,0 +1,111 @@
+# Product intent
+
+This document answers: **“What behavior is the code trying to implement?”** It is derived from models, routes, and worker logic in `backend/` (and the product description in the root [README](../README.md)). When this file disagrees with code, **the code wins** until the product spec is updated.
+
+---
+
+## Target users
+
+| Actor | Role in the system |
+|--------|---------------------|
+| **Business client** | Primary user: a business operator who signs up (`/auth/signup`), signs in, completes onboarding, and owns **campaigns**, **products**, and (indirectly) the ads produced for their audience. Represented by `business_clients` (email, business name, subscription tier, credits balance, optional Stripe placeholder). |
+| **End consumers (audience)** | People the business markets to. Stored as **`consumers`** with traits (JSON), optional persona assignment, and contact fields. They are **not** app logins here—they are **targets** for personalized ad variants. |
+| **Operators / admins** | Implied for moderation, monitoring, and infra; no separate admin product surface is spelled out in the models—**in-app “admin” is out of scope** unless the frontend adds it. |
+
+---
+
+## Core user journeys
+
+1. **Onboard and authenticate** — Register or sign in, receive a JWT, load profile (`/auth/me`), persist onboarding data (business traits / plan context as implemented in auth routes).
+2. **Define catalog and strategy** — Create **products** (with image in blob storage), **campaigns** (goals, audience, brief, dates, budget, linked product IDs), and maintain **personas** (marketing archetypes with motivators, pain points, tone).
+3. **Build audience data** — Create or import **consumers** (per `business_client_id`), optionally run **persona assignment** (LLM-assisted mapping to primary/secondary persona + confidence).
+4. **Explore creative (preview)** — Call **campaign preview** generation: sample up to **six** personas, pick one consumer per persona, generate **preview** ad variants (`is_preview=true`) so the business can see variety before a full rollout.
+5. **Produce at scale (batch)** — **Enqueue** one **ad job** per consumer who does **not** yet have an **ad variant** for this **campaign + version**. A background **poller** processes jobs **FIFO**, with **retries** capped by `AD_JOB_MAX_ATTEMPTS` (default 3).
+6. **Iterate on creative** — Use **version numbers** on variants and **per-version briefs** on campaigns so new creative generations can align to different brief slices.
+7. **Campaign assistant chat** — JWT-protected **chat completions**: user message is stored, history + context is sent to **Grok** (xAI-compatible client), assistant reply is stored; responses may include a structured **plan** when the assistant wraps JSON in a Markdown fenced `json` code block (see `detect_plan_in_response` in `services/chat_ai/service.py`).
+
+---
+
+## Major features
+
+| Feature | Intended behavior (from code) |
+|---------|----------------------------------|
+| **Campaigns** | CRUD by `business_client_id`; `brief` can hold **JSON** whose keys are **version numbers** (string or int) mapping to brief text for that creative version. |
+| **Products** | CRUD; images uploaded to Azure **`product-images`**; **`image_name`** is required for automated ad generation (worker loads blob by name). |
+| **Consumers** | CRUD; **unique (business_client_id, email)** when email is used; **traits** JSON drives script personalization; **persona** links for segmentation. |
+| **Personas** | Global persona library (UUID id, unique name); JSON lists for motivators, pain points, optional tone preferences. |
+| **Ad variants** | One row per **campaign × consumer × version** (enforced by generation logic + CRUD helpers); **status** lifecycle includes `Generating` → `completed` or `failed`; **`meta`** holds script JSON and errors; **`media_url`** points to rendered video in blob; **`is_preview`** separates samples from full rollout. |
+| **Ad jobs & batches** | **Batch** tracks `total_jobs`, `succeeded_jobs`, `failed_jobs`; each **job** carries **`input_json`** with `campaign_id`, `product_id`, `consumer_id`, `version_number` (defaults to **1** if missing). Poller **claims** jobs atomically (`locked_at` / `locked_by`), runs pipeline, updates job + batch counters. |
+| **Direct single-ad run** | HTTP **`POST /ad-job-worker/run-ad-job`** runs **`execute_ad_job`** **synchronously** (no batch row required)—useful for debugging or one-off runs. |
+| **Signed video URLs** | When Azure is configured, listing/reading ad variants can append a **time-limited SAS** (default **1 hour**) to **`media_url`** for **`ad-videos`** blobs only. |
+| **Script moderation** | After script generation, a **policy reviewer** LLM call must return JSON `passed` / `feedback`. If it **fails**, the system **regenerates the script once** using the feedback, then continues (no third automatic pass in code). |
+| **Video generation** | Short-form vertical video (**8s**, **720×1280**) from script + product image via the configured video API; output uploaded to **`ad-videos`**. |
+
+---
+
+## Important business rules
+
+1. **Tenant boundary** — Consumers belong to a **`business_client_id`**. Campaigns carry **`business_client_id`**. APIs should only expose data for the authenticated client where **`get_current_client_id`** or explicit filters are applied (verify each route when changing auth).
+2. **Uniqueness** — **One ad variant per (campaign, consumer, version)** for **batch** generation: `generate_campaign_ad_variants` **skips** consumers who already have a variant for that version.
+3. **Batch empty case** — If every consumer already has a variant, enqueue returns **`None`** and the API responds with **“No ad variants to generate”** (not an error).
+4. **Preview sampling** — Preview uses **`random.sample`** on **all personas** (up to 6) and **`random.choice`** among consumers per persona—**not deterministic** across calls.
+5. **Job ordering** — Pending jobs are processed **oldest first** (`created_at` ascending).
+6. **Failed jobs** — After **`MAX_ATTEMPTS`**, jobs stop being picked as **pending**; invalid **`input_json`** is marked **failed** **without** incrementing **`attempt_count`** (parse happens before claim).
+7. **Moderation** — Scripts must pass brand-safety norms suitable for **general-audience** social ads (see moderation prompt in `script_moderation_worker`).
+8. **Credits / billing** — `business_clients` has **`credits_balance`** and **`subscription_tier`**; **deduction rules are not centralized** in the snippets reviewed—treat billing as **product policy** to enforce consistently when implemented.
+
+---
+
+## Domain glossary
+
+| Term | Meaning |
+|------|---------|
+| **Business client** | The paying organization / account (login entity). |
+| **Campaign** | A marketing push with status, budget, dates, goal, audience, product context, and versioned **brief** text. |
+| **Product** | Something sold or promoted; must have a stored **image** for automated video generation. |
+| **Consumer** | A modeled audience member (traits + optional persona); receives **personalized** ad variants. |
+| **Persona** | A segment archetype (motivators, pain points, tones) used to cluster consumers and to **sample** previews. |
+| **Ad variant** | A concrete creative: script + video URL + status for one **campaign × consumer × version**; may be **preview** or production-scale output. |
+| **Version number** | Integer creative iteration key; selects **which brief slice** to use from `campaign.brief` JSON. |
+| **Ad job** | A unit of async work: inputs in JSON, status, attempts, optional lock fields, link to a **batch**. |
+| **Ad job batch** | Groups many jobs; tracks aggregate success/failure counts for progress UI or ops. |
+
+---
+
+## Correct behavior in ambiguous cases
+
+| Situation | Intended behavior |
+|-----------|-------------------|
+| **Brief missing or invalid JSON** | `_brief_for_version` returns **empty string**; generation still runs with **no** extra strategic brief (only other campaign fields passed where applicable). |
+| **Moderation fails first time** | **One** regeneration with **`moderation_feedback`**; if the second script is still bad, code **does not** loop again—downstream video may still run unless additional checks are added. |
+| **Product has no `image_name`** | **`execute_ad_job` raises** before generation; variant ends **`failed`** with error in **`meta`**. |
+| **Image download/resize fails** | Resize falls back to **original bytes**; other failures surface as **failed** variant. |
+| **Video job times out** | After **max poll attempts** (~10 minutes at 5s), raises **`RuntimeError`**; job marked failed, batch **failed** counter incremented. |
+| **Duplicate preview vs production** | **Preview** variants are **`is_preview=true`**; listing can filter them. Full batch jobs create **non-preview** variants by default (`execute_ad_job(..., is_preview=False)` from poller). |
+| **SAS not appended** | If **`AZURE_STORAGE_CONNECTION_STRING`** is unset, or URL is not a recognized **`ad-videos`** blob URL, API returns **raw `media_url`** (may be unusable without separate auth). |
+| **Chat without SCRIPT_API_KEY / SCRIPT_BASE_URL** | Service raises; endpoint should surface a **clear configuration error** to the client (translate in route if needed). |
+
+---
+
+## Edge cases users care about
+
+- **“How many previews will I get?”** — Up to **six**, and **fewer** if there are fewer than six personas, or if some personas have **no consumers**.
+- **“Will the same preview run twice look identical?”** — **No**—randomness in persona and consumer selection.
+- **“I changed the brief—what happens to old variants?”** — Existing **ad_variant** rows are unchanged; new runs need a **new version** or new jobs to pick up new brief text for that version key.
+- **“Job stuck?”** — Check **`ad_jobs.status`**, **`attempt_count`**, **`error_message`**, and **`ad_variants.status` / `meta`**; locks should clear on completion or failure paths; transient poller errors may **release** lock back to **pending**.
+- **“Can I watch the video later?”** — SAS links **expire** (default **1 hour**); clients may need to **refetch** the variant to get a fresh URL.
+- **“Is my data isolated from other businesses?”** — **Intended** via `business_client_id` on core entities; any new endpoint must **preserve** that boundary.
+
+---
+
+## Related docs
+
+| Doc | Purpose |
+|-----|---------|
+| [ARCHITECTURE.md](./ARCHITECTURE.md) | How components and data flows are wired. |
+| [BACKEND.md](./BACKEND.md) | How to implement behavior without breaking structure. |
+| [FRONTEND.md](./FRONTEND.md) | How the UI is organized and should behave. |
+| [TESTING.md](./TESTING.md) | How to prove behavior with tests and CI. |
+| [references/](./references/) | Quick lookup (API, env, persistence). |
+| [AGENTS.md](../AGENTS.md) | How to run, test, and navigate the repo. |
+| [README.md](../README.md) | High-level product pitch and setup. |

--- a/agent_resources/TESTING.md
+++ b/agent_resources/TESTING.md
@@ -1,0 +1,177 @@
+# Testing guide
+
+This document answers: **“How do I prove my change works?”** It reflects **what the repo does today** plus practical expectations for new work.
+
+---
+
+## Philosophy (test pyramid)
+
+We aim for a **short, fast base** of **unit tests**, a **middle layer** of **integration tests** (API + in-memory DB + mocks), and **few** **end-to-end** checks—because E2E is slow and brittle without dedicated tooling.
+
+| Layer | Goal | Speed | Count (directional) |
+|-------|------|--------|---------------------|
+| **Unit** | Pure logic, parsers, prompt builders, CRUD helpers with mocked DB | Fast | Many |
+| **Integration** | FastAPI `TestClient`, real router + **SQLite** session override | Medium | Several per feature |
+| **Worker / poller** | `unittest.mock.patch` / `AsyncMock` on I/O and CRUD | Medium | Cover branches |
+| **Smoke / import** | `from main import app` (CI) | Fast | Always green |
+| **E2E (browser)** | Full stack, real services | Slow | Rare / not automated yet |
+
+**Bias:** Prefer tests that **fail for the right reason** (assertion on behavior, not implementation detail) and **do not call production** APIs or databases.
+
+---
+
+## What kinds of tests exist today
+
+### Backend (`backend/tests/`)
+
+- **API integration:** `TestClient` against **`main.app`**, **`dependency_overrides`** for `get_db` and `get_current_client_id`, **in-memory SQLite** (`StaticPool`), temporary removal of **`dbo`** schema on models for SQLite (`test_consumers.py`, `test_product.py`, etc.).
+- **Route unit behavior:** e.g. **`test_ad_variants.py`** uses **`monkeypatch`** on env and CRUD functions to test SAS URL signing without Azure.
+- **Services:** **`test_persona_assignment_service.py`**, **`test_consumer_persona_processor.py`**, **`test_script_moderation_worker.py`** — mocks for LLM clients, **no network**.
+- **Workers / poller:** **`test_ad_job_worker.py`**, **`test_ad_job_poller.py`** — **`pytest.importorskip("azure.storage.blob")`** when imports pull Azure; **`patch`** / **`AsyncMock`** for `execute_ad_job`, `claim_ad_job`, etc.
+- **ML / numeric:** **`test_gmm_*`**, **`test_gmm_vectorizer`** — deterministic math fixtures.
+- **DB connectivity (manual):** **`db_connection_test.py`** — intended as a **script** against **real `.env`** (`python …` or run functions manually); **not** the same pattern as SQLite tests.
+
+### Frontend (`frontend/`)
+
+- **Automated:** **`npm run lint`** and **`npm run build`** in CI only—**no** Jest/Vitest/Playwright wired in `package.json` yet.
+- **Typecheck:** **`npx tsc --noEmit`** locally (see [AGENTS.md](../AGENTS.md)).
+
+### CI (GitHub Actions)
+
+| Workflow | What it proves |
+|----------|----------------|
+| **`run-tests.yml`** | `python -m pytest tests -v` in **`backend/`** with **`JWT_SECRET`**, **`DB_CONNECTION_STRING=sqlite:///test.db`**, **`ALLOWED_ORIGINS`**. |
+| **`backend-build.yaml`** | `python -c "from main import app"` with same env pattern. |
+| **`lint.yaml`** | Frontend **ESLint**. |
+| **`frontend-build.yaml`** | Frontend **Vite build**. |
+
+---
+
+## When to write which kind
+
+| You changed… | Prefer |
+|--------------|--------|
+| **Pure function** (parse, format, validation helper) | **Unit test** — no DB. |
+| **`crud/*`** | **Unit or integration** with SQLite + small fixture data; assert query behavior. |
+| **`routes/*`** | **`TestClient`** test: status code, **`detail`**, response shape; **mock** heavy services if needed. |
+| **`services/*` / `workers/*`** | **Unit** with mocks; if orchestration is thin, **integration** through route or poller test. |
+| **`main.py`** (lifespan, middleware, new router) | **Import smoke** + targeted test if behavior is observable. |
+| **Auth / tenant rules** | **Integration** with **`get_current_client_id`** override **and** negative cases (wrong/missing token). |
+| **Frontend UI** | Until component tests exist: **manual** critical path + keep **lint/build** green; add **Vitest + RTL** for new complex components if you introduce the stack. |
+| **Cross-service E2E** | **Manual** checklist or future Playwright/Cypress; document steps in PR when behavior is user-visible. |
+
+---
+
+## How to run tests
+
+### Backend (matches CI)
+
+```bash
+cd backend
+pip install -r requirements.txt
+export JWT_SECRET=ci-test-secret
+export DB_CONNECTION_STRING=sqlite:///test.db
+export ALLOWED_ORIGINS=http://localhost:5173
+python -m pytest tests -v
+```
+
+**Single file / test:**
+
+```bash
+cd backend && python -m pytest tests/test_ad_job_poller.py -v
+```
+
+**App import smoke (matches `backend-build`):**
+
+```bash
+cd backend && JWT_SECRET=ci-test-secret DB_CONNECTION_STRING=sqlite:///test.db ALLOWED_ORIGINS=http://localhost:5173 \
+  python -c "from main import app"
+```
+
+### Real database connectivity (optional, local)
+
+```bash
+cd backend
+# Ensure .env points at a reachable DB
+python tests/db_connection_test.py
+```
+
+Do **not** rely on this for CI; use for **local debugging** only.
+
+### Frontend
+
+```bash
+cd frontend && npm ci && npm run lint && npm run build
+npx tsc --noEmit
+```
+
+---
+
+## Fixtures and mocking rules
+
+1. **Path setup:** Many tests prepend **`backend/`** to **`sys.path`** so imports match runtime layout—**keep this consistent** when adding new test packages.
+2. **SQLite vs SQL Server:** ORM models use **`schema="dbo"`**; SQLite tests often **strip schema** on specific tables in fixtures and **`create_all`** only needed tables—**follow the nearest existing test file** (`test_consumers.py`, `test_product.py`).
+3. **`get_db` override:** Use **`app.dependency_overrides[get_db] = _override`** yielding a **session bound to in-memory engine**; reset clients between tests if needed.
+4. **JWT:** Override **`get_current_client_id`** to return a fixed **`_TEST_CLIENT_ID`** for happy paths.
+5. **Async:** **`pytest.ini`** sets **`asyncio_mode = auto`**; use **`@pytest.mark.asyncio`** where needed (see poller tests).
+6. **Optional deps:** Use **`pytest.importorskip("azure.storage.blob", …)`** when importing modules that require Azure SDK so environments without it **skip** instead of erroring obscurely.
+7. **LLM / HTTP:** **Never** hit real OpenAI/xAI in unit tests—**`AsyncMock`**, **`MagicMock`**, or patch **`responses.create`** / **`chat.completions.create`** at the boundary used by your code.
+8. **Env:** Prefer **`monkeypatch.setenv`** / **`delenv`** over mutating **`os.environ`** globally without cleanup.
+
+---
+
+## Coverage expectations
+
+- **No enforced coverage gate** is configured today (`pytest-cov` is not in `requirements.txt`).
+- **Expectation for meaningful changes:** add or extend tests so that **new branches** and **failure modes** you introduce are exercised; reviewers should ask for tests when risk is **auth, money, data loss, or job correctness**.
+- **Optional locally:** `pip install pytest-cov` and `pytest tests --cov=. --cov-report=term-missing` from **`backend/`** (may need omit patterns for noise).
+
+---
+
+## Flaky test handling
+
+| Symptom | Likely cause | Fix |
+|---------|----------------|-----|
+| **Passes alone, fails in suite** | Shared global state (`sys.path`, env, **`get_openai_client.cache_clear`** not called, engine singleton) | Isolate with fixtures; clear caches in **`autouse`** fixture where needed. |
+| **Async timing** | Missing **`await`**, wrong **`AsyncMock`** | Use **`pytest-asyncio`** patterns from `test_ad_job_poller.py`. |
+| **SQLite locked** | Sessions not closed, **`check_same_thread`** | Use **`StaticPool`** pattern from existing tests. |
+| **Skip on CI** | **`importorskip`** for Azure | Ensure **`requirements.txt`** includes **`azure-storage-blob`** (it does); if skip persists, fix import path. |
+| **Real network** | Accidental live client | Patch at module **import used by code under test** (target string must match **`where`** the name is looked up). |
+
+**Rule:** Do not **`@pytest.mark.flaky`** retry without fixing root cause unless the flake is **documented** and **tracked** (prefer fixing).
+
+---
+
+## Test data setup
+
+- **Prefer factories** inside the test file or a shared **`tests/factories.py`** (not present yet—**inline helpers** like **`_make_persona`** are the house style).
+- **Minimal rows:** Only create **Persona** before **Consumer** when FK order demands it (see consumer tests).
+- **UUIDs:** Use **`uuid4()`** for job/batch ids in poller tests.
+- **Secrets:** Never put real keys in tests; use **`monkeypatch`** for env vars.
+- **CSV / uploads:** **`io.BytesIO`** for **`UploadFile`**-style tests (`test_consumers.py`).
+
+---
+
+## End-to-end guidance
+
+**Not automated in-repo** today. To **prove** a change for reviewers:
+
+1. **Backend:** Run **pytest** + **import smoke**; hit **`/docs`** locally for manual calls with a valid JWT.
+2. **Frontend:** **`npm run dev`**, walk **HashRouter** paths (`/#/…`) affected; verify **network** tab calls **`/api`** as expected.
+3. **Full stack:** Start **FastAPI** + **Vite** (see [AGENTS.md](../AGENTS.md)); run one **golden path** (sign-in → campaign → generate) when touching **both** sides.
+4. **Document** in the PR: env vars used, seed data, and any **known limitations** (e.g. Azure-only features stubbed locally).
+
+When the team adds **Playwright** or similar, this section should gain **one** committed smoke spec and CI job.
+
+---
+
+## Related docs
+
+| Doc | Purpose |
+|-----|---------|
+| [AGENTS.md](../AGENTS.md) | Commands and directory map. |
+| [ARCHITECTURE.md](./ARCHITECTURE.md) | What to smoke-test end-to-end. |
+| [BACKEND.md](./BACKEND.md) | Layers and where to put logic. |
+| [FRONTEND.md](./FRONTEND.md) | Frontend structure; future component tests. |
+| [PRODUCT.md](./PRODUCT.md) | Behaviors worth asserting in tests. |
+| [references/ci-and-tooling.md](./references/ci-and-tooling.md) | Workflow file names and local commands. |

--- a/agent_resources/design-docs/README.md
+++ b/agent_resources/design-docs/README.md
@@ -1,0 +1,45 @@
+# Design docs (major changes)
+
+Use this folder for **written design** before **implementation** when a change is **major** (see [AGENTS.md](../../AGENTS.md)). The doc is the place to align on behavior, scope, and tradeoffs—especially for humans and agents working together.
+
+**Task-level steps** (checklists, acceptance criteria for a single assignment) belong in repo-root [`exec-plans/`](../../exec-plans/); link from there to a design doc when the task implements a major design.
+
+## When to create one
+
+Create a design doc **before writing implementation code** if **any** of these apply:
+
+- Touches **auth, tenancy, billing, or PII** in a new way
+- Adds or changes **API contracts** consumed by the frontend or external clients
+- Changes **database schema**, **job processing**, or **background pollers**
+- Introduces a **new integration** (vendor, queue, storage) or **moves** logic across layers (`routes` / `services` / `workers`)
+- Is **large or risky** enough that reviewers need a shared picture before reading a diff
+
+**Small fixes** (copy, a single bug fix, one test, localized UI tweak) do **not** need a design doc.
+
+## File naming
+
+Use a **short kebab-case slug** plus optional date prefix so files sort well:
+
+- `2026-04-14-campaign-auth-scoping.md`
+- `ad-job-idempotency.md`
+
+One topic per file; link related docs from the body.
+
+## Suggested outline
+
+Paste and fill in:
+
+1. **Context** — Problem, who it affects, link to issues or product notes.
+2. **Goals / non-goals** — What success means; what is explicitly out of scope.
+3. **Current behavior** — Pointer to code paths or [PRODUCT.md](../PRODUCT.md) / [ARCHITECTURE.md](../ARCHITECTURE.md).
+4. **Proposed behavior** — User-visible and system behavior after the change.
+5. **Design** — Components, data flow, API shapes, schema deltas (bullet diagrams welcome).
+6. **Alternatives considered** — 1–2 options and why this one won.
+7. **Migration & rollout** — Feature flags, deploy order, backfill, backwards compatibility.
+8. **Testing** — What tests or manual checks prove it ([TESTING.md](../TESTING.md)).
+9. **Open questions** — Decisions still needed before or during implementation.
+
+## After implementation
+
+- Update the design doc with a **“Implementation notes”** section (what changed vs plan, if different), or link the merging PR.
+- If the design is obsolete, add a line at the top: **Status: superseded by …** rather than deleting history.

--- a/agent_resources/references/README.md
+++ b/agent_resources/references/README.md
@@ -1,0 +1,26 @@
+# Reference lookup (agent_resources)
+
+Short, **stable lookup tables** for day-to-day work. For narrative explanations, use the main docs in the parent folder [`../`](..):
+
+| Main doc | Topic |
+|----------|--------|
+| [ARCHITECTURE.md](../ARCHITECTURE.md) | System shape, flows |
+| [PRODUCT.md](../PRODUCT.md) | Product behavior |
+| [FRONTEND.md](../FRONTEND.md) | UI structure, patterns |
+| [BACKEND.md](../BACKEND.md) | Layers, auth, jobs |
+| [TESTING.md](../TESTING.md) | How to validate |
+| [design-docs/README.md](../design-docs/README.md) | Major-change design process (before implementation) |
+| [exec-plans/README.md](../../exec-plans/README.md) | Task-level execution plans (repo root) |
+
+Repo-root [AGENTS.md](../../AGENTS.md) is the contributor quick map (run, test, directories); it links here for lookups.
+
+## Files in this folder
+
+| File | Use when you need… |
+|------|---------------------|
+| [backend-api.md](./backend-api.md) | HTTP path + verb cheat sheet |
+| [environment.md](./environment.md) | Env vars (backend + frontend) |
+| [frontend.md](./frontend.md) | Hash routes, API base, React Query keys, storage keys |
+| [persistence.md](./persistence.md) | SQLAlchemy models / tables overview |
+| [ci-and-tooling.md](./ci-and-tooling.md) | GitHub Actions, local commands |
+| [integrations.md](./integrations.md) | External APIs and SDK touchpoints |

--- a/agent_resources/references/backend-api.md
+++ b/agent_resources/references/backend-api.md
@@ -1,0 +1,121 @@
+# Backend HTTP reference
+
+Base URL (local): `http://localhost:8000`  
+Vite dev proxy: browser calls **`/api/...`** → backend **`/...`** (see `frontend/vite.config.ts`).
+
+OpenAPI: **`/docs`**, **`/redoc`**.
+
+## Root| Method | Path | Notes |
+|--------|------|--------|
+| GET, HEAD | `/` | Service metadata JSON |
+| GET | `/health` | `{"status":"healthy"}` |
+
+## By router prefix
+
+### `/auth`
+
+| Method | Path |
+|--------|------|
+| POST | `/auth/signup` |
+| POST | `/auth/signin` |
+| GET | `/auth/me` |
+| POST | `/auth/onboarding` |
+
+### `/ad-job-worker`
+
+| Method | Path |
+|--------|------|
+| GET | `/ad-job-worker/hello` |
+| POST | `/ad-job-worker/run-ad-job` |
+| POST | `/ad-job-worker/generate-campaign-preview` |
+| POST | `/ad-job-worker/generate-campaign-ad-variants` |
+
+### `/ad-post-worker`
+
+| Method | Path |
+|--------|------|
+| GET | `/ad-post-worker/hello` |
+
+### `/ad-variants`
+
+| Method | Path |
+|--------|------|
+| GET | `/ad-variants/` |
+| GET | `/ad-variants/{ad_variant_id}` |
+| POST | `/ad-variants/` |
+| PUT | `/ad-variants/{ad_variant_id}` |
+| DELETE | `/ad-variants/{ad_variant_id}` |
+
+### `/ad-jobs`
+
+| Method | Path |
+|--------|------|
+| GET | `/ad-jobs/` |
+| GET | `/ad-jobs/{ad_job_id}` |
+| POST | `/ad-jobs/` |
+| PUT | `/ad-jobs/{ad_job_id}` |
+| DELETE | `/ad-jobs/{ad_job_id}` |
+
+### `/ad-job-batches`
+
+| Method | Path |
+|--------|------|
+| GET | `/ad-job-batches/` |
+| GET | `/ad-job-batches/{batch_id}` |
+| POST | `/ad-job-batches/` |
+| PUT | `/ad-job-batches/{batch_id}` |
+| DELETE | `/ad-job-batches/{batch_id}` |
+
+### `/campaigns`
+
+| Method | Path |
+|--------|------|
+| GET | `/campaigns/` |
+| GET | `/campaigns/{campaign_id}` |
+| POST | `/campaigns/` |
+| PUT | `/campaigns/{campaign_id}` |
+| DELETE | `/campaigns/{campaign_id}` |
+
+### `/chat-messages`
+
+| Method | Path |
+|--------|------|
+| GET | `/chat-messages/` |
+| POST | `/chat-messages/` |
+| DELETE | `/chat-messages/` |
+
+### `/chat/completions`
+
+| Method | Path |
+|--------|------|
+| POST | `/chat/completions/` |
+
+### `/consumers`
+
+| Method | Path |
+|--------|------|
+| GET | `/consumers/` |
+| POST | `/consumers/upload-csv` |
+| POST | `/consumers/assign-personas` |
+| POST | `/consumers/` |
+
+### `/products`
+
+| Method | Path |
+|--------|------|
+| GET | `/products/` |
+| GET | `/products/{product_id}` |
+| POST | `/products/` |
+| PUT | `/products/{product_id}` |
+| DELETE | `/products/{product_id}` |
+| POST | `/products/{product_id}/upload-image` |
+
+### `/personas`
+
+| Method | Path |
+|--------|------|
+| GET | `/personas/` |
+
+---
+
+**Auth note:** Many routes use **`get_current_client_id`**; some (notably parts of **`/campaigns`**) do not—see [BACKEND.md](../BACKEND.md). Prefer verifying each handler when integrating.

--- a/agent_resources/references/backend-api.md
+++ b/agent_resources/references/backend-api.md
@@ -5,7 +5,9 @@ Vite dev proxy: browser calls **`/api/...`** → backend **`/...`** (see `fronte
 
 OpenAPI: **`/docs`**, **`/redoc`**.
 
-## Root| Method | Path | Notes |
+## Root and health
+
+| Method | Path | Notes |
 |--------|------|--------|
 | GET, HEAD | `/` | Service metadata JSON |
 | GET | `/health` | `{"status":"healthy"}` |

--- a/agent_resources/references/ci-and-tooling.md
+++ b/agent_resources/references/ci-and-tooling.md
@@ -1,0 +1,32 @@
+# CI and tooling reference
+
+## GitHub Actions (`.github/workflows/`)
+
+| Workflow file | Trigger | What runs |
+|---------------|---------|-----------|
+| `run-tests.yml` | PR → `main` | `pip install` + `python -m pytest tests -v` in **`backend/`** |
+| `backend-build.yaml` | PR → `main` | `python -c "from main import app"` in **`backend/`** |
+| `lint.yaml` | PR → `main` | `npm ci` + `npm run lint` in **`frontend/`** |
+| `frontend-build.yaml` | PR → `main` | `npm ci` + `npm run build` in **`frontend/`** |
+
+Backend jobs set: `JWT_SECRET`, `DB_CONNECTION_STRING=sqlite:///test.db`, `ALLOWED_ORIGINS`.
+
+## Local commands (short)
+
+| Goal | Command |
+|------|---------|
+| Backend dev | `cd backend && source venv/bin/activate && python3 main.py` |
+| Backend tests | See [TESTING.md](../TESTING.md) |
+| Frontend dev | `cd frontend && npm run dev` |
+| Frontend lint | `cd frontend && npm run lint` |
+| Frontend build | `cd frontend && npm run build` |
+| Frontend typecheck | `cd frontend && npx tsc --noEmit` |
+
+## Deploy hint
+
+- `render.yaml`: API Docker service, context **`backend/`**.
+
+## ESLint
+
+- Config: `frontend/eslint.config.js`
+- Ignores: `dist`, `.next`, `node_modules`

--- a/agent_resources/references/ci-and-tooling.md
+++ b/agent_resources/references/ci-and-tooling.md
@@ -15,7 +15,7 @@ Backend jobs set: `JWT_SECRET`, `DB_CONNECTION_STRING=sqlite:///test.db`, `ALLOW
 
 | Goal | Command |
 |------|---------|
-| Backend dev | `cd backend && source venv/bin/activate && python3 main.py` |
+| Backend dev | `cd backend && source venv/bin/activate && python3 main.py` (needs an existing venv; full setup in [AGENTS.md](../../AGENTS.md)) |
 | Backend tests | See [TESTING.md](../TESTING.md) |
 | Frontend dev | `cd frontend && npm run dev` |
 | Frontend lint | `cd frontend && npm run lint` |

--- a/agent_resources/references/environment.md
+++ b/agent_resources/references/environment.md
@@ -1,0 +1,69 @@
+# Environment variables reference
+
+Values are **representative**; authoritative defaults live in code and **`backend/.env.example`**.
+
+## Backend (`backend/.env`)
+
+Loaded via **`python-dotenv`** from **`backend/.env`** (`database.py`, several workers).
+
+### Required for a running API (typical)
+
+| Variable | Role |
+|----------|------|
+| `JWT_SECRET` | HS256 signing; **required** at import for `routes/auth.py` |
+| `ALLOWED_ORIGINS` | Comma-separated CORS origins; read at startup (**KeyError if missing**) |
+| `DB_CONNECTION_STRING` | SQLAlchemy URL; placeholder `${DB_PASSWORD}` may be substituted |
+| `DB_PASSWORD` | Injected into `DB_CONNECTION_STRING` when used |
+
+### Database (Azure AD alternative)
+
+| Variable | Role |
+|----------|------|
+| `USE_AZURE_AD` | When `true`, use ODBC + `DefaultAzureCredential` |
+| `DB_ODBC_CONNECTION_STRING` | ODBC string for Azure AD path |
+
+### LLM / media (feature-dependent)
+
+| Variable | Role |
+|----------|------|
+| `OPENAI_API_KEY` | `core/openai_client.py` (e.g. consumer persona flows) |
+| `SCRIPT_MODEL` | Model id for script/moderation/chat client paths |
+| `SCRIPT_API_KEY` | Key for OpenAI-compatible client (script moderation, Grok chat, some workers) |
+| `SCRIPT_BASE_URL` | Base URL for same client |
+| `VIDEO_API_KEY` | OpenAI-compatible video generation (`ad_video_generation_worker`) |
+
+### Azure Storage
+
+| Variable | Role |
+|----------|------|
+| `AZURE_STORAGE_CONNECTION_STRING` | Blob upload/download + SAS signing in routes/workers |
+| `AZURE_STORAGE_VIDEO_CONTAINER` | Documented in `.env.example` (default `ad-videos`); code may hardcode container names in places |
+
+### Ad job poller
+
+| Variable | Role |
+|----------|------|
+| `AD_JOB_POLL_INTERVAL_SECONDS` | Default `5` |
+| `AD_JOB_MAX_ATTEMPTS` | Default `3` |
+
+## CI (GitHub Actions)
+
+Backend workflows set at least:
+
+- `JWT_SECRET=ci-test-secret`
+- `DB_CONNECTION_STRING=sqlite:///test.db`
+- `ALLOWED_ORIGINS=http://localhost:5173`
+
+## Frontend (`frontend/.env` — optional)
+
+| Variable | Role |
+|----------|------|
+| `VITE_ENV` | When `local` (or unset per `api/config.ts` logic), **`API_BASE_URL`** is `/api` |
+| `VITE_API_URL` | Backend origin for non-local builds and Vite proxy default (`vite.config.ts` uses it as proxy target, default `http://localhost:8000`) |
+
+## Local storage (browser)
+
+Not env vars, but configuration-like (see [frontend.md](./frontend.md)):
+
+- `adgentic_token`, `adgentic_current_user`, `adgentic_client_id`
+- `theme` (light/dark)

--- a/agent_resources/references/environment.md
+++ b/agent_resources/references/environment.md
@@ -58,7 +58,7 @@ Backend workflows set at least:
 
 | Variable | Role |
 |----------|------|
-| `VITE_ENV` | When `local` (or unset per `api/config.ts` logic), **`API_BASE_URL`** is `/api` |
+| `VITE_ENV` | Unset defaults to **`local`** in `api/config.ts`; when `ENV === 'local'`, **`API_BASE_URL`** is `/api` |
 | `VITE_API_URL` | Backend origin for non-local builds and Vite proxy default (`vite.config.ts` uses it as proxy target, default `http://localhost:8000`) |
 
 ## Local storage (browser)

--- a/agent_resources/references/frontend.md
+++ b/agent_resources/references/frontend.md
@@ -30,10 +30,14 @@ Source: `frontend/src/App.tsx`.
 
 ## API base URL (`src/api/config.ts`)
 
+`ENV` is `import.meta.env.VITE_ENV` or **`local`** if unset. **`isLocal`** is true when `ENV === 'local'`.
+
 | Condition | `API_BASE_URL` |
 |-------------|----------------|
-| `VITE_ENV === 'local'` (or logic treats as local) | `/api` |
+| **`isLocal`** (`VITE_ENV` unset or `local`) | `/api` |
 | Else | `import.meta.env.VITE_API_URL` or `/api` fallback |
+
+Same rules as [FRONTEND.md](../FRONTEND.md) (data-fetching section).
 
 ## Vite dev proxy
 

--- a/agent_resources/references/frontend.md
+++ b/agent_resources/references/frontend.md
@@ -1,0 +1,67 @@
+# Frontend lookup
+
+## Routes (`HashRouter`)
+
+Browser URL shape: `https://host/#/<path>` (hash segment, not server path).
+
+| Path | Page component |
+|------|------------------|
+| `/` | `SimpleLanding` |
+| `/old-landing` | `LandingPage` |
+| `/sign-up` | `SignUpPage` |
+| `/sign-in` | `SignInPage` |
+| `/onboarding` | `OnboardingPage` |
+| `/dashboard` | `DashboardPage` |
+| `/workspace` | `DashboardPage` |
+| `/campaigns` | `CampaignsPage` |
+| `/campaign/:id` | `CampaignDetailPage` |
+| `/generate` | `GenerateAdsPage` |
+| `/products` | `ProductsPage` |
+| `/customer-data` | `CustomerDataPage` |
+| `/all-consumers` | `AllConsumersPage` |
+| `/profile` | `ProfilePage` |
+| `/settings` | `SettingsPage` |
+| `/features` | `FeaturesPage` |
+| `/how-it-works` | `HowItWorksPage` |
+| `/pricing` | `PricingPage` |
+| `/team` | `TeamPage` |
+
+Source: `frontend/src/App.tsx`.
+
+## API base URL (`src/api/config.ts`)
+
+| Condition | `API_BASE_URL` |
+|-------------|----------------|
+| `VITE_ENV === 'local'` (or logic treats as local) | `/api` |
+| Else | `import.meta.env.VITE_API_URL` or `/api` fallback |
+
+## Vite dev proxy
+
+- Requests to **`/api/*`** → **`VITE_API_URL`** (or `http://localhost:8000`), path rewritten to drop `/api`.
+
+## React Query cache keys
+
+| Export | Key shape (conceptual) |
+|--------|-------------------------|
+| `PROFILE_KEY` | `['auth','profile']` |
+| `CAMPAIGNS_KEY` | `['campaigns', businessClientId?, status?]` / detail `['campaigns', campaignId]` |
+| `PRODUCTS_KEY` | `['products', businessClientId]` |
+| `CONSUMERS_KEY` | `['consumers', skip, limit]` |
+| `PERSONAS_KEY` | `['personas']` |
+| `CHAT_MESSAGES_KEY` | `['chatMessages', campaignId]` |
+| `AD_VARIANTS_KEY` | `['ad-variants', campaignId, status?, isPreview?]` / preview variant |
+
+Invalidation often uses **prefix** `CAMPAIGNS_KEY` or `AD_VARIANTS_KEY` only—see hook files under `frontend/src/hooks/`.
+
+## `localStorage` keys (`api/config.ts`)
+
+| Key constant | Purpose |
+|--------------|---------|
+| `TOKEN_KEY` → `adgentic_token` | JWT |
+| `USER_KEY` → `adgentic_current_user` | Email display |
+| `CLIENT_ID_KEY` → `adgentic_client_id` | Numeric client id |
+
+## Theme
+
+- `localStorage` key: `theme` (`light` | `dark`)
+- `document.documentElement` class: `dark` when dark mode

--- a/agent_resources/references/integrations.md
+++ b/agent_resources/references/integrations.md
@@ -1,0 +1,23 @@
+# External integrations lookup
+
+Where the code talks to the outside world (excluding the browser).
+
+| Integration | Python / package | Typical entrypoints | Config |
+|-------------|------------------|---------------------|--------|
+| **Azure Blob** | `azure-storage-blob` | `BlobClient`, `ContainerClient`; `routes/product.py`, `routes/ad_variants.py`, `workers/ad_job_worker/worker.py` | `AZURE_STORAGE_CONNECTION_STRING` |
+| **Azure identity** | `azure-identity` | `database.py` (`DefaultAzureCredential`) when `USE_AZURE_AD=true` | `DB_ODBC_CONNECTION_STRING` |
+| **OpenAI API** | `openai` (`AsyncOpenAI`) | `core/openai_client.py`, video worker, moderation worker, persona code paths | `OPENAI_API_KEY`, `VIDEO_API_KEY`, `SCRIPT_*` |
+| **xAI / Grok** | `openai` client + `xai_sdk` | `services/chat_ai/service.py` (chat); `workers/script_creation_worker/worker.py` (scripts) | `SCRIPT_API_KEY`, `SCRIPT_BASE_URL`, model env |
+| **SQL Server / ODBC** | `sqlalchemy`, `pyodbc` | `database.py` | URL or Azure AD ODBC path |
+
+## Blob containers (hardcoded in code paths)
+
+| Container | Typical use |
+|-----------|-------------|
+| `product-images` | Product image blobs; worker reads by `image_name` |
+| `ad-videos` | Rendered MP4 uploads; SAS signing in ad variant routes |
+
+## JWT
+
+- Library: **`python-jose`** (`dependencies.py`).
+- Signing: **`JWT_SECRET`**, HS256, 7-day expiry via **`create_access_token`**.

--- a/agent_resources/references/persistence.md
+++ b/agent_resources/references/persistence.md
@@ -1,0 +1,22 @@
+# Persistence reference (SQLAlchemy)
+
+ORM models live in **`backend/models/`**. Tables use schema **`dbo`** (SQL Server); tests may strip schema for SQLite.
+
+| Module | Table (`dbo`) | Primary identifiers | Notes |
+|--------|---------------|---------------------|--------|
+| `business_client.py` | `business_clients` | `id` int | Email unique; `stripe_customer_id` placeholder default |
+| `campaign.py` | `campaigns` | `id` int | `business_client_id`; `brief` may store versioned JSON text |
+| `product.py` | `products` | `id` int | `business_client_id`; `image_name` / blob for generation |
+| `consumer.py` | `consumers` | `id` int | `business_client_id`; FK to `personas`; unique `(business_client_id, email)` |
+| `persona.py` | `personas` | `id` string UUID | Unique `name`; JSON string columns for lists |
+| `ad_variant.py` | `ad_variants` | `id` int | `campaign_id`, `consumer_id`, `version_number`, `is_preview`, `status`, `media_url`, `metadata` column mapped as `meta` |
+| `ad_job.py` | `ad_jobs` | `id` UUID | `batch_id` UUID; lock columns; `input_json` / `output_json` |
+| `ad_job_batch.py` | `ad_job_batches` | `id` UUID | Progress counters; optional `idempotency_key` |
+| `chat_message.py` | `chat_messages` | `id` int | `campaign_id`, `business_client_id`, `role`, `message_type`, `content`, `version_ref` |
+| `consumer_event.py` | `consumer_events` | `id` bigint | Tied to `ad_variant_id`, `event_type`, optional fingerprint/session metadata |
+
+**Session access:** `database.get_db` → SQLAlchemy `Session`.
+
+**CRUD:** `backend/crud/*` per aggregate.
+
+For concurrency on jobs, see **`crud/ad_job.py`** (`claim_ad_job`, `release_job_lock`).

--- a/exec-plans/README.md
+++ b/exec-plans/README.md
@@ -23,4 +23,4 @@ Add a Markdown file per task or epic slice, for example:
 - **Acceptance criteria** or test commands to run
 - Links to issues, design docs in `agent_resources/design-docs/`, or PRs
 
-**Relationship to design docs:** large or risky changes may need a design doc in `agent_resources/design-docs/` *before* implementation; the exec plan can link to it and focus on execution.
+**Relationship to design docs:** large or risky changes may need a design doc in `agent_resources/design-docs/` *before* implementation; the exec plan should **link to it** or **state a waiver** (e.g. hotfix). If the plan is silent but the task is **clearly major** (auth, schema, jobs, new integrations), confirm with the human whether a design doc is required before coding—see [AGENTS.md: Major changes (design doc first)](../AGENTS.md#major-changes-design-doc-first).

--- a/exec-plans/README.md
+++ b/exec-plans/README.md
@@ -1,0 +1,26 @@
+# Execution plans
+
+This directory holds **task-specific** instructions: what to build or change, in what order, and how to know you’re done.
+
+## For agents
+
+- **Start here** when [AGENTS.md](../AGENTS.md) or your assignment mentions `exec-plans/`, or when completing scoped repo work that has a matching file here.
+- Prefer the plan’s **steps and acceptance criteria** over guessing scope.
+- Use [agent_resources/](../agent_resources/) for **system** background (architecture, product rules, API/env lookups).
+
+## For authors
+
+Add a Markdown file per task or epic slice, for example:
+
+- `feature-name.md`
+- `2026-04-14-fix-campaign-list-auth.md`
+
+**Include** where helpful:
+
+- Objective and **non-goals**
+- **Steps** (ordered checklist)
+- **Files / areas** to touch (`backend/routes/...`, `frontend/src/...`)
+- **Acceptance criteria** or test commands to run
+- Links to issues, design docs in `agent_resources/design-docs/`, or PRs
+
+**Relationship to design docs:** large or risky changes may need a design doc in `agent_resources/design-docs/` *before* implementation; the exec plan can link to it and focus on execution.


### PR DESCRIPTION
- Add agent_resources/ docs for architecture, product intent, frontend, backend, and testing.
- Add agent_resources/references/ lookup tables (API paths, env vars, persistence, CI, integrations).
- Update AGENTS.md with operational contributor guidance plus design-doc and exec-plan workflows.