### PR TITLE
feat: multi-image support for products

### DIFF
--- a/backend/routes/product.py
+++ b/backend/routes/product.py
@@ -1,5 +1,6 @@
-"""API routes for products — full CRUD + image upload endpoints (JWT-protected)."""
+"""API routes for products — full CRUD + image upload/delete endpoints (JWT-protected)."""
 
+import json
 import os
 import uuid
 from datetime import datetime, timedelta, timezone
@@ -30,6 +31,35 @@ router = APIRouter()
 
 CONTAINER_NAME = "product-images"
 SAS_EXPIRY_HOURS = 1
+MAX_IMAGES_PER_PRODUCT = 5
+
+
+def _parse_image_list(raw: str | None) -> list[str]:
+    """Safely parse image_url / image_name from DB.
+
+    Handles three cases:
+      - None / empty string  → []
+      - JSON array string    → ["url1", "url2"]
+      - Legacy plain string  → ["url"]   (old single-image rows)
+    """
+    if not raw:
+        return []
+    raw = raw.strip()
+    try:
+        parsed = json.loads(raw)
+        if isinstance(parsed, list):
+            return [str(x) for x in parsed if x]
+        return [str(parsed)]
+    except (json.JSONDecodeError, ValueError):
+        return [raw]
+
+ALLOWED_IMAGE_TYPES = {
+    "image/jpeg": ".jpg",
+    "image/png": ".png",
+    "image/webp": ".webp",
+    "image/gif": ".gif",
+}
+MAX_IMAGE_SIZE = 10 * 1024 * 1024  # 10 MB
 
 
 def _parse_conn_str(conn_str: str) -> tuple[str, str]:
@@ -38,26 +68,46 @@ def _parse_conn_str(conn_str: str) -> tuple[str, str]:
     return parts["AccountName"], parts["AccountKey"]
 
 
+def _sign_url(url: str, blob_name: str, account_name: str, account_key: str) -> str:
+    """Append a SAS token to a single blob URL."""
+    sas_token = generate_blob_sas(
+        account_name=account_name,
+        container_name=CONTAINER_NAME,
+        blob_name=blob_name,
+        account_key=account_key,
+        permission=BlobSasPermissions(read=True),
+        expiry=datetime.now(timezone.utc) + timedelta(hours=SAS_EXPIRY_HOURS),
+    )
+    return f"{url}?{sas_token}"
+
+
 def _sign_product(product) -> ProductResponse:
-    """Convert ORM product to response with a time-limited SAS URL for the image."""
-    resp = ProductResponse.model_validate(product, from_attributes=True)
-    if not resp.image_url or not resp.image_name:
+    """Convert ORM product to response, signing each image URL with a SAS token."""
+    resp = ProductResponse.model_validate(product)
+    if not resp.image_urls or not resp.image_names:
         return resp
     conn_str = os.getenv("AZURE_STORAGE_CONNECTION_STRING", "").strip()
     if not conn_str:
         return resp
     account_name, account_key = _parse_conn_str(conn_str)
-    sas_token = generate_blob_sas(
-        account_name=account_name,
-        container_name=CONTAINER_NAME,
-        blob_name=resp.image_name,
-        account_key=account_key,
-        permission=BlobSasPermissions(read=True),
-        expiry=datetime.now(timezone.utc) + timedelta(hours=SAS_EXPIRY_HOURS),
-    )
-    resp.image_url = f"{resp.image_url}?{sas_token}"
+    resp.image_urls = [
+        _sign_url(url, name, account_name, account_key)
+        for url, name in zip(resp.image_urls, resp.image_names)
+    ]
     return resp
 
