### PR TITLE
Campaigns: live list data, filters, and analytics empty state

### DIFF
--- a/.github/workflows/frontend-build.yaml
+++ b/.github/workflows/frontend-build.yaml
@@ -24,6 +24,10 @@ jobs:
         run: npm ci
         working-directory: frontend
 
+      - name: Unit tests
+        run: npm run test
+        working-directory: frontend
+
       - name: Build
         run: npm run build
         working-directory: frontend

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__/
 .pytest_cache/
 .env/
 backend/.venv
+exec-plans/

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "backend",
+      "version": "1.0.0",
+      "license": "ISC"
+    }
+  }
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -30,7 +30,8 @@
         "tailwindcss": "3.4.17",
         "typescript": "^5.5.4",
         "typescript-eslint": "^8.55.0",
-        "vite": "^5.2.0"
+        "vite": "^5.2.0",
+        "vitest": "^3.0.5"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1569,6 +1570,24 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1930,6 +1949,121 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -2159,6 +2293,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -2325,6 +2469,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -2415,6 +2569,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2430,6 +2601,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -2632,6 +2813,16 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-is": {
@@ -2851,6 +3042,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -3197,6 +3395,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3205,6 +3413,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -4326,6 +4544,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4343,6 +4568,16 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/math-intrinsics": {
@@ -4721,6 +4956,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
@@ -5468,6 +5720,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -5486,6 +5745,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -5612,6 +5885,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stylis": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
@@ -5727,6 +6020,20 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -5773,6 +6080,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -6071,6 +6408,115 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -6174,6 +6620,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "npx vite",
     "build": "npx vite build",
     "lint": "eslint .",
-    "preview": "npx vite preview"
+    "preview": "npx vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@emotion/react": "^11.13.3",
@@ -32,6 +33,7 @@
     "tailwindcss": "3.4.17",
     "typescript": "^5.5.4",
     "typescript-eslint": "^8.55.0",
-    "vite": "^5.2.0"
+    "vite": "^5.2.0",
+    "vitest": "^3.0.5"
   }
 }

--- a/frontend/src/components/campaigns/CampaignGridCard.tsx
+++ b/frontend/src/components/campaigns/CampaignGridCard.tsx
@@ -1,19 +1,7 @@
 import { Link } from 'react-router-dom';
+import type { CampaignListItem } from '../../lib/campaignsList';
 