+
+def _get_container(conn_str: str) -> ContainerClient:
+    container = ContainerClient.from_connection_string(
+        conn_str=conn_str,
+        container_name=CONTAINER_NAME,
+    )
+    if not container.exists():
+        container.create_container()
+    return container
+
+
+# ---------- CRUD routes ----------
 
 @router.get("/", response_model=list[ProductResponse])
 def list_products(
@@ -67,14 +117,7 @@ def list_products(
     db: Session = Depends(get_db),
     client_id: int = Depends(get_current_client_id),
 ):
-    """Get all products for the authenticated client, with optional is_active filter."""
-    products = get_products(
-        db,
-        business_client_id=client_id,
-        is_active=is_active,
-        skip=skip,
-        limit=limit,
-    )
+    products = get_products(db, business_client_id=client_id, is_active=is_active, skip=skip, limit=limit)
     return [_sign_product(p) for p in products]
 
 
@@ -84,7 +127,6 @@ def read_product(
     db: Session = Depends(get_db),
     client_id: int = Depends(get_current_client_id),
 ):
-    """Get a single product by ID. Returns 404 if not found or not owned by the client."""
     product = get_product(db, product_id)
     if product is None or product.business_client_id != client_id:
         raise HTTPException(status_code=404, detail="Product not found")
@@ -97,7 +139,6 @@ def create_new_product(
     db: Session = Depends(get_db),
     client_id: int = Depends(get_current_client_id),
 ):
-    """Create a new product for the authenticated client."""
     return _sign_product(create_product(db, client_id, data))
 
 
@@ -108,7 +149,6 @@ def update_existing_product(
     db: Session = Depends(get_db),
     client_id: int = Depends(get_current_client_id),
 ):
-    """Update an existing product. Returns 404 if not found or not owned by the client."""
     product = get_product(db, product_id)
     if product is None or product.business_client_id != client_id:
         raise HTTPException(status_code=404, detail="Product not found")
@@ -121,77 +161,140 @@ def remove_product(
     db: Session = Depends(get_db),
     client_id: int = Depends(get_current_client_id),
 ):
-    """Delete a product by ID. Returns 404 if not found or not owned by the client."""
     product = get_product(db, product_id)
     if product is None or product.business_client_id != client_id:
         raise HTTPException(status_code=404, detail="Product not found")
     delete_product(db, product_id)
 
 
-ALLOWED_IMAGE_TYPES = {
-    "image/jpeg": ".jpg",
-    "image/png": ".png",
-    "image/webp": ".webp",
-    "image/gif": ".gif",
-}
-MAX_IMAGE_SIZE = 10 * 1024 * 1024  # 10 MB
-
+# ---------- Image upload ----------
 
 @router.post("/{product_id}/upload-image", response_model=ProductResponse)
-async def upload_product_image(
+async def upload_product_images(
     product_id: int,
-    file: UploadFile = File(...),
+    files: list[UploadFile] = File(...),
     db: Session = Depends(get_db),
     client_id: int = Depends(get_current_client_id),
 ):
-    """Upload or replace a product image. Stores in Azure Blob Storage (product-images container)."""
+    """Upload one or more product images (appended to the existing list, max 5 total)."""
     product = get_product(db, product_id)
     if product is None or product.business_client_id != client_id:
         raise HTTPException(status_code=404, detail="Product not found")
 
-    content_type = file.content_type or ""
-    if content_type not in ALLOWED_IMAGE_TYPES:
+    if not files:
+        raise HTTPException(status_code=400, detail="No files provided.")
+
+    # Parse existing lists from DB (handles legacy plain-URL rows)
+    existing_urls = _parse_image_list(product.image_url)
+    existing_names = _parse_image_list(product.image_name)
+
+    slots_remaining = MAX_IMAGES_PER_PRODUCT - len(existing_urls)
+    if slots_remaining <= 0:
         raise HTTPException(
             status_code=400,
-            detail=f"Unsupported image type: {content_type}. Allowed: {', '.join(ALLOWED_IMAGE_TYPES.keys())}",
+            detail=f"Product already has {MAX_IMAGES_PER_PRODUCT} images. Delete one first.",
         )
-
-    image_bytes = await file.read()
-    if len(image_bytes) > MAX_IMAGE_SIZE:
-        raise HTTPException(status_code=400, detail="Image must be under 10 MB.")
-
-    ext = ALLOWED_IMAGE_TYPES[content_type]
-    blob_name = f"{uuid.uuid4().hex}{ext}"
+    if len(files) > slots_remaining:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Too many files. You can add {slots_remaining} more image(s) (max {MAX_IMAGES_PER_PRODUCT} total).",
+        )
 
     conn_str = os.getenv("AZURE_STORAGE_CONNECTION_STRING", "").strip()
     if not conn_str:
         raise HTTPException(status_code=500, detail="Storage not configured.")
 
-    container = ContainerClient.from_connection_string(
-        conn_str=conn_str,
-        container_name="product-images",
-    )
-    if not container.exists():
-        container.create_container()
+    _get_container(conn_str)
 
-    blob_client = BlobClient.from_connection_string(
-        conn_str=conn_str,
-        container_name="product-images",
-        blob_name=blob_name,
-    )
-    blob_client.upload_blob(
-        image_bytes,
-        overwrite=True,
-        content_settings=ContentSettings(content_type=content_type),
-    )
+    new_urls: list[str] = []
+    new_names: list[str] = []
+
+    for file in files:
+        content_type = file.content_type or ""
+        if content_type not in ALLOWED_IMAGE_TYPES:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Unsupported image type '{content_type}' for file '{file.filename}'. Allowed: {', '.join(ALLOWED_IMAGE_TYPES.keys())}",
+            )
+        image_bytes = await file.read()
+        if len(image_bytes) > MAX_IMAGE_SIZE:
+            raise HTTPException(
+                status_code=400,
+                detail=f"File '{file.filename}' exceeds 10 MB limit.",
+            )
+
+        ext = ALLOWED_IMAGE_TYPES[content_type]
+        blob_name = f"{uuid.uuid4().hex}{ext}"
+
+        blob_client = BlobClient.from_connection_string(
+            conn_str=conn_str,
+            container_name=CONTAINER_NAME,
+            blob_name=blob_name,
+        )
+        blob_client.upload_blob(
+            image_bytes,
+            overwrite=True,
+            content_settings=ContentSettings(content_type=content_type),
+        )
+        new_urls.append(blob_client.url)
+        new_names.append(blob_name)
 
     updated = update_product(
         db,
         product_id,
         ProductUpdate(
             name=product.name,
-            image_url=blob_client.url,
-            image_name=blob_name,
+            image_url=json.dumps(existing_urls + new_urls),
+            image_name=json.dumps(existing_names + new_names),
+        ),
+    )
+    return _sign_product(updated)
+
+
+# ---------- Image delete ----------
+
+@router.delete("/{product_id}/images/{blob_name}", response_model=ProductResponse)
+def delete_product_image(
+    product_id: int,
+    blob_name: str,
+    db: Session = Depends(get_db),
+    client_id: int = Depends(get_current_client_id),
+):
+    """Remove a single image from a product by its blob name."""
+    product = get_product(db, product_id)
+    if product is None or product.business_client_id != client_id:
+        raise HTTPException(status_code=404, detail="Product not found")
+
+    existing_urls = _parse_image_list(product.image_url)
+    existing_names = _parse_image_list(product.image_name)
+
+    if blob_name not in existing_names:
+        raise HTTPException(status_code=404, detail="Image not found on this product.")
+
+    # Delete from Azure Blob Storage
+    conn_str = os.getenv("AZURE_STORAGE_CONNECTION_STRING", "").strip()
+    if conn_str:
+        try:
+            blob_client = BlobClient.from_connection_string(
+                conn_str=conn_str,
+                container_name=CONTAINER_NAME,
+                blob_name=blob_name,
+            )
+            blob_client.delete_blob()
+        except Exception:
+            pass  # Don't block the DB update if blob deletion fails
+
+    idx = existing_names.index(blob_name)
+    new_urls = existing_urls[:idx] + existing_urls[idx + 1:]
+    new_names = existing_names[:idx] + existing_names[idx + 1:]
+
+    updated = update_product(
+        db,
+        product_id,
+        ProductUpdate(
+            name=product.name,
+            image_url=json.dumps(new_urls) if new_urls else None,
+            image_name=json.dumps(new_names) if new_names else None,
         ),
     )
     return _sign_product(updated)

--- a/backend/schemas/product.py
+++ b/backend/schemas/product.py
@@ -1,17 +1,16 @@
 """Pydantic schemas for products — request/response validation."""
 
+import json
 from datetime import datetime
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class ProductCreate(BaseModel):
     """Schema for creating a new product."""
     name: str = Field(..., min_length=1)
     description: Optional[str] = None
-    image_url: Optional[str] = None
-    image_name: Optional[str] = None
     product_link: Optional[str] = None
     product_metadata: Optional[str] = None
     is_active: Optional[bool] = None
@@ -21,8 +20,8 @@ class ProductUpdate(BaseModel):
     """Schema for updating a product. All fields optional."""
     name: Optional[str] = Field(None, min_length=1)
     description: Optional[str] = None
-    image_url: Optional[str] = None
-    image_name: Optional[str] = None
+    image_url: Optional[str] = None    # raw JSON string — set by upload/delete routes only
+    image_name: Optional[str] = None   # raw JSON string — set by upload/delete routes only
     product_link: Optional[str] = None
     product_metadata: Optional[str] = None
     is_active: Optional[bool] = None
@@ -34,8 +33,8 @@ class ProductResponse(BaseModel):
     business_client_id: int
     name: str
     description: Optional[str] = None
-    image_url: Optional[str] = None
-    image_name: Optional[str] = None
+    image_urls: list[str] = []         # deserialised from image_url JSON column
+    image_names: list[str] = []        # deserialised from image_name JSON column
     product_link: Optional[str] = None
     product_metadata: Optional[str] = None
     is_active: Optional[bool] = None
@@ -43,3 +42,59 @@ class ProductResponse(BaseModel):
     updated_at: Optional[datetime] = None
 
     model_config = {"from_attributes": True, "populate_by_name": True}
+
+    @field_validator("image_urls", mode="before")
+    @classmethod
+    def parse_image_urls(cls, v: object) -> list[str]:
+        """DB stores a JSON array string or a legacy plain URL string."""
+        if v is None:
+            return []
+        if isinstance(v, list):
+            return v
+        if isinstance(v, str):
+            v = v.strip()
+            if not v:
+                return []
+            try:
+                parsed = json.loads(v)
+                if isinstance(parsed, list):
+                    return [str(x) for x in parsed if x]
+                # Stored as a JSON string (quoted URL) — unwrap it
+                return [str(parsed)]
+            except (json.JSONDecodeError, ValueError):
+                # Legacy plain URL — wrap in list
+                return [v]
+        return []
+
+    @field_validator("image_names", mode="before")
+    @classmethod
+    def parse_image_names(cls, v: object) -> list[str]:
+        """Same deserialization logic as image_urls."""
+        if v is None:
+            return []
+        if isinstance(v, list):
+            return v
+        if isinstance(v, str):
+            v = v.strip()
+            if not v:
+                return []
+            try:
+                parsed = json.loads(v)
+                if isinstance(parsed, list):
+                    return [str(x) for x in parsed if x]
+                return [str(parsed)]
+            except (json.JSONDecodeError, ValueError):
+                return [v]
+        return []
+
+    # Map ORM column names → response field names
+    @classmethod
+    def model_validate(cls, obj, **kwargs):  # type: ignore[override]
+        if hasattr(obj, "__dict__") and not isinstance(obj, dict):
+            data = {
+                **obj.__dict__,
+                "image_urls": getattr(obj, "image_url", None),
+                "image_names": getattr(obj, "image_name", None),
+            }
+            return super().model_validate(data, **kwargs)
+        return super().model_validate(obj, **kwargs)