-// ---------- Types ----------
-
-export interface CampaignItem {
-  id: string;
-  name: string;
-  product: string;
-  status: 'active' | 'completed' | 'draft' | 'paused';
-  reach: string;
-  engagement: string;
-  platform: string;
-  objective: string;
-  dateCreated: string;
-  thumbnail?: string;
-}
+export type CampaignItem = CampaignListItem;
 
 const statusStyles = {
   active: 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
@@ -75,15 +63,13 @@ export function CampaignGridCard({ campaign, isSelected, onToggleSelection }: Ca
                 </span>
               </div>
               <div className="mt-auto flex items-center gap-4 pt-3 border-t border-border">
-                <div>
-                  <p className="text-sm font-medium">{campaign.reach}</p>
-                  <p className="text-xs text-muted-foreground">Reach</p>
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm font-medium truncate" title={campaign.objective}>
+                    {campaign.objective}
+                  </p>
+                  <p className="text-xs text-muted-foreground">Goal</p>
                 </div>
-                <div>
-                  <p className="text-sm font-medium">{campaign.engagement}</p>
-                  <p className="text-xs text-muted-foreground">Eng.</p>
-                </div>
-                <div className="ml-auto text-xs text-muted-foreground">{campaign.dateCreated}</div>
+                <div className="flex-shrink-0 text-xs text-muted-foreground">{campaign.dateCreated}</div>
               </div>
             </div>
           </div>

--- a/frontend/src/components/campaigns/CampaignSettings.tsx
+++ b/frontend/src/components/campaigns/CampaignSettings.tsx
@@ -3,16 +3,7 @@ import { Card } from '../ui/Card';
 import { Input } from '../ui/Input';
 import { Button } from '../ui/Button';
 import { CheckIcon, Loader2Icon } from 'lucide-react';
-
-// ---------- Constants ----------
-
-const settingsPlatforms = [
-  { id: 'meta', label: 'Meta (Facebook/Instagram)' },
-  { id: 'tiktok', label: 'TikTok' },
-  { id: 'youtube', label: 'YouTube' },
-  { id: 'linkedin', label: 'LinkedIn' },
-  { id: 'google', label: 'Google Ads' },
-];
+import { CAMPAIGN_PLATFORM_OPTIONS } from '../../constants/campaigns';
 
 // ---------- Types ----------
 
@@ -89,7 +80,7 @@ export function CampaignSettings({ initial, onSave, isSaving = false, error = nu
             Target Platforms
           </label>
           <div className="flex flex-wrap gap-2">
-            {settingsPlatforms.map((platform) => (
+            {CAMPAIGN_PLATFORM_OPTIONS.map((platform) => (
               <button
                 key={platform.id}
                 type="button"

--- a/frontend/src/components/campaigns/CampaignTable.tsx
+++ b/frontend/src/components/campaigns/CampaignTable.tsx
@@ -36,8 +36,7 @@ export function CampaignTable({ campaigns, selectedCampaigns, onToggleSelection,
             <th className="px-4 py-3 text-xs font-semibold text-muted-foreground uppercase tracking-wide">Name</th>
             <th className="px-4 py-3 text-xs font-semibold text-muted-foreground uppercase tracking-wide">Status</th>
             <th className="px-4 py-3 text-xs font-semibold text-muted-foreground uppercase tracking-wide">Product</th>
-            <th className="px-4 py-3 text-xs font-semibold text-muted-foreground uppercase tracking-wide">Reach</th>
-            <th className="px-4 py-3 text-xs font-semibold text-muted-foreground uppercase tracking-wide">Engagement</th>
+            <th className="px-4 py-3 text-xs font-semibold text-muted-foreground uppercase tracking-wide">Goal</th>
             <th className="px-4 py-3 text-xs font-semibold text-muted-foreground uppercase tracking-wide">Created</th>
             <th className="px-4 py-3 text-xs font-semibold text-muted-foreground uppercase tracking-wide text-right">Actions</th>
           </tr>
@@ -67,8 +66,9 @@ export function CampaignTable({ campaigns, selectedCampaigns, onToggleSelection,
                 </span>
               </td>
               <td className="px-4 py-3 text-muted-foreground">{campaign.product}</td>
-              <td className="px-4 py-3 font-medium">{campaign.reach}</td>
-              <td className="px-4 py-3 font-medium">{campaign.engagement}</td>
+              <td className="px-4 py-3 text-muted-foreground max-w-[12rem] truncate" title={campaign.objective}>
+                {campaign.objective}
+              </td>
               <td className="px-4 py-3 text-muted-foreground">{campaign.dateCreated}</td>
               <td className="px-4 py-3 text-right">
                 <div className="flex items-center justify-end gap-2">

--- a/frontend/src/components/campaigns/CreateCampaignModal.tsx
+++ b/frontend/src/components/campaigns/CreateCampaignModal.tsx
@@ -12,15 +12,7 @@ import {
 import { useCreateCampaign } from '../../hooks/useCampaigns';
 import { useProducts } from '../../hooks/useProducts';
 import type { Product } from '../../types';
-
-const platforms = [
-  { id: 'instagram', label: 'Instagram' },
-  { id: 'facebook', label: 'Facebook' },
-  { id: 'tiktok', label: 'TikTok' },
-  { id: 'youtube', label: 'YouTube' },
-  { id: 'linkedin', label: 'LinkedIn' },
-  { id: 'X', label: 'Twitter' },
-];
+import { CAMPAIGN_PLATFORM_OPTIONS } from '../../constants/campaigns';
 
 const regions = [
   { id: 'na', label: 'North America' },
@@ -162,6 +154,7 @@ function ProductSelector({
 // ---------- Main Modal ----------
 
 interface CreateCampaignModalProps {
+  /** Positive business client id; parent must not render the modal until this is set. */
   businessClientId: number;
   onClose: () => void;
 }
@@ -195,7 +188,13 @@ export function CreateCampaignModal({ businessClientId, onClose }: CreateCampaig
   const handleAutofill = () => {
     setIsAutofilling(true);
     setTimeout(() => {
-      setNewCampaign({ ...newCampaign, platforms: ['instagram', 'tiktok'], region: 'na', goal: 'sales', targetAudience: 'Tech-savvy millennials interested in productivity tools.' });
+      setNewCampaign({
+        ...newCampaign,
+        platforms: ['instagram', 'tiktok'],
+        region: 'na',
+        goal: 'sales',
+        targetAudience: 'Tech-savvy millennials interested in productivity tools (sample text for local testing).',
+      });
       setIsAutofilling(false);
     }, 1500);
   };
@@ -233,17 +232,24 @@ export function CreateCampaignModal({ businessClientId, onClose }: CreateCampaig
         </div>
 
         <div className="p-6 space-y-4">
-          <button
-            onClick={handleAutofill}
-            disabled={isAutofilling || isCreating}
-            className="w-full flex items-center justify-center gap-2 px-4 py-2.5 border border-border rounded-lg text-sm hover:bg-muted transition-colors disabled:opacity-50"
-          >
-            {isAutofilling ? (
-              <><Loader2Icon className="w-4 h-4 animate-spin text-muted-foreground" /> Auto-filling...</>
-            ) : (
-              <><SparklesIcon className="w-4 h-4 text-blue-600" /> Auto-fill from profile</>
-            )}
-          </button>
+          {import.meta.env.DEV && (
+            <button
+              type="button"
+              onClick={handleAutofill}
+              disabled={isAutofilling || isCreating}
+              className="w-full flex items-center justify-center gap-2 px-4 py-2.5 border border-dashed border-border rounded-lg text-sm hover:bg-muted transition-colors disabled:opacity-50 text-muted-foreground"
+            >
+              {isAutofilling ? (
+                <>
+                  <Loader2Icon className="w-4 h-4 animate-spin text-muted-foreground" /> Filling sample data...
+                </>
+              ) : (
+                <>
+                  <SparklesIcon className="w-4 h-4 text-blue-600" /> Fill with sample data (dev only)
+                </>
+              )}
+            </button>
+          )}
 
           <div>
             <label className={labelClass}>Campaign Name <span className="text-red-500">*</span></label>
@@ -307,7 +313,7 @@ export function CreateCampaignModal({ businessClientId, onClose }: CreateCampaig
           <div>
             <label className={labelClass}>Target Platforms</label>
             <div className="flex flex-wrap gap-2">
-              {platforms.map((platform) => (
+              {CAMPAIGN_PLATFORM_OPTIONS.map((platform) => (
                 <button
                   key={platform.id}
                   type="button"

--- a/frontend/src/components/campaigns/CreateCampaignModal.tsx
+++ b/frontend/src/components/campaigns/CreateCampaignModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useCallback } from 'react';
 import {
   XIcon,
   CheckIcon,
@@ -161,6 +161,7 @@ interface CreateCampaignModalProps {
 
 export function CreateCampaignModal({ businessClientId, onClose }: CreateCampaignModalProps) {
   const createMutation = useCreateCampaign();
+  const autofillTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const [isAutofilling, setIsAutofilling] = useState(false);
   const [customGoal, setCustomGoal] = useState('');
@@ -176,6 +177,15 @@ export function CreateCampaignModal({ businessClientId, onClose }: CreateCampaig
 
   const isCreating = createMutation.isPending;
 
+  useEffect(() => {
+    return () => {
+      if (autofillTimeoutRef.current !== null) {
+        clearTimeout(autofillTimeoutRef.current);
+        autofillTimeoutRef.current = null;
+      }
+    };
+  }, []);
+
   const togglePlatform = (platformId: string) => {
     setNewCampaign({
       ...newCampaign,
@@ -185,19 +195,24 @@ export function CreateCampaignModal({ businessClientId, onClose }: CreateCampaig
     });
   };
 
-  const handleAutofill = () => {
+  const handleAutofill = useCallback(() => {
+    if (autofillTimeoutRef.current !== null) {
+      clearTimeout(autofillTimeoutRef.current);
+      autofillTimeoutRef.current = null;
+    }
     setIsAutofilling(true);
-    setTimeout(() => {
-      setNewCampaign({
-        ...newCampaign,
+    autofillTimeoutRef.current = setTimeout(() => {
+      autofillTimeoutRef.current = null;
+      setNewCampaign((prev) => ({
+        ...prev,
         platforms: ['instagram', 'tiktok'],
         region: 'na',
         goal: 'sales',
         targetAudience: 'Tech-savvy millennials interested in productivity tools (sample text for local testing).',
-      });
+      }));
       setIsAutofilling(false);
     }, 1500);
-  };
+  }, []);
 
   const handleCreateCampaign = () => {
     const newErrors: Record<string, string> = {};

--- a/frontend/src/constants/campaigns.ts
+++ b/frontend/src/constants/campaigns.ts
@@ -1,0 +1,15 @@
+/** Canonical platform IDs for create/settings flows (list API does not expose per-campaign platforms yet). */
+export interface CampaignPlatformOption {
+  id: string;
+  label: string;
+}
+
+export const CAMPAIGN_PLATFORM_OPTIONS: readonly CampaignPlatformOption[] = [
+  { id: 'instagram', label: 'Instagram' },
+  { id: 'facebook', label: 'Facebook' },
+  { id: 'tiktok', label: 'TikTok' },
+  { id: 'youtube', label: 'YouTube' },
+  { id: 'linkedin', label: 'LinkedIn' },
+  { id: 'twitter', label: 'X (Twitter)' },
+  { id: 'google', label: 'Google Ads' },
+];

--- a/frontend/src/lib/campaignHeroIcon.test.ts
+++ b/frontend/src/lib/campaignHeroIcon.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeCampaignHeroIcon, getHeroIconStyles, HERO_ICON_STYLES } from './campaignHeroIcon';
+
+describe('normalizeCampaignHeroIcon', () => {
+  it('preserves known icon strings', () => {
+    expect(normalizeCampaignHeroIcon('users')).toBe('users');
+    expect(normalizeCampaignHeroIcon('globe')).toBe('globe');
+  });
+
+  it('falls back to chart for unknown or invalid values', () => {
+    expect(normalizeCampaignHeroIcon('new_icon_from_api')).toBe('chart');
+    expect(normalizeCampaignHeroIcon('')).toBe('chart');
+    expect(normalizeCampaignHeroIcon(null)).toBe('chart');
+    expect(normalizeCampaignHeroIcon(undefined)).toBe('chart');
+    expect(normalizeCampaignHeroIcon(1)).toBe('chart');
+  });
+});
+
+describe('getHeroIconStyles', () => {
+  it('returns stable styles for any input', () => {
+    expect(getHeroIconStyles('not_a_real_icon').wrap).toBe(HERO_ICON_STYLES.chart.wrap);
+    expect(getHeroIconStyles('not_a_real_icon').iconClass).toBe(HERO_ICON_STYLES.chart.iconClass);
+  });
+});

--- a/frontend/src/lib/campaignHeroIcon.ts
+++ b/frontend/src/lib/campaignHeroIcon.ts
@@ -1,0 +1,21 @@
+import type { CampaignHeroIcon } from '../types';
+
+export const HERO_ICON_STYLES: Record<CampaignHeroIcon, { wrap: string; iconClass: string }> = {
+  users: { wrap: 'bg-blue-100', iconClass: 'w-5 h-5 text-blue-600' },
+  pointer: { wrap: 'bg-purple-100', iconClass: 'w-5 h-5 text-purple-600' },
+  chart: { wrap: 'bg-emerald-100', iconClass: 'w-5 h-5 text-emerald-600' },
+  globe: { wrap: 'bg-amber-100', iconClass: 'w-5 h-5 text-amber-600' },
+};
+
+const KNOWN_HERO_ICONS = new Set(Object.keys(HERO_ICON_STYLES) as CampaignHeroIcon[]);
+
+/** API payloads are not validated at runtime; coerce unknown icon strings to a safe default. */
+export function normalizeCampaignHeroIcon(icon: unknown): CampaignHeroIcon {
+  return typeof icon === 'string' && KNOWN_HERO_ICONS.has(icon as CampaignHeroIcon)
+    ? (icon as CampaignHeroIcon)
+    : 'chart';
+}
+
+export function getHeroIconStyles(icon: unknown) {
+  return HERO_ICON_STYLES[normalizeCampaignHeroIcon(icon)];
+}

--- a/frontend/src/lib/campaignsList.test.ts
+++ b/frontend/src/lib/campaignsList.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseProductContext,
+  campaignToItem,
+  distinctGoalsFromCampaigns,
+  matchesDateRangePreset,
+  filterCampaignsByDatePreset,
+} from './campaignsList';
+import type { Campaign } from '../types';
+
+const baseCampaign = (over: Partial<Campaign>): Campaign => ({
+  id: 1,
+  business_client_id: 10,
+  name: 'Test',
+  status: 'draft',
+  budget_total: null,
+  start_date: null,
+  end_date: null,
+  goal: null,
+  target_audience: null,
+  product_context: null,
+  created_at: '2026-01-15T12:00:00.000Z',
+  updated_at: '2026-01-15T12:00:00.000Z',
+  product_ids: null,
+  brief: null,
+  ...over,
+});
+
+describe('parseProductContext', () => {
+  it('returns em dash for empty input', () => {
+    expect(parseProductContext(null)).toBe('—');
+    expect(parseProductContext(undefined)).toBe('—');
+    expect(parseProductContext('')).toBe('—');
+  });
+
+  it('parses JSON object with text', () => {
+    expect(parseProductContext('{"text":"Widget"}')).toBe('Widget');
+  });
+
+  it('returns raw string when JSON is invalid', () => {
+    expect(parseProductContext('plain')).toBe('plain');
+  });
+});
+
+describe('campaignToItem', () => {
+  it('maps API fields and uses dash for missing goal', () => {
+    const item = campaignToItem(
+      baseCampaign({ id: 42, name: 'N', goal: null, created_at: '2026-03-01T00:00:00.000Z' }),
+      'en-US',
+    );
+    expect(item.id).toBe('42');
+    expect(item.name).toBe('N');
+    expect(item.objective).toBe('—');
+    expect(item.dateCreated).toMatch(/2026/);
+  });
+
+  it('trims goal', () => {
+    const item = campaignToItem(baseCampaign({ goal: '  leads  ' }), 'en-US');
+    expect(item.objective).toBe('leads');
+  });
+});
+
+describe('distinctGoalsFromCampaigns', () => {
+  it('returns sorted unique goals', () => {
+    const goals = distinctGoalsFromCampaigns([
+      baseCampaign({ id: 1, goal: 'z' }),
+      baseCampaign({ id: 2, goal: 'a' }),
+      baseCampaign({ id: 3, goal: 'a' }),
+      baseCampaign({ id: 4, goal: null }),
+    ]);
+    expect(goals).toEqual(['a', 'z']);
+  });
+});
+
+describe('matchesDateRangePreset', () => {
+  it('all time matches any campaign', () => {
+    const c = baseCampaign({ created_at: '2000-01-01T00:00:00.000Z' });
+    expect(matchesDateRangePreset(c, 'all', Date.UTC(2026, 0, 1))).toBe(true);
+  });
+
+  it('30d excludes older campaigns', () => {
+    const now = Date.UTC(2026, 3, 16, 12, 0, 0);
+    const recent = baseCampaign({ created_at: new Date(now - 5 * 86400000).toISOString() });
+    const old = baseCampaign({ id: 2, created_at: new Date(now - 40 * 86400000).toISOString() });
+    expect(matchesDateRangePreset(recent, '30d', now)).toBe(true);
+    expect(matchesDateRangePreset(old, '30d', now)).toBe(false);
+  });
+});
+
+describe('filterCampaignsByDatePreset', () => {
+  it('filters list', () => {
+    const now = Date.UTC(2026, 0, 10, 0, 0, 0);
+    const a = baseCampaign({ id: 1, created_at: new Date(now - 2 * 86400000).toISOString() });
+    const b = baseCampaign({ id: 2, created_at: new Date(now - 20 * 86400000).toISOString() });
+    expect(filterCampaignsByDatePreset([a, b], '7d', now)).toEqual([a]);
+  });
+});

--- a/frontend/src/lib/campaignsList.ts
+++ b/frontend/src/lib/campaignsList.ts
@@ -1,0 +1,74 @@
+import type { Campaign } from '../types';
+
+/**
+ * product_context is stored as a JSON object {"text": "..."} in the DB
+ * (Azure SQL's ISJSON() only accepts objects/arrays, not scalar strings).
+ * Fall back gracefully for any other shape.
+ */
+export function parseProductContext(raw: string | null | undefined): string {
+  if (!raw) return '—';
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      const o = parsed as Record<string, unknown>;
+      return String(o.text ?? o.description ?? JSON.stringify(parsed));
+    }
+    if (typeof parsed === 'string') return parsed;
+    return String(parsed);
+  } catch {
+    return raw;
+  }
+}
+
+export interface CampaignListItem {
+  id: string;
+  name: string;
+  product: string;
+  status: Campaign['status'];
+  objective: string;
+  dateCreated: string;
+  thumbnail?: string;
+}
+
+export function campaignToItem(c: Campaign, dateLocale?: string | string[]): CampaignListItem {
+  return {
+    id: String(c.id),
+    name: c.name,
+    product: parseProductContext(c.product_context),
+    status: c.status,
+    objective: c.goal?.trim() || '—',
+    dateCreated: new Date(c.created_at).toLocaleDateString(dateLocale, {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    }),
+  };
+}
+
+/** Distinct non-empty goal strings from loaded campaigns (for filter checkboxes). */
+export function distinctGoalsFromCampaigns(campaigns: Campaign[]): string[] {
+  const set = new Set<string>();
+  for (const c of campaigns) {
+    const g = c.goal?.trim();
+    if (g) set.add(g);
+  }
+  return [...set].sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }));
+}
+
+export type DateRangePreset = '7d' | '30d' | '90d' | 'all';
+
+export function matchesDateRangePreset(
+  c: Campaign,
+  preset: DateRangePreset,
+  nowMs: number = Date.now(),
+): boolean {
+  if (preset === 'all') return true;
+  const created = new Date(c.created_at).getTime();
+  const days = preset === '7d' ? 7 : preset === '30d' ? 30 : 90;
+  const cutoff = nowMs - days * 24 * 60 * 60 * 1000;
+  return created >= cutoff;
+}
+
+export function filterCampaignsByDatePreset(campaigns: Campaign[], preset: DateRangePreset, nowMs?: number): Campaign[] {
+  return campaigns.filter((c) => matchesDateRangePreset(c, preset, nowMs));
+}

--- a/frontend/src/pages/CampaignDetailPage.tsx
+++ b/frontend/src/pages/CampaignDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 import { useParams, Link, useNavigate } from 'react-router-dom';
 import { Sidebar } from '../components/layout/Sidebar';
 import { useSidebar } from '../contexts/SidebarContext';
@@ -32,24 +32,118 @@ import { useCampaign, useUpdateCampaign, useDeleteCampaign } from '../hooks/useC
 import { useCampaignAdVariants } from '../hooks/useAdGeneration';
 import { useUser } from '../contexts/UserContext';
 import { useProducts } from '../hooks/useProducts';
-import type { CampaignStatus, Product } from '../types';
+import type { CampaignStatus, Product, CampaignAnalyticsSummary, CampaignHeroIcon } from '../types';
 
-// ---------- Static placeholder data (analytics not yet in API) ----------
+// ---------- Analytics helpers (live data only; empty state when API omits summary) ----------
 
-const analyticsMetrics: AnalyticsMetric[] = [
-  { label: 'Impressions', value: '342,180', change: '+14%', positive: true },
-  { label: 'Clicks', value: '14,371', change: '+22%', positive: true },
-  { label: 'CTR', value: '4.2%', change: '+0.8%', positive: true },
-  { label: 'CPC', value: '$0.86', change: '-12%', positive: true },
-  { label: 'Conversions', value: '1,240', change: '+18%', positive: true },
-  { label: 'ROAS', value: '3.4x', change: '+0.6x', positive: true },
-];
+function resolveAnalyticsSummary(campaign: { analytics_summary?: CampaignAnalyticsSummary | null }): CampaignAnalyticsSummary | null {
+  const s = campaign.analytics_summary;
+  if (!s) return null;
+  if (!Array.isArray(s.hero) || s.hero.length !== 4) return null;
+  if (!Array.isArray(s.metrics) || s.metrics.length === 0) return null;
+  if (!Array.isArray(s.personas) || s.personas.length === 0) return null;
+  return s;
+}
 
-const personaPerformance: PersonaPerf[] = [
-  { name: 'The Skeptic', convRate: '4.3%', impressions: '142K', color: 'teal' },
-  { name: 'The Impulse Buyer', convRate: '5.9%', impressions: '118K', color: 'orange' },
-  { name: 'The Researcher', convRate: '3.0%', impressions: '82K', color: 'blue' },
-];
+function heroBadgeClass(style: 'positive' | 'neutral' | 'muted'): string {
+  if (style === 'positive') {
+    return 'text-xs font-medium text-emerald-600 bg-emerald-50 px-2 py-1 rounded-full';
+  }
+  if (style === 'neutral') {
+    return 'text-xs font-medium text-muted-foreground bg-muted px-2 py-1 rounded-full';
+  }
+  return 'text-xs font-medium text-muted-foreground bg-muted/80 px-2 py-1 rounded-full';
+}
+
+const HERO_ICON_STYLES: Record<CampaignHeroIcon, { wrap: string; iconClass: string }> = {
+  users: { wrap: 'bg-blue-100', iconClass: 'w-5 h-5 text-blue-600' },
+  pointer: { wrap: 'bg-purple-100', iconClass: 'w-5 h-5 text-purple-600' },
+  chart: { wrap: 'bg-emerald-100', iconClass: 'w-5 h-5 text-emerald-600' },
+  globe: { wrap: 'bg-amber-100', iconClass: 'w-5 h-5 text-amber-600' },
+};
+
+function MousePointerClickIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <path d="m9 9 5 12 1.8-5.2L21 14Z" />
+      <path d="M7.2 2.2 8 5.1" />
+      <path d="m5.1 8-2.9-.8" />
+      <path d="M14 4.1 12 6" />
+      <path d="m6 12-1.9 2" />
+    </svg>
+  );
+}
+
+function renderHeroIcon(icon: CampaignHeroIcon) {
+  const { iconClass } = HERO_ICON_STYLES[icon];
+  switch (icon) {
+    case 'users':
+      return <UsersIcon className={iconClass} />;
+    case 'pointer':
+      return <MousePointerClickIcon className={iconClass} />;
+    case 'chart':
+      return <BarChart3Icon className={iconClass} />;
+    case 'globe':
+      return <GlobeIcon className={iconClass} />;
+  }
+}
+
+function HeroKpiGrid({ hero }: { hero: CampaignAnalyticsSummary['hero'] }) {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-6 mb-8">
+      {hero.map((kpi, index) => {
+        const wrap = HERO_ICON_STYLES[kpi.icon].wrap;
+        return (
+          <Card key={`${kpi.label}-${index}`} variant="elevated" padding="md">
+            <div className="flex items-center justify-between mb-4">
+              <div className={`p-2 rounded-lg ${wrap}`}>{renderHeroIcon(kpi.icon)}</div>
+              {kpi.badge != null ? (
+                <span className={heroBadgeClass(kpi.badgeStyle)}>{kpi.badge}</span>
+              ) : null}
+            </div>
+            <p className="text-2xl font-bold text-foreground">{kpi.value}</p>
+            <p className="text-sm text-muted-foreground">{kpi.label}</p>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}
+
+function AnalyticsEmptyState({
+  title,
+  description,
+  className = '',
+}: {
+  title: string;
+  description: ReactNode;
+  className?: string;
+}) {
+  return (
+    <Card variant="elevated" padding="lg" className={className}>
+      <div className="flex flex-col sm:flex-row items-start gap-4">
+        <div className="w-12 h-12 rounded-xl bg-muted flex items-center justify-center flex-shrink-0">
+          <BarChart3Icon className="w-6 h-6 text-muted-foreground" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <h2 className="text-lg font-semibold text-foreground">{title}</h2>
+          <div className="text-sm text-muted-foreground mt-1 space-y-2">{description}</div>
+        </div>
+      </div>
+    </Card>
+  );
+}
 
 function parseProductIds(raw: string | null): number[] {
   if (!raw) return [];
@@ -249,6 +343,7 @@ export function CampaignDetailPage() {
     .filter((p): p is Product => !!p);
   const productContextText = parseProductContext(campaign.product_context);
   const approvedVariants = campaignVariants.filter((variant) => variant.status === 'completed');
+  const analyticsSummary = resolveAnalyticsSummary(campaign);
 
   // ---------- Render ----------
 
@@ -305,60 +400,20 @@ export function CampaignDetailPage() {
           </div>
         </div>
 
-        {/* Hero Metrics — static placeholders until analytics API exists */}
-        <div className="grid grid-cols-4 gap-6 mb-8">
-          <Card variant="elevated" padding="md">
-            <div className="flex items-center justify-between mb-4">
-              <div className="p-2 bg-blue-100 rounded-lg">
-                <UsersIcon className="w-5 h-5 text-blue-600" />
-              </div>
-              <span className="text-xs font-medium text-emerald-600 bg-emerald-50 px-2 py-1 rounded-full">
-                +12%
-              </span>
-            </div>
-            <p className="text-2xl font-bold text-foreground">124.5K</p>
-            <p className="text-sm text-muted-foreground">Total Reach</p>
-          </Card>
-
-          <Card variant="elevated" padding="md">
-            <div className="flex items-center justify-between mb-4">
-              <div className="p-2 bg-purple-100 rounded-lg">
-                <MousePointerClickIcon className="w-5 h-5 text-purple-600" />
-              </div>
-              <span className="text-xs font-medium text-emerald-600 bg-emerald-50 px-2 py-1 rounded-full">
-                +5.2%
-              </span>
-            </div>
-            <p className="text-2xl font-bold text-foreground">4.2%</p>
-            <p className="text-sm text-muted-foreground">Click Rate (CTR)</p>
-          </Card>
-
-          <Card variant="elevated" padding="md">
-            <div className="flex items-center justify-between mb-4">
-              <div className="p-2 bg-emerald-100 rounded-lg">
-                <BarChart3Icon className="w-5 h-5 text-emerald-600" />
-              </div>
-              <span className="text-xs font-medium text-emerald-600 bg-emerald-50 px-2 py-1 rounded-full">
-                +8.4%
-              </span>
-            </div>
-            <p className="text-2xl font-bold text-foreground">$1.24</p>
-            <p className="text-sm text-muted-foreground">Cost Per Click</p>
-          </Card>
-
-          <Card variant="elevated" padding="md">
-            <div className="flex items-center justify-between mb-4">
-              <div className="p-2 bg-amber-100 rounded-lg">
-                <GlobeIcon className="w-5 h-5 text-amber-600" />
-              </div>
-              <span className="text-xs font-medium text-muted-foreground bg-muted px-2 py-1 rounded-full">
-                Global
-              </span>
-            </div>
-            <p className="text-2xl font-bold text-foreground">4</p>
-            <p className="text-sm text-muted-foreground">Active Regions</p>
-          </Card>
-        </div>
+        {analyticsSummary ? (
+          <HeroKpiGrid hero={analyticsSummary.hero} />
+        ) : (
+          <AnalyticsEmptyState
+            className="mb-8"
+            title="Performance metrics aren’t available yet"
+            description={
+              <p>
+                Reach, CTR, spend, and regional breakdown will show here once live analytics are connected for this
+                campaign.
+              </p>
+            }
+          />
+        )}
 
         {/* Tabs */}
         <div className="mb-6 border-b border-border">
@@ -439,12 +494,23 @@ export function CampaignDetailPage() {
           </>
         )}
 
-        {activeTab === 'analytics' && (
-          <CampaignAnalytics
-            metrics={analyticsMetrics}
-            personas={personaPerformance}
-          />
-        )}
+        {activeTab === 'analytics' &&
+          (analyticsSummary ? (
+            <CampaignAnalytics
+              metrics={analyticsSummary.metrics as AnalyticsMetric[]}
+              personas={analyticsSummary.personas as PersonaPerf[]}
+            />
+          ) : (
+            <AnalyticsEmptyState
+              title="No analytics data yet"
+              description={
+                <p>
+                  Charts, funnel metrics, and persona breakdown will show here after your ad platforms are connected
+                  and we receive performance payloads for this campaign.
+                </p>
+              }
+            />
+          ))}
 
         {activeTab === 'settings' && (
           <CampaignSettings
@@ -485,28 +551,5 @@ export function CampaignDetailPage() {
         )}
       </main>
     </div>
-  );
-}
-
-function MousePointerClickIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="24"
-      height="24"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-    >
-      <path d="m9 9 5 12 1.8-5.2L21 14Z" />
-      <path d="M7.2 2.2 8 5.1" />
-      <path d="m5.1 8-2.9-.8" />
-      <path d="M14 4.1 12 6" />
-      <path d="m6 12-1.9 2" />
-    </svg>
   );
 }

--- a/frontend/src/pages/CampaignDetailPage.tsx
+++ b/frontend/src/pages/CampaignDetailPage.tsx
@@ -32,18 +32,10 @@ import { useCampaign, useUpdateCampaign, useDeleteCampaign } from '../hooks/useC
 import { useCampaignAdVariants } from '../hooks/useAdGeneration';
 import { useUser } from '../contexts/UserContext';
 import { useProducts } from '../hooks/useProducts';
-import type { CampaignStatus, Product, CampaignAnalyticsSummary, CampaignHeroIcon } from '../types';
+import type { CampaignStatus, Product, CampaignAnalyticsSummary } from '../types';
+import { HERO_ICON_STYLES, normalizeCampaignHeroIcon, getHeroIconStyles } from '../lib/campaignHeroIcon';
 
 // ---------- Analytics helpers (live data only; empty state when API omits summary) ----------
-
-function resolveAnalyticsSummary(campaign: { analytics_summary?: CampaignAnalyticsSummary | null }): CampaignAnalyticsSummary | null {
-  const s = campaign.analytics_summary;
-  if (!s) return null;
-  if (!Array.isArray(s.hero) || s.hero.length !== 4) return null;
-  if (!Array.isArray(s.metrics) || s.metrics.length === 0) return null;
-  if (!Array.isArray(s.personas) || s.personas.length === 0) return null;
-  return s;
-}
 
 function heroBadgeClass(style: 'positive' | 'neutral' | 'muted'): string {
   if (style === 'positive') {
@@ -55,12 +47,20 @@ function heroBadgeClass(style: 'positive' | 'neutral' | 'muted'): string {
   return 'text-xs font-medium text-muted-foreground bg-muted/80 px-2 py-1 rounded-full';
 }
 
-const HERO_ICON_STYLES: Record<CampaignHeroIcon, { wrap: string; iconClass: string }> = {
-  users: { wrap: 'bg-blue-100', iconClass: 'w-5 h-5 text-blue-600' },
-  pointer: { wrap: 'bg-purple-100', iconClass: 'w-5 h-5 text-purple-600' },
-  chart: { wrap: 'bg-emerald-100', iconClass: 'w-5 h-5 text-emerald-600' },
-  globe: { wrap: 'bg-amber-100', iconClass: 'w-5 h-5 text-amber-600' },
-};
+function resolveAnalyticsSummary(campaign: { analytics_summary?: CampaignAnalyticsSummary | null }): CampaignAnalyticsSummary | null {
+  const s = campaign.analytics_summary;
+  if (!s) return null;
+  if (!Array.isArray(s.hero) || s.hero.length === 0) return null;
+  if (!Array.isArray(s.metrics) || s.metrics.length === 0) return null;
+  if (!Array.isArray(s.personas) || s.personas.length === 0) return null;
+  return {
+    ...s,
+    hero: s.hero.map((kpi) => ({
+      ...kpi,
+      icon: normalizeCampaignHeroIcon(kpi?.icon),
+    })),
+  };
+}
 
 function MousePointerClickIcon({ className }: { className?: string }) {
   return (
@@ -85,9 +85,10 @@ function MousePointerClickIcon({ className }: { className?: string }) {
   );
 }
 
-function renderHeroIcon(icon: CampaignHeroIcon) {
-  const { iconClass } = HERO_ICON_STYLES[icon];
-  switch (icon) {
+function renderHeroIcon(icon: unknown) {
+  const resolved = normalizeCampaignHeroIcon(icon);
+  const { iconClass } = HERO_ICON_STYLES[resolved];
+  switch (resolved) {
     case 'users':
       return <UsersIcon className={iconClass} />;
     case 'pointer':
@@ -101,9 +102,9 @@ function renderHeroIcon(icon: CampaignHeroIcon) {
 
 function HeroKpiGrid({ hero }: { hero: CampaignAnalyticsSummary['hero'] }) {
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-6 mb-8">
+    <div className="mb-8 grid grid-cols-1 gap-6 sm:grid-cols-2 xl:grid-cols-[repeat(auto-fit,minmax(220px,1fr))]">
       {hero.map((kpi, index) => {
-        const wrap = HERO_ICON_STYLES[kpi.icon].wrap;
+        const wrap = getHeroIconStyles(kpi.icon).wrap;
         return (
           <Card key={`${kpi.label}-${index}`} variant="elevated" padding="md">
             <div className="flex items-center justify-between mb-4">

--- a/frontend/src/pages/CampaignsPage.tsx
+++ b/frontend/src/pages/CampaignsPage.tsx
@@ -1,4 +1,5 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { Sidebar } from '../components/layout/Sidebar';
 import {
   LayoutGridIcon,
@@ -28,6 +29,10 @@ import {
   filterCampaignsByDatePreset,
   type DateRangePreset,
 } from '../lib/campaignsList';
+import type { Campaign } from '../types';
+
+/** Stable fallback while campaigns query has no data (avoids a new `[]` each render). */
+const EMPTY_CAMPAIGNS: Campaign[] = [];
 
 // ---------- Component ----------
 
@@ -38,7 +43,8 @@ export function CampaignsPage() {
   const businessClientId = user?.client_id;
   const canManageCampaigns = typeof businessClientId === 'number' && businessClientId > 0;
 
-  const { data: rawCampaigns = [], isLoading, isError, error } = useCampaigns(businessClientId);
+  const { data: rawCampaignsData, isLoading, isError, error } = useCampaigns(businessClientId);
+  const rawCampaigns = rawCampaignsData ?? EMPTY_CAMPAIGNS;
   const deleteMutation = useDeleteCampaign();
   const updateMutation = useUpdateCampaign();
 
@@ -50,6 +56,15 @@ export function CampaignsPage() {
   );
 
   const goalOptions = useMemo(() => distinctGoalsFromCampaigns(campaignsByDate), [campaignsByDate]);
+
+  useEffect(() => {
+    const allowed = new Set(distinctGoalsFromCampaigns(campaignsByDate));
+    setSelectedObjectives((prev) => {
+      const next = prev.filter((g) => allowed.has(g));
+      if (next.length === prev.length && next.every((g, i) => g === prev[i])) return prev;
+      return next;
+    });
+  }, [campaignsByDate]);
 
   const campaigns = useMemo(
     () => campaignsByDate.map((c) => campaignToItem(c)),
@@ -222,6 +237,21 @@ export function CampaignsPage() {
           </div>
         )}
 
+        {!userLoading && !user ? (
+          <div className="flex flex-col items-center justify-center py-24 text-center px-4">
+            <MegaphoneIcon className="w-8 h-8 text-muted-foreground mb-4" />
+            <h2 className="text-base font-semibold mb-1">Sign in to view campaigns</h2>
+            <p className="text-sm text-muted-foreground mb-6 max-w-sm">
+              You need an account to load your campaigns and create new ones.
+            </p>
+            <Link
+              to="/sign-in"
+              className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 transition-colors"
+            >
+              Sign in
+            </Link>
+          </div>
+        ) : (
         <div className="flex gap-8">
           <div className="w-56 flex-shrink-0 space-y-6">
             <div className="relative">
@@ -290,7 +320,9 @@ export function CampaignsPage() {
               <div className="flex flex-col items-center justify-center py-24 text-center">
                 <AlertCircleIcon className="w-8 h-8 text-red-500 mb-3" />
                 <h2 className="text-base font-semibold mb-1">Failed to load campaigns</h2>
-                <p className="text-sm text-muted-foreground">{(error as Error).message}</p>
+                <p className="text-sm text-muted-foreground">
+                  {error instanceof Error ? error.message : String(error ?? 'Unknown error')}
+                </p>
               </div>
             )}
 
@@ -361,6 +393,7 @@ export function CampaignsPage() {
             )}
           </div>
         </div>
+        )}
 
         {showCreateModal && typeof businessClientId === 'number' && businessClientId > 0 && (
           <CreateCampaignModal

--- a/frontend/src/pages/CampaignsPage.tsx
+++ b/frontend/src/pages/CampaignsPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Sidebar } from '../components/layout/Sidebar';
 import {
   LayoutGridIcon,
@@ -17,88 +17,53 @@ import { CampaignGridCard } from '../components/campaigns/CampaignGridCard';
 import { CampaignTable } from '../components/campaigns/CampaignTable';
 import { CreateCampaignModal } from '../components/campaigns/CreateCampaignModal';
 import { DeleteCampaignModal } from '../components/campaigns/DeleteCampaignModal';
-import type { CampaignItem } from '../components/campaigns/CampaignGridCard';
 
 import { useUser } from '../contexts/UserContext';
 import { useSidebar } from '../contexts/SidebarContext';
 import { useTheme } from '../contexts/ThemeContext';
 import { useCampaigns, useDeleteCampaign, useUpdateCampaign } from '../hooks/useCampaigns';
-import type { Campaign } from '../types';
-
-// ---------- Helpers ----------
-
-/**
- * product_context is stored as a JSON object {"text": "..."} in the DB
- * (Azure SQL's ISJSON() only accepts objects/arrays, not scalar strings).
- * Fall back gracefully for any other shape.
- */
-function parseProductContext(raw: string | null | undefined): string {
-  if (!raw) return '—';
-  try {
-    const parsed = JSON.parse(raw);
-    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-      return parsed.text ?? parsed.description ?? JSON.stringify(parsed);
-    }
-    if (typeof parsed === 'string') return parsed;
-    return String(parsed);
-  } catch {
-    return raw;
-  }
-}
-
-// ---------- Mapper: API Campaign → UI CampaignItem ----------
-
-function campaignToItem(c: Campaign): CampaignItem {
-  return {
-    id: String(c.id),
-    name: c.name,
-    product: parseProductContext(c.product_context),
-    status: c.status,
-    reach: '—',
-    engagement: '—',
-    platform: '—',
-    objective: c.goal ?? '—',
-    dateCreated: new Date(c.created_at).toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-    }),
-  };
-}
+import {
+  campaignToItem,
+  distinctGoalsFromCampaigns,
+  filterCampaignsByDatePreset,
+  type DateRangePreset,
+} from '../lib/campaignsList';
 
 // ---------- Component ----------
 
 export function CampaignsPage() {
   const { collapsed } = useSidebar();
   const { theme, toggleTheme } = useTheme();
-  const { user } = useUser();
+  const { user, loading: userLoading } = useUser();
   const businessClientId = user?.client_id;
+  const canManageCampaigns = typeof businessClientId === 'number' && businessClientId > 0;
 
   const { data: rawCampaigns = [], isLoading, isError, error } = useCampaigns(businessClientId);
   const deleteMutation = useDeleteCampaign();
   const updateMutation = useUpdateCampaign();
 
-  const campaigns = rawCampaigns.map(campaignToItem);
+  const [dateRangePreset, setDateRangePreset] = useState<DateRangePreset>('all');
+
+  const campaignsByDate = useMemo(
+    () => filterCampaignsByDatePreset(rawCampaigns, dateRangePreset),
+    [rawCampaigns, dateRangePreset],
+  );
+
+  const goalOptions = useMemo(() => distinctGoalsFromCampaigns(campaignsByDate), [campaignsByDate]);
+
+  const campaigns = useMemo(
+    () => campaignsByDate.map((c) => campaignToItem(c)),
+    [campaignsByDate],
+  );
 
   const [viewMode, setViewMode] = useState<'grid' | 'table'>('grid');
   const [searchQuery, setSearchQuery] = useState('');
-  const [selectedPlatforms, setSelectedPlatforms] = useState<string[]>([]);
   const [selectedObjectives, setSelectedObjectives] = useState<string[]>([]);
   const [selectedCampaigns, setSelectedCampaigns] = useState<string[]>([]);
 
-  // Modal visibility
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [campaignToDelete, setCampaignToDelete] = useState<{ id: number; name: string } | null>(null);
-// ---------- Filter helpers ----------
-
-  const togglePlatform = (platform: string) => {
-    setSelectedPlatforms((prev) =>
-      prev.includes(platform)
-        ? prev.filter((p) => p !== platform)
-        : [...prev, platform],
-    );
-  };
 
   const toggleObjective = (objective: string) => {
     setSelectedObjectives((prev) =>
@@ -112,16 +77,10 @@ export function CampaignsPage() {
     const matchesSearch =
       campaign.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
       campaign.product.toLowerCase().includes(searchQuery.toLowerCase());
-    const matchesPlatform =
-      selectedPlatforms.length === 0 ||
-      selectedPlatforms.includes(campaign.platform);
     const matchesObjective =
-      selectedObjectives.length === 0 ||
-      selectedObjectives.includes(campaign.objective);
-    return matchesSearch && matchesPlatform && matchesObjective;
+      selectedObjectives.length === 0 || selectedObjectives.includes(campaign.objective);
+    return matchesSearch && matchesObjective;
   });
-
-  // ---------- Selection helpers ----------
 
   const toggleCampaignSelection = (id: string) => {
     setSelectedCampaigns((prev) =>
@@ -136,8 +95,6 @@ export function CampaignsPage() {
       setSelectedCampaigns(filteredCampaigns.map((c) => c.id));
     }
   };
-
-  // ---------- Bulk actions ----------
 
   const handleBulkPause = async () => {
     await Promise.all(
@@ -155,8 +112,6 @@ export function CampaignsPage() {
     setSelectedCampaigns([]);
   };
 
-  // ---------- Delete ----------
-
   const handleDeleteClick = (campaignId: string, campaignName: string) => {
     setCampaignToDelete({ id: Number(campaignId), name: campaignName });
     setShowDeleteModal(true);
@@ -172,14 +127,18 @@ export function CampaignsPage() {
     });
   };
 
-  // ---------- Render ----------
+  const openCreateModal = () => {
+    if (!canManageCampaigns) return;
+    setShowCreateModal(true);
+  };
+
+  const dateRangeSelectId = 'campaigns-date-range';
 
   return (
     <div className="flex min-h-screen bg-background text-foreground">
       <Sidebar />
 
       <main className={`${collapsed ? 'ml-16' : 'ml-64'} transition-all duration-300 flex-1 p-8`}>
-        {/* Header */}
         <div className="flex items-center justify-between mb-8">
           <div>
             <h1 className="text-2xl font-semibold tracking-tight">Campaigns</h1>
@@ -188,12 +147,14 @@ export function CampaignsPage() {
           <div className="flex items-center gap-3">
             <div className="inline-flex items-center bg-muted border border-border rounded-lg p-1">
               <button
+                type="button"
                 onClick={() => setViewMode('grid')}
                 className={`p-1.5 rounded-md transition-colors ${viewMode === 'grid' ? 'bg-foreground text-background' : 'text-muted-foreground hover:text-foreground'}`}
               >
                 <LayoutGridIcon className="w-4 h-4" />
               </button>
               <button
+                type="button"
                 onClick={() => setViewMode('table')}
                 className={`p-1.5 rounded-md transition-colors ${viewMode === 'table' ? 'bg-foreground text-background' : 'text-muted-foreground hover:text-foreground'}`}
               >
@@ -201,13 +162,17 @@ export function CampaignsPage() {
               </button>
             </div>
             <button
-              onClick={() => setShowCreateModal(true)}
-              className="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 transition-colors"
+              type="button"
+              onClick={openCreateModal}
+              disabled={!canManageCampaigns}
+              title={!canManageCampaigns ? 'A business client is required to create campaigns.' : undefined}
+              className="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:pointer-events-none"
             >
               <PlusIcon className="w-4 h-4" />
               Create Campaign
             </button>
             <button
+              type="button"
               onClick={toggleTheme}
               className="p-2 bg-muted rounded-lg hover:bg-border transition-colors"
               aria-label="Toggle theme"
@@ -217,7 +182,16 @@ export function CampaignsPage() {
           </div>
         </div>
 
-        {/* Bulk Actions Bar */}
+        {!userLoading && user && !canManageCampaigns && (
+          <div
+            className="mb-4 rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-900 dark:text-amber-100"
+            role="status"
+          >
+            Your profile does not have a business client id yet. Campaigns cannot be loaded or created until one is
+            assigned.
+          </div>
+        )}
+
         {selectedCampaigns.length > 0 && (
           <div className="mb-4 flex items-center gap-3 bg-blue-600/10 border border-blue-600/20 rounded-lg px-4 py-3">
             <span className="text-sm font-medium text-blue-500">
@@ -225,18 +199,21 @@ export function CampaignsPage() {
             </span>
             <div className="flex-1" />
             <button
+              type="button"
               onClick={handleBulkPause}
               className="px-3 py-1.5 text-sm border border-border rounded-lg hover:bg-muted transition-colors"
             >
               Pause Selected
             </button>
             <button
+              type="button"
               onClick={handleBulkDelete}
               className="px-3 py-1.5 text-sm border border-red-500/30 text-red-500 rounded-lg hover:bg-red-500/10 transition-colors"
             >
               Delete Selected
             </button>
             <button
+              type="button"
               onClick={() => setSelectedCampaigns([])}
               className="p-1 rounded hover:bg-muted transition-colors text-muted-foreground"
             >
@@ -246,7 +223,6 @@ export function CampaignsPage() {
         )}
 
         <div className="flex gap-8">
-          {/* Filters Sidebar */}
           <div className="w-56 flex-shrink-0 space-y-6">
             <div className="relative">
               <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
@@ -260,53 +236,49 @@ export function CampaignsPage() {
             </div>
 
             <div>
-              <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-3">Date Range</h3>
-              <select className="w-full px-3 py-2 bg-background border border-border rounded-lg text-sm focus:outline-none focus:ring-1 focus:ring-foreground/20">
-                <option>Last 30 days</option>
-                <option>Last 7 days</option>
-                <option>Last 90 days</option>
-                <option>All time</option>
+              <label htmlFor={dateRangeSelectId} className="block text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-3">
+                Date range
+              </label>
+              <select
+                id={dateRangeSelectId}
+                value={dateRangePreset}
+                onChange={(e) => setDateRangePreset(e.target.value as DateRangePreset)}
+                className="w-full px-3 py-2 bg-background border border-border rounded-lg text-sm focus:outline-none focus:ring-1 focus:ring-foreground/20"
+              >
+                <option value="7d">Last 7 days</option>
+                <option value="30d">Last 30 days</option>
+                <option value="90d">Last 90 days</option>
+                <option value="all">All time</option>
               </select>
+              <p className="mt-1.5 text-xs text-muted-foreground">Filters by campaign created date.</p>
             </div>
 
-            <div>
-              <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-3">Platform</h3>
-              <div className="space-y-2">
-                {['meta', 'tiktok', 'youtube', 'linkedin'].map((platform) => (
-                  <label key={platform} className="flex items-center gap-2 text-sm text-muted-foreground cursor-pointer hover:text-foreground transition-colors">
-                    <input
-                      type="checkbox"
-                      checked={selectedPlatforms.includes(platform)}
-                      onChange={() => togglePlatform(platform)}
-                      className="rounded border-border text-blue-600 focus:ring-blue-500"
-                    />
-                    <span className="capitalize">{platform}</span>
-                  </label>
-                ))}
+            {goalOptions.length > 0 && (
+              <div>
+                <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-3">Goal</h3>
+                <div className="space-y-2">
+                  {goalOptions.map((objective) => (
+                    <label
+                      key={objective}
+                      className="flex items-center gap-2 text-sm text-muted-foreground cursor-pointer hover:text-foreground transition-colors"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={selectedObjectives.includes(objective)}
+                        onChange={() => toggleObjective(objective)}
+                        className="rounded border-border text-blue-600 focus:ring-blue-500"
+                      />
+                      <span className="truncate" title={objective}>
+                        {objective}
+                      </span>
+                    </label>
+                  ))}
+                </div>
               </div>
-            </div>
-
-            <div>
-              <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-3">Objective</h3>
-              <div className="space-y-2">
-                {['sales', 'awareness', 'engagement', 'leads'].map((objective) => (
-                  <label key={objective} className="flex items-center gap-2 text-sm text-muted-foreground cursor-pointer hover:text-foreground transition-colors">
-                    <input
-                      type="checkbox"
-                      checked={selectedObjectives.includes(objective)}
-                      onChange={() => toggleObjective(objective)}
-                      className="rounded border-border text-blue-600 focus:ring-blue-500"
-                    />
-                    <span className="capitalize">{objective}</span>
-                  </label>
-                ))}
-              </div>
-            </div>
+            )}
           </div>
 
-          {/* Content */}
           <div className="flex-1">
-            {/* Loading state */}
             {isLoading && (
               <div className="flex flex-col items-center justify-center py-24 text-muted-foreground">
                 <Loader2Icon className="w-6 h-6 animate-spin mb-3" />
@@ -314,7 +286,6 @@ export function CampaignsPage() {
               </div>
             )}
 
-            {/* Error state */}
             {isError && (
               <div className="flex flex-col items-center justify-center py-24 text-center">
                 <AlertCircleIcon className="w-8 h-8 text-red-500 mb-3" />
@@ -323,8 +294,7 @@ export function CampaignsPage() {
               </div>
             )}
 
-            {/* Empty state */}
-            {!isLoading && !isError && campaigns.length === 0 && (
+            {!isLoading && !isError && canManageCampaigns && rawCampaigns.length === 0 && (
               <div className="flex flex-col items-center justify-center py-24 text-center">
                 <MegaphoneIcon className="w-8 h-8 text-muted-foreground mb-4" />
                 <h2 className="text-base font-semibold mb-1">No campaigns yet</h2>
@@ -332,7 +302,8 @@ export function CampaignsPage() {
                   Create your first campaign to start reaching your audience with AI-generated ads.
                 </p>
                 <button
-                  onClick={() => setShowCreateModal(true)}
+                  type="button"
+                  onClick={openCreateModal}
                   className="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 transition-colors"
                 >
                   <PlusIcon className="w-4 h-4" />
@@ -341,16 +312,31 @@ export function CampaignsPage() {
               </div>
             )}
 
-            {/* No search results */}
-            {!isLoading && !isError && campaigns.length > 0 && filteredCampaigns.length === 0 && (
+            {!isLoading && !isError && canManageCampaigns && rawCampaigns.length > 0 && campaigns.length === 0 && (
               <div className="flex flex-col items-center justify-center py-24 text-center">
-                <SearchIcon className="w-8 h-8 text-muted-foreground mb-3" />
-                <h2 className="text-base font-semibold mb-1">No campaigns match your filters</h2>
-                <p className="text-sm text-muted-foreground">Try adjusting your search or filter criteria.</p>
+                <MegaphoneIcon className="w-8 h-8 text-muted-foreground mb-4" />
+                <h2 className="text-base font-semibold mb-1">No campaigns in this date range</h2>
+                <p className="text-sm text-muted-foreground mb-4 max-w-sm">
+                  Try choosing &ldquo;All time&rdquo; or a longer window. Filters use each campaign&rsquo;s created date.
+                </p>
+                <button
+                  type="button"
+                  onClick={() => setDateRangePreset('all')}
+                  className="px-4 py-2 text-sm border border-border rounded-lg hover:bg-muted transition-colors"
+                >
+                  Show all time
+                </button>
               </div>
             )}
 
-            {/* Campaign grid / table */}
+            {!isLoading && !isError && canManageCampaigns && campaigns.length > 0 && filteredCampaigns.length === 0 && (
+              <div className="flex flex-col items-center justify-center py-24 text-center">
+                <SearchIcon className="w-8 h-8 text-muted-foreground mb-3" />
+                <h2 className="text-base font-semibold mb-1">No campaigns match your filters</h2>
+                <p className="text-sm text-muted-foreground">Try adjusting your search, date range, or goal filters.</p>
+              </div>
+            )}
+
             {!isLoading && !isError && filteredCampaigns.length > 0 && (
               viewMode === 'grid' ? (
                 <div className="grid grid-cols-2 gap-6">
@@ -376,10 +362,9 @@ export function CampaignsPage() {
           </div>
         </div>
 
-        {/* Modals */}
-        {showCreateModal && (
+        {showCreateModal && typeof businessClientId === 'number' && businessClientId > 0 && (
           <CreateCampaignModal
-            businessClientId={businessClientId ?? 0}
+            businessClientId={businessClientId}
             onClose={() => setShowCreateModal(false)}
           />
         )}

--- a/frontend/src/types/campaign.ts
+++ b/frontend/src/types/campaign.ts
@@ -1,5 +1,45 @@
 export type CampaignStatus = 'draft' | 'active' | 'paused' | 'completed';
 
+/** Icons supported by the campaign detail hero KPI strip (mapped to visuals in the UI). */
+export type CampaignHeroIcon = 'users' | 'pointer' | 'chart' | 'globe';
+
+/** One hero KPI card when `Campaign.analytics_summary` is present (from API). */
+export interface CampaignHeroKpi {
+    icon: CampaignHeroIcon;
+    /** Small pill top-right; omit when null */
+    badge: string | null;
+    /** Visual style for the badge pill */
+    badgeStyle: 'positive' | 'neutral' | 'muted';
+    value: string;
+    label: string;
+}
+
+/** One row in the analytics metrics grid (matches `CampaignAnalytics` metric shape). */
+export interface CampaignAnalyticsMetricRow {
+    label: string;
+    value: string;
+    change: string;
+    positive: boolean;
+}
+
+/** One persona row under analytics (matches `CampaignAnalytics` persona shape). */
+export interface CampaignPersonaPerfRow {
+    name: string;
+    convRate: string;
+    impressions: string;
+    color: 'teal' | 'orange' | 'blue';
+}
+
+/**
+ * Live campaign analytics from the API. When absent, the detail page shows an empty state
+ * instead of placeholder KPIs. Populate from the backend when metrics are available.
+ */
+export interface CampaignAnalyticsSummary {
+    hero: CampaignHeroKpi[];
+    metrics: CampaignAnalyticsMetricRow[];
+    personas: CampaignPersonaPerfRow[];
+}
+
 /** Shape returned by GET /campaigns and GET /campaigns/:id */
 export interface Campaign {
     id: number;
@@ -16,6 +56,8 @@ export interface Campaign {
     updated_at: string;
     product_ids: string | null;
     brief: string | null;
+    /** When set with a valid shape, the hero strip and analytics tab use live data. */
+    analytics_summary?: CampaignAnalyticsSummary | null;
 }
 
 /** Payload for POST /campaigns */

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,6 +8,10 @@ export default defineConfig(({ mode }) => {
 
   return {
     plugins: [react()],
+    test: {
+      environment: 'node',
+      include: ['src/**/*.test.ts'],
+    },
     server: {
       proxy: {
         '/api': {


### PR DESCRIPTION
## Changes
- Campaigns page: Fetches real campaigns; search, date range, and goal filters; grid/table; fixes infinite re-render when query data is still undefined.
- Detail page: Removes fake hero KPIs; shows empty states until campaign.analytics_summary is present and valid; keeps existing KPI + analytics UI when the API sends that payload.
- Supporting: campaignsList helpers + tests, create-campaign / card / table / settings tweaks, small frontend tooling and CI updates.

## Testing
- Test: #/campaigns with an authenticated client; filters and navigation; open campaign detail and confirm empty analytics until the API returns analytics_summary