--- a/backend/tests/test_product.py
+++ b/backend/tests/test_product.py
@@ -144,8 +144,6 @@ class TestProductCreateSchema:
         data = ProductCreate(
             name="Full Product",
             description="A description",
-            image_url="https://example.com/img.png",
-            image_name="img.png",
             product_link="https://example.com",
             product_metadata='{"key": "value"}',
             is_active=True,
@@ -206,7 +204,7 @@ class TestProductResponseSchema:
         assert resp.description == "Desc"
         assert resp.product_link == "https://link.com"
         assert resp.product_metadata == '{"key": "value"}'
-        assert resp.image_name == "pic.png"
+        assert resp.image_names == ["pic.png"]
         assert resp.is_active is True
         assert resp.created_at == now
         assert resp.updated_at == now
@@ -393,8 +391,6 @@ class TestProductRoutesCreate:
         payload = {
             "name": "Full",
             "description": "Desc",
-            "image_url": "https://example.com/img.png",
-            "image_name": "img.png",
             "product_link": "https://example.com",
             "product_metadata": "{}",
             "is_active": True,
@@ -404,7 +400,7 @@ class TestProductRoutesCreate:
         body = resp.json()
         assert body["name"] == "Full"
         assert body["description"] == "Desc"
-        assert body["image_url"] == "https://example.com/img.png"
+        assert body["image_urls"] == []
         assert body["product_metadata"] == "{}"
         assert body["is_active"] is True
 

--- a/frontend/src/api/products.ts
+++ b/frontend/src/api/products.ts
@@ -1,72 +1,48 @@
 import { apiUrl, authHeaders } from './config';
 import type { Product, CreateProductPayload, UpdateProductPayload } from '../types';
 
-// ---------- API calls ----------
-
-export async function fetchProducts(
-  businessClientId: number,
-): Promise<Product[]> {
-  const params = new URLSearchParams({
-    business_client_id: String(businessClientId),
-  });
-
-  const res = await fetch(apiUrl(`/products/?${params.toString()}`), {
-    headers: authHeaders(),
-  });
-
+export async function fetchProducts(businessClientId: number): Promise<Product[]> {
+  const params = new URLSearchParams({ business_client_id: String(businessClientId) });
+  const res = await fetch(apiUrl(`/products/?${params.toString()}`), { headers: authHeaders() });
   if (!res.ok) {
     const body = await res.json().catch(() => ({}));
     throw new Error(body.detail || 'Failed to fetch products.');
   }
-
   return (await res.json()) as Product[];
 }
 
 export async function fetchProduct(productId: number): Promise<Product> {
-  const res = await fetch(apiUrl(`/products/${productId}`), {
-    headers: authHeaders(),
-  });
-
+  const res = await fetch(apiUrl(`/products/${productId}`), { headers: authHeaders() });
   if (!res.ok) {
     const body = await res.json().catch(() => ({}));
     throw new Error(body.detail || 'Product not found.');
   }
-
   return (await res.json()) as Product;
 }
 
-export async function createProduct(
-  data: CreateProductPayload,
-): Promise<Product> {
+export async function createProduct(data: CreateProductPayload): Promise<Product> {
   const res = await fetch(apiUrl('/products/'), {
     method: 'POST',
     headers: authHeaders(),
     body: JSON.stringify(data),
   });
-
   if (!res.ok) {
     const body = await res.json().catch(() => ({}));
     throw new Error(body.detail || 'Failed to create product.');
   }
-
   return (await res.json()) as Product;
 }
 
-export async function updateProduct(
-  productId: number,
-  data: UpdateProductPayload,
-): Promise<Product> {
+export async function updateProduct(productId: number, data: UpdateProductPayload): Promise<Product> {
   const res = await fetch(apiUrl(`/products/${productId}`), {
     method: 'PUT',
     headers: authHeaders(),
     body: JSON.stringify(data),
   });
-
   if (!res.ok) {
     const body = await res.json().catch(() => ({}));
     throw new Error(body.detail || 'Failed to update product.');
   }
-
   return (await res.json()) as Product;
 }
 
@@ -75,31 +51,39 @@ export async function deleteProduct(productId: number): Promise<void> {
     method: 'DELETE',
     headers: authHeaders(),
   });
-
   if (!res.ok) {
     const body = await res.json().catch(() => ({}));
     throw new Error(body.detail || 'Failed to delete product.');
   }
 }
 
-/** Upload or replace a product image (multipart). Returns updated product. */
-export async function uploadProductImage(
-  productId: number,
-  file: File,
-): Promise<Product> {
+/** Upload one or more images for a product (appended, max 5 total). Returns updated product. */
+export async function uploadProductImages(productId: number, files: File[]): Promise<Product> {
   const formData = new FormData();
-  formData.append('file', file);
-
+  for (const file of files) {
+    formData.append('files', file);
+  }
   const res = await fetch(apiUrl(`/products/${productId}/upload-image`), {
     method: 'POST',
     headers: authHeaders(false), // no Content-Type — browser sets multipart boundary
     body: formData,
   });
-
   if (!res.ok) {
     const body = await res.json().catch(() => ({}));
-    throw new Error(body.detail || 'Failed to upload product image.');
+    throw new Error(body.detail || 'Failed to upload product image(s).');
   }
+  return (await res.json()) as Product;
+}
 
+/** Delete a single image from a product by its blob name. Returns updated product. */
+export async function deleteProductImage(productId: number, blobName: string): Promise<Product> {
+  const res = await fetch(apiUrl(`/products/${productId}/images/${encodeURIComponent(blobName)}`), {
+    method: 'DELETE',
+    headers: authHeaders(),
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.detail || 'Failed to delete product image.');
+  }
   return (await res.json()) as Product;
 }

--- a/frontend/src/components/campaigns/CreateCampaignModal.tsx
+++ b/frontend/src/components/campaigns/CreateCampaignModal.tsx
@@ -73,8 +73,8 @@ function ProductSelector({
       <div>
         <label className={labelClass}>Product <span className="text-red-500">*</span></label>
         <div className="flex items-center gap-2 px-3 py-2 bg-blue-600/10 border border-blue-600/20 rounded-lg">
-          {selectedProduct.image_url ? (
-            <img src={selectedProduct.image_url} alt={selectedProduct.name} className="w-8 h-8 rounded-lg object-cover flex-shrink-0" />
+          {selectedProduct.image_urls[0] ? (
+            <img src={selectedProduct.image_urls[0]} alt={selectedProduct.name} className="w-8 h-8 rounded-lg object-cover flex-shrink-0" />
           ) : (
             <div className="w-8 h-8 rounded-lg bg-muted flex items-center justify-center flex-shrink-0">
               <ImageIcon className="w-4 h-4 text-muted-foreground" />
@@ -138,8 +138,8 @@ function ProductSelector({
               onClick={() => { onSelect(product); setQuery(''); setIsOpen(false); }}
               className="w-full flex items-center gap-3 px-4 py-2.5 hover:bg-muted transition-colors text-left"
             >
-              {product.image_url ? (
-                <img src={product.image_url} alt={product.name} className="w-8 h-8 rounded-lg object-cover flex-shrink-0" />
+              {product.image_urls[0] ? (
+                <img src={product.image_urls[0]} alt={product.name} className="w-8 h-8 rounded-lg object-cover flex-shrink-0" />
               ) : (
                 <div className="w-8 h-8 rounded-lg bg-muted flex items-center justify-center flex-shrink-0">
                   <ImageIcon className="w-4 h-4 text-muted-foreground" />

--- a/frontend/src/hooks/useProducts.ts
+++ b/frontend/src/hooks/useProducts.ts
@@ -4,13 +4,13 @@ import {
   createProduct,
   updateProduct,
   deleteProduct,
-  uploadProductImage,
+  uploadProductImages,
+  deleteProductImage,
 } from '../api/products';
 import type { CreateProductPayload, UpdateProductPayload } from '../types';
 
 export const PRODUCTS_KEY = ['products'] as const;
 
-/** Fetch all products for a business client. */
 export function useProducts(businessClientId: number | undefined) {
   return useQuery({
     queryKey: [...PRODUCTS_KEY, businessClientId],
@@ -20,48 +20,47 @@ export function useProducts(businessClientId: number | undefined) {
   });
 }
 
-/** Create a new product. Invalidates the products list on success. */
 export function useCreateProduct() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (data: CreateProductPayload) => createProduct(data),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: PRODUCTS_KEY });
-    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: PRODUCTS_KEY }),
   });
 }
 
-/** Update an existing product. Invalidates the products list on success. */
 export function useUpdateProduct() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: ({ productId, data }: { productId: number; data: UpdateProductPayload }) =>
       updateProduct(productId, data),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: PRODUCTS_KEY });
-    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: PRODUCTS_KEY }),
   });
 }
 
-/** Delete a product. Invalidates the products list on success. */
 export function useDeleteProduct() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (productId: number) => deleteProduct(productId),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: PRODUCTS_KEY });
-    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: PRODUCTS_KEY }),
   });
 }
 
-/** Upload or replace a product image. Invalidates the products list on success. */
-export function useUploadProductImage() {
+/** Upload one or more images for a product. Appends to existing list (max 5 total). */
+export function useUploadProductImages() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: ({ productId, file }: { productId: number; file: File }) =>
-      uploadProductImage(productId, file),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: PRODUCTS_KEY });
-    },
+    mutationFn: ({ productId, files }: { productId: number; files: File[] }) =>
+      uploadProductImages(productId, files),
+    onSuccess: () => qc.invalidateQueries({ queryKey: PRODUCTS_KEY }),
+  });
+}
+
+/** Delete a single image from a product by blob name. */
+export function useDeleteProductImage() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ productId, blobName }: { productId: number; blobName: string }) =>
+      deleteProductImage(productId, blobName),
+    onSuccess: () => qc.invalidateQueries({ queryKey: PRODUCTS_KEY }),
   });
 }

--- a/frontend/src/pages/CampaignDetailPage.tsx
+++ b/frontend/src/pages/CampaignDetailPage.tsx
@@ -84,9 +84,9 @@ function AttachedProducts({ products }: { products: Product[] }) {
       {products.map((product) => (
         <Card key={product.id} padding="md">
           <div className="flex items-start gap-3">
-            {product.image_url ? (
+            {product.image_urls[0] ? (
               <img
-                src={product.image_url}
+                src={product.image_urls[0]}
                 alt={product.name}
                 className="w-12 h-12 rounded-lg object-cover flex-shrink-0"
               />

--- a/frontend/src/pages/ProductsPage.tsx
+++ b/frontend/src/pages/ProductsPage.tsx
@@ -11,6 +11,8 @@ import {
   TrashIcon,
   UploadIcon,
   ExternalLinkIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
   Sun,
   Moon,
 } from 'lucide-react';
@@ -22,39 +24,89 @@ import {
   useProducts,
   useCreateProduct,
   useDeleteProduct,
-  useUploadProductImage,
+  useUploadProductImages,
+  useDeleteProductImage,
 } from '../hooks/useProducts';
 import type { Product } from '../types';
 
+const MAX_IMAGES = 5;
 const inputClass = 'w-full px-3 py-2 bg-background border border-border rounded-lg text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-foreground/20 disabled:opacity-50';
 const labelClass = 'block text-sm font-medium mb-1.5';
 
 // ---------- Product Card ----------
 
-function ProductCard({ product, onDelete, onUploadImage }: {
+function ProductCard({ product, onUploadImages, onDeleteImage, onDelete }: {
   product: Product;
+  onUploadImages: (p: Product) => void;
+  onDeleteImage: (p: Product, blobName: string) => void;
   onDelete: (p: Product) => void;
-  onUploadImage: (p: Product) => void;
 }) {
+  const [imgIdx, setImgIdx] = useState(0);
+  const hasImages = product.image_urls.length > 0;
+  const currentUrl = hasImages ? product.image_urls[Math.min(imgIdx, product.image_urls.length - 1)] : null;
+  const currentBlob = hasImages ? product.image_names[Math.min(imgIdx, product.image_names.length - 1)] : null;
+  const canAddMore = product.image_urls.length < MAX_IMAGES;
+
+  const prev = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setImgIdx((i) => (i - 1 + product.image_urls.length) % product.image_urls.length);
+  };
+  const next = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setImgIdx((i) => (i + 1) % product.image_urls.length);
+  };
+
   return (
     <div className="bg-card border border-border rounded-xl overflow-hidden group hover:border-foreground/20 transition-colors">
       {/* Image area */}
       <div className="h-40 bg-muted flex items-center justify-center relative">
-        {product.image_url ? (
-          <img src={product.image_url} alt={product.name} className="w-full h-full object-cover" />
+        {currentUrl ? (
+          <img src={currentUrl} alt={product.name} className="w-full h-full object-cover" />
         ) : (
           <div className="flex flex-col items-center gap-2 text-muted-foreground">
             <ImageIcon className="w-7 h-7" />
             <span className="text-xs">No image</span>
           </div>
         )}
-        <button
-          onClick={() => onUploadImage(product)}
-          className="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center gap-2 text-white text-sm font-medium"
-        >
-          <UploadIcon className="w-4 h-4" />
-          {product.image_url ? 'Replace Image' : 'Upload Image'}
-        </button>
+
+        {/* Delete current image — top-right, z-20 */}
+        {currentBlob && (
+          <button
+            onClick={(e) => { e.stopPropagation(); onDeleteImage(product, currentBlob); }}
+            className="absolute top-2 right-2 z-20 p-1 rounded-full bg-black/60 text-white opacity-0 group-hover:opacity-100 transition-opacity hover:bg-red-500/80"
+            title="Remove this image"
+          >
+            <XIcon className="w-3 h-3" />
+          </button>
+        )}
+
+        {/* Upload button — small corner button, never blocks carousel */}
+        {canAddMore && (
+          <button
+            onClick={() => onUploadImages(product)}
+            className="absolute top-2 left-2 z-10 flex items-center gap-1 px-2 py-1 rounded-md bg-black/60 text-white text-xs font-medium opacity-0 group-hover:opacity-100 transition-opacity hover:bg-black/80"
+          >
+            <UploadIcon className="w-3 h-3" />
+            {hasImages ? 'Add' : 'Upload'}
+          </button>
+        )}
+
+        {/* Carousel controls — only when >1 image, z-20 to sit above upload button */}
+        {product.image_urls.length > 1 && (
+          <>
+            <button onClick={prev} className="absolute left-1 top-1/2 -translate-y-1/2 z-20 p-1 rounded-full bg-black/50 text-white opacity-0 group-hover:opacity-100 transition-opacity hover:bg-black/80">
+              <ChevronLeftIcon className="w-3.5 h-3.5" />
+            </button>
+            <button onClick={next} className="absolute right-1 top-1/2 -translate-y-1/2 z-20 p-1 rounded-full bg-black/50 text-white opacity-0 group-hover:opacity-100 transition-opacity hover:bg-black/80">
+              <ChevronRightIcon className="w-3.5 h-3.5" />
+            </button>
+            <div className="absolute bottom-1.5 left-1/2 -translate-x-1/2 z-10 flex gap-1 pointer-events-none">
+              {product.image_urls.map((_, i) => (
+                <div key={i} className={`w-1.5 h-1.5 rounded-full ${i === imgIdx ? 'bg-white' : 'bg-white/40'}`} />
+              ))}
+            </div>
+          </>
+        )}
       </div>
 
       {/* Info */}
@@ -66,9 +118,9 @@ function ProductCard({ product, onDelete, onUploadImage }: {
               <p className="text-xs text-muted-foreground mt-0.5 line-clamp-2">{product.description}</p>
             )}
           </div>
-          {product.image_url && (
+          {hasImages && (
             <span className="flex-shrink-0 px-1.5 py-0.5 bg-emerald-500/10 text-emerald-500 text-[10px] font-medium rounded">
-              Image
+              {product.image_urls.length} image{product.image_urls.length > 1 ? 's' : ''}
             </span>
           )}
         </div>
@@ -86,13 +138,18 @@ function ProductCard({ product, onDelete, onUploadImage }: {
         )}
 
         <div className="flex items-center gap-2 mt-3 pt-3 border-t border-border">
-          <button
-            onClick={() => onUploadImage(product)}
-            className="flex items-center gap-1 px-2 py-1 text-xs text-muted-foreground hover:text-foreground hover:bg-muted rounded-lg transition-colors"
-          >
-            <ImageIcon className="w-3 h-3" />
-            {product.image_url ? 'Replace' : 'Add'} Image
-          </button>
+          {canAddMore && (
+            <button
+              onClick={() => onUploadImages(product)}
+              className="flex items-center gap-1 px-2 py-1 text-xs text-muted-foreground hover:text-foreground hover:bg-muted rounded-lg transition-colors"
+            >
+              <ImageIcon className="w-3 h-3" />
+              {hasImages ? 'Add' : 'Upload'} Image
+            </button>
+          )}
+          {!canAddMore && (
+            <span className="text-xs text-muted-foreground px-2 py-1">Max images reached</span>
+          )}
           <div className="flex-1" />
           <button
             onClick={() => onDelete(product)}
@@ -152,7 +209,7 @@ function CreateProductModal({ onClose }: { onClose: () => void }) {
             <input className={inputClass} placeholder="https://example.com/product" value={form.product_link} onChange={(e) => setForm({ ...form, product_link: e.target.value })} disabled={isCreating} />
           </div>
 
-          <p className="text-xs text-muted-foreground">You can upload a product image after creating the product.</p>
+          <p className="text-xs text-muted-foreground">You can upload up to {MAX_IMAGES} product images after creating the product.</p>
         </div>
 
         {createMutation.isError && (
@@ -162,9 +219,7 @@ function CreateProductModal({ onClose }: { onClose: () => void }) {
         )}
 
         <div className="flex items-center justify-end gap-3 px-6 py-4 border-t border-border">
-          <button onClick={onClose} disabled={isCreating} className="px-4 py-2 text-sm text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50">
-            Cancel
-          </button>
+          <button onClick={onClose} disabled={isCreating} className="px-4 py-2 text-sm text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50">Cancel</button>
           <button
             onClick={handleCreate}
             disabled={isCreating}
@@ -195,9 +250,7 @@ function DeleteProductModal({ product, onClose, onConfirm, isLoading }: {
           Are you sure you want to delete <span className="font-medium text-foreground">{product.name}</span>? This action cannot be undone.
         </p>
         <div className="flex justify-end gap-3">
-          <button onClick={onClose} disabled={isLoading} className="px-4 py-2 text-sm text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50">
-            Cancel
-          </button>
+          <button onClick={onClose} disabled={isLoading} className="px-4 py-2 text-sm text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50">Cancel</button>
           <button
             onClick={onConfirm}
             disabled={isLoading}
@@ -222,7 +275,8 @@ export function ProductsPage() {
 
   const { data: products = [], isLoading, isError, error } = useProducts(businessClientId);
   const deleteMutation = useDeleteProduct();
-  const uploadMutation = useUploadProductImage();
+  const uploadMutation = useUploadProductImages();
+  const deleteImageMutation = useDeleteProductImage();
 
   const [searchQuery, setSearchQuery] = useState('');
   const [showCreateModal, setShowCreateModal] = useState(false);
@@ -230,23 +284,28 @@ export function ProductsPage() {
 
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [uploadTargetProduct, setUploadTargetProduct] = useState<Product | null>(null);
-const filteredProducts = products.filter((p) =>
+
+  const filteredProducts = products.filter((p) =>
     p.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
     (p.description ?? '').toLowerCase().includes(searchQuery.toLowerCase()),
   );
 
-  const handleUploadImage = (product: Product) => {
+  const handleUploadImages = (product: Product) => {
     setUploadTargetProduct(product);
     fileInputRef.current?.click();
   };
 
-  const handleFileSelected = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file || !uploadTargetProduct) return;
+  const handleFilesSelected = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files ?? []);
+    if (!files.length || !uploadTargetProduct) return;
     uploadMutation.mutate(
-      { productId: uploadTargetProduct.id, file },
+      { productId: uploadTargetProduct.id, files },
       { onSettled: () => { setUploadTargetProduct(null); if (fileInputRef.current) fileInputRef.current.value = ''; } },
     );
+  };
+
+  const handleDeleteImage = (product: Product, blobName: string) => {
+    deleteImageMutation.mutate({ productId: product.id, blobName });
   };
 
   const handleConfirmDelete = () => {
@@ -295,19 +354,17 @@ const filteredProducts = products.filter((p) =>
         {uploadMutation.isPending && (
           <div className="mb-4 flex items-center gap-2 bg-blue-600/10 border border-blue-600/20 rounded-lg px-4 py-3 text-sm text-blue-500">
             <Loader2Icon className="w-4 h-4 animate-spin" />
-            Uploading image for {uploadTargetProduct?.name}...
+            Uploading image(s) for {uploadTargetProduct?.name}...
           </div>
         )}
 
-        {/* Loading */}
+        {/* Loading / Error / Empty states */}
         {isLoading && (
           <div className="flex flex-col items-center justify-center py-24 text-muted-foreground">
             <Loader2Icon className="w-6 h-6 animate-spin mb-3" />
             <p className="text-sm">Loading products...</p>
           </div>
         )}
-
-        {/* Error */}
         {isError && (
           <div className="flex flex-col items-center justify-center py-24 text-center">
             <AlertCircleIcon className="w-8 h-8 text-red-500 mb-3" />
@@ -315,15 +372,11 @@ const filteredProducts = products.filter((p) =>
             <p className="text-sm text-muted-foreground">{(error as Error).message}</p>
           </div>
         )}
-
-        {/* Empty state */}
         {!isLoading && !isError && products.length === 0 && (
           <div className="flex flex-col items-center justify-center py-24 text-center">
             <PackageIcon className="w-8 h-8 text-muted-foreground mb-4" />
             <h2 className="text-base font-semibold mb-1">No products yet</h2>
-            <p className="text-sm text-muted-foreground mb-6 max-w-xs">
-              Add your first product to start creating campaigns and generating ads.
-            </p>
+            <p className="text-sm text-muted-foreground mb-6 max-w-xs">Add your first product to start creating campaigns and generating ads.</p>
             <button
               onClick={() => setShowCreateModal(true)}
               className="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 transition-colors"
@@ -333,8 +386,6 @@ const filteredProducts = products.filter((p) =>
             </button>
           </div>
         )}
-
-        {/* No search results */}
         {!isLoading && !isError && products.length > 0 && filteredProducts.length === 0 && (
           <div className="flex flex-col items-center justify-center py-24 text-center">
             <SearchIcon className="w-8 h-8 text-muted-foreground mb-3" />
@@ -347,13 +398,26 @@ const filteredProducts = products.filter((p) =>
         {!isLoading && !isError && filteredProducts.length > 0 && (
           <div className="grid grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
             {filteredProducts.map((product) => (
-              <ProductCard key={product.id} product={product} onDelete={setProductToDelete} onUploadImage={handleUploadImage} />
+              <ProductCard
+                key={product.id}
+                product={product}
+                onUploadImages={handleUploadImages}
+                onDeleteImage={handleDeleteImage}
+                onDelete={setProductToDelete}
+              />
             ))}
           </div>
         )}
 
-        {/* Hidden file input */}
-        <input ref={fileInputRef} type="file" accept="image/jpeg,image/png,image/webp,image/gif" className="hidden" onChange={handleFileSelected} />
+        {/* Hidden file input — multiple allowed, capped by remaining slots on backend */}
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/jpeg,image/png,image/webp,image/gif"
+          multiple
+          className="hidden"
+          onChange={handleFilesSelected}
+        />
 
         {/* Modals */}
         {showCreateModal && <CreateProductModal onClose={() => setShowCreateModal(false)} />}

--- a/frontend/src/types/product.ts
+++ b/frontend/src/types/product.ts
@@ -4,8 +4,8 @@ export interface Product {
     business_client_id: number;
     name: string;
     description: string | null;
-    image_url: string | null;
-    image_name: string | null;
+    image_urls: string[];     // list of SAS-signed URLs (may be empty)
+    image_names: string[];    // parallel list of blob names (used for deletion)
     product_link: string | null;
     product_metadata: string | null;
     is_active: boolean | null;
@@ -13,7 +13,7 @@ export interface Product {
     updated_at: string | null;
 }
 
-/** Payload for POST /products (JSON body — image uploaded separately via multipart) */
+/** Payload for POST /products (JSON body — images uploaded separately via multipart) */
 export interface CreateProductPayload {
     name: string;
     description?: string | null;


### PR DESCRIPTION
- Backend: upload endpoint accepts list of files and appends to existing
  images; new DELETE /{product_id}/images/{blob_name} endpoint removes
  individual images; image_url/image_name columns now store JSON arrays
  with backwards-compatible parsing for legacy plain-URL rows
- Schemas: ProductResponse exposes image_urls/image_names as list[str]
  with field validators handling legacy data; ProductCreate no longer
  accepts image fields (upload endpoint owns that)
- Frontend: ProductCard shows image carousel with prev/next chevrons,
  dot indicators, per-image delete (X), and add-image button; all
  product.image_url references updated to image_urls[0] or image_urls[]
- Tests: updated product test fixtures and assertions for new field names