### PR TITLE
Fix Ad Generation Issue with Multi-Images

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -8,7 +8,7 @@ SCRIPT_MODEL=MODEL_NAME
 SCRIPT_API_KEY=YOUR_API_KEY
 SCRIPT_BASE_URL=YOUR_BASE_URL
 VIDEO_API_KEY=YOUR_API_KEY
-# Clip length for OpenAI video API: 4, 8, or 12 (default 12). Script prompts are authored for 12s; if you use 4 or 8, align script_creation_worker beats or expect drift.
+# Clip length for OpenAI video API: 4, 8, or 12 (default 12). Script beat template and audio guards follow this value automatically.
 VIDEO_SECONDS=12
 
 # Azure Blob Storage (for ad videos)

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -8,6 +8,8 @@ SCRIPT_MODEL=MODEL_NAME
 SCRIPT_API_KEY=YOUR_API_KEY
 SCRIPT_BASE_URL=YOUR_BASE_URL
 VIDEO_API_KEY=YOUR_API_KEY
+# Clip length for OpenAI video API: 4, 8, or 12 (default 12). Script prompts are authored for 12s; if you use 4 or 8, align script_creation_worker beats or expect drift.
+VIDEO_SECONDS=12
 
 # Azure Blob Storage (for ad videos)
 AZURE_STORAGE_CONNECTION_STRING=YOUR_AZURE_STORAGE_CONNECTION_STRING

--- a/backend/crud/ad_variant.py
+++ b/backend/crud/ad_variant.py
@@ -74,7 +74,7 @@ def update_ad_variant(
         setattr(ad_variant, field, value)
     ad_variant.updated_at = datetime.now(timezone.utc)
     db.commit()
-    db.refresh(ad_variant)
+    # Omit refresh(): extra SELECT can fail on flaky connections after a successful commit.
     return ad_variant
 
 

--- a/backend/database.py
+++ b/backend/database.py
@@ -77,7 +77,10 @@ def _get_session_factory():
     global _SessionLocal
     if _SessionLocal is None:
         _SessionLocal = sessionmaker(
-            autocommit=False, autoflush=False, bind=_get_engine()
+            autocommit=False,
+            autoflush=False,
+            bind=_get_engine(),
+            expire_on_commit=False,
         )
     return _SessionLocal
 

--- a/backend/routes/product.py
+++ b/backend/routes/product.py
@@ -26,32 +26,13 @@ from crud.product import (
     update_product,
     delete_product,
 )
+from utils.product_image_names import parse_product_image_entries
 
 router = APIRouter()
 
 CONTAINER_NAME = "product-images"
 SAS_EXPIRY_HOURS = 1
 MAX_IMAGES_PER_PRODUCT = 5
-
-
-def _parse_image_list(raw: str | None) -> list[str]:
-    """Safely parse image_url / image_name from DB.
-
-    Handles three cases:
-      - None / empty string  → []
-      - JSON array string    → ["url1", "url2"]
-      - Legacy plain string  → ["url"]   (old single-image rows)
-    """
-    if not raw:
-        return []
-    raw = raw.strip()
-    try:
-        parsed = json.loads(raw)
-        if isinstance(parsed, list):
-            return [str(x) for x in parsed if x]
-        return [str(parsed)]
-    except (json.JSONDecodeError, ValueError):
-        return [raw]
 
 ALLOWED_IMAGE_TYPES = {
     "image/jpeg": ".jpg",
@@ -185,8 +166,8 @@ async def upload_product_images(
         raise HTTPException(status_code=400, detail="No files provided.")
 
     # Parse existing lists from DB (handles legacy plain-URL rows)
-    existing_urls = _parse_image_list(product.image_url)
-    existing_names = _parse_image_list(product.image_name)
+    existing_urls = parse_product_image_entries(product.image_url)
+    existing_names = parse_product_image_entries(product.image_name)
 
     slots_remaining = MAX_IMAGES_PER_PRODUCT - len(existing_urls)
     if slots_remaining <= 0:
@@ -265,8 +246,8 @@ def delete_product_image(
     if product is None or product.business_client_id != client_id:
         raise HTTPException(status_code=404, detail="Product not found")
 
-    existing_urls = _parse_image_list(product.image_url)
-    existing_names = _parse_image_list(product.image_name)
+    existing_urls = parse_product_image_entries(product.image_url)
+    existing_names = parse_product_image_entries(product.image_name)
 
     if blob_name not in existing_names:
         raise HTTPException(status_code=404, detail="Image not found on this product.")

--- a/backend/tests/test_ad_job_worker.py
+++ b/backend/tests/test_ad_job_worker.py
@@ -18,6 +18,7 @@ pytest.importorskip("azure.storage.blob", reason="azure-storage-blob required fo
 from workers.ad_job_worker.worker import (
     execute_ad_job,
     _brief_for_version,
+    _first_product_image_blob_name,
     generate_campaign_preview,
     generate_campaign_ad_variants,
 )
@@ -48,6 +49,21 @@ class TestBriefForVersion:
 
     def test_preserves_empty_string_brief_for_version(self):
         assert _brief_for_version('{"1": ""}', 1) == ""
+
+
+class TestFirstProductImageBlobName:
+    """image_name column may be JSON array (multi-upload), legacy plain blob name, or empty."""
+
+    def test_json_array_uses_first_blob(self):
+        assert _first_product_image_blob_name('["a.jpg", "b.jpg"]') == "a.jpg"
+
+    def test_legacy_plain_name(self):
+        assert _first_product_image_blob_name("blob-name.png") == "blob-name.png"
+
+    def test_empty_none(self):
+        assert _first_product_image_blob_name(None) is None
+        assert _first_product_image_blob_name("") is None
+        assert _first_product_image_blob_name("[]") is None
 
 
 # ---------------------------------------------------------------------------
@@ -304,6 +320,40 @@ async def test_execute_ad_job_uses_image_name_fallback(mock_db, mock_session_fac
     calls = blob_cls.from_connection_string.call_args_list
     blob_names = [c[1].get("blob_name", "") for c in calls if len(c) > 1 and isinstance(c[1], dict)]
     assert "blob-name.png" in blob_names
+
+
+@pytest.mark.asyncio
+async def test_execute_ad_job_json_image_name_uses_first_blob_for_download(
+    mock_db, mock_session_factory, mock_ad_variant, mock_campaign, mock_consumer, mock_blob_client
+):
+    """Multi-image products store image_name as JSON; worker must use first blob name only."""
+    product = MagicMock()
+    product.name = "Prod"
+    product.description = "Desc"
+    product.image_name = '["first.png", "second.png"]'
+
+    with (
+        patch("workers.ad_job_worker.worker._get_session_factory", return_value=mock_session_factory),
+        patch("workers.ad_job_worker.worker.create_ad_variant", return_value=mock_ad_variant),
+        patch("workers.ad_job_worker.worker.update_ad_variant"),
+        patch("workers.ad_job_worker.worker.get_campaign", return_value=mock_campaign),
+        patch("workers.ad_job_worker.worker.get_consumer", return_value=mock_consumer),
+        patch("workers.ad_job_worker.worker.get_product", return_value=product),
+        patch("workers.ad_job_worker.worker.BlobClient") as blob_cls,
+        patch("workers.ad_job_worker.worker.evaluate_script", new_callable=AsyncMock, return_value=_PASS_MODERATION),
+        patch("workers.ad_job_worker.worker.generate_ad_script", new_callable=AsyncMock, return_value="S"),
+        patch("workers.ad_job_worker.worker.generate_ad_video", new_callable=AsyncMock, return_value=b"v"),
+    ):
+        blob_cls.from_connection_string.return_value = mock_blob_client
+        await execute_ad_job(campaign_id=1, product_id=1, consumer_id=1, version_number=1)
+
+    product_calls = [
+        c
+        for c in blob_cls.from_connection_string.call_args_list
+        if len(c) > 1 and c[1].get("container_name") == "product-images"
+    ]
+    assert product_calls
+    assert product_calls[0][1]["blob_name"] == "first.png"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_ad_job_worker.py
+++ b/backend/tests/test_ad_job_worker.py
@@ -15,10 +15,10 @@ sys.path.insert(0, str(_backend_dir))
 import pytest
 
 pytest.importorskip("azure.storage.blob", reason="azure-storage-blob required for ad_job_worker tests")
+from utils.product_image_names import first_product_image_blob_name
 from workers.ad_job_worker.worker import (
     execute_ad_job,
     _brief_for_version,
-    _first_product_image_blob_name,
     generate_campaign_preview,
     generate_campaign_ad_variants,
 )
@@ -55,15 +55,15 @@ class TestFirstProductImageBlobName:
     """image_name column may be JSON array (multi-upload), legacy plain blob name, or empty."""
 
     def test_json_array_uses_first_blob(self):
-        assert _first_product_image_blob_name('["a.jpg", "b.jpg"]') == "a.jpg"
+        assert first_product_image_blob_name('["a.jpg", "b.jpg"]') == "a.jpg"
 
     def test_legacy_plain_name(self):
-        assert _first_product_image_blob_name("blob-name.png") == "blob-name.png"
+        assert first_product_image_blob_name("blob-name.png") == "blob-name.png"
 
     def test_empty_none(self):
-        assert _first_product_image_blob_name(None) is None
-        assert _first_product_image_blob_name("") is None
-        assert _first_product_image_blob_name("[]") is None
+        assert first_product_image_blob_name(None) is None
+        assert first_product_image_blob_name("") is None
+        assert first_product_image_blob_name("[]") is None
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_ad_job_worker.py
+++ b/backend/tests/test_ad_job_worker.py
@@ -15,7 +15,9 @@ sys.path.insert(0, str(_backend_dir))
 import pytest
 
 pytest.importorskip("azure.storage.blob", reason="azure-storage-blob required for ad_job_worker tests")
+from azure.core.exceptions import ResourceNotFoundError
 from utils.product_image_names import first_product_image_blob_name
+from workers.ad_job_worker.errors import AdJobClientError
 from workers.ad_job_worker.worker import (
     execute_ad_job,
     _brief_for_version,
@@ -136,6 +138,35 @@ def mock_blob_client():
     client.get_blob_properties.return_value = props
     client.url = "https://example.blob.core.windows.net/container/blob"
     return client
+
+
+@pytest.mark.asyncio
+async def test_execute_ad_job_blob_not_found_on_readall_raises_ad_job_client_error(
+    mock_db,
+    mock_session_factory,
+    mock_ad_variant,
+    mock_campaign,
+    mock_consumer,
+    mock_product,
+):
+    """404 during stream read must map to AdJobClientError (same as missing blob on download)."""
+    download = MagicMock()
+    download.readall.side_effect = ResourceNotFoundError()
+    blob_client = MagicMock()
+    blob_client.download_blob.return_value = download
+
+    with (
+        patch("workers.ad_job_worker.worker._get_session_factory", return_value=mock_session_factory),
+        patch("workers.ad_job_worker.worker.create_ad_variant", return_value=mock_ad_variant),
+        patch("workers.ad_job_worker.worker.update_ad_variant"),
+        patch("workers.ad_job_worker.worker.get_campaign", return_value=mock_campaign),
+        patch("workers.ad_job_worker.worker.get_consumer", return_value=mock_consumer),
+        patch("workers.ad_job_worker.worker.get_product", return_value=mock_product),
+        patch("workers.ad_job_worker.worker.BlobClient") as blob_cls,
+    ):
+        blob_cls.from_connection_string.return_value = blob_client
+        with pytest.raises(AdJobClientError, match="Product image not found"):
+            await execute_ad_job(campaign_id=1, product_id=1, consumer_id=1, version_number=1)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_ad_video_generation_worker.py
+++ b/backend/tests/test_ad_video_generation_worker.py
@@ -14,7 +14,10 @@ sys.path.insert(0, str(_backend_dir))
 
 import pytest
 
-from workers.ad_video_generation_worker.worker import generate_ad_video
+from workers.ad_video_generation_worker.worker import (
+    VIDEO_PROMPT_AUDIO_PREFIX,
+    generate_ad_video,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -73,9 +76,9 @@ async def test_generate_ad_video_returns_bytes_when_mock_succeeds():
     assert result == fake_video_bytes
     mock_video_client.videos.create.assert_awaited_once()
     call_kw = mock_video_client.videos.create.await_args[1]
-    assert call_kw["prompt"] == "Short script"
+    assert call_kw["prompt"] == VIDEO_PROMPT_AUDIO_PREFIX + "Short script"
     assert call_kw["size"] == "720x1280"
-    assert call_kw["seconds"] == 8
+    assert call_kw["seconds"] == 12
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_ad_video_generation_worker.py
+++ b/backend/tests/test_ad_video_generation_worker.py
@@ -15,7 +15,8 @@ sys.path.insert(0, str(_backend_dir))
 import pytest
 
 from workers.ad_video_generation_worker.worker import (
-    VIDEO_PROMPT_AUDIO_PREFIX,
+    allowed_video_seconds,
+    video_prompt_audio_prefix,
     generate_ad_video,
 )
 
@@ -76,9 +77,9 @@ async def test_generate_ad_video_returns_bytes_when_mock_succeeds():
     assert result == fake_video_bytes
     mock_video_client.videos.create.assert_awaited_once()
     call_kw = mock_video_client.videos.create.await_args[1]
-    assert call_kw["prompt"] == VIDEO_PROMPT_AUDIO_PREFIX + "Short script"
+    assert call_kw["seconds"] == allowed_video_seconds()
+    assert call_kw["prompt"] == video_prompt_audio_prefix(call_kw["seconds"]) + "Short script"
     assert call_kw["size"] == "720x1280"
-    assert call_kw["seconds"] == 12
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_product_image_names.py
+++ b/backend/tests/test_product_image_names.py
@@ -1,0 +1,26 @@
+"""Tests for utils.product_image_names."""
+
+import sys
+from pathlib import Path
+
+_backend_dir = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_backend_dir))
+
+from utils.product_image_names import first_product_image_blob_name, parse_product_image_entries
+
+
+def test_parse_json_array():
+    assert parse_product_image_entries('["x.png", "y.png"]') == ["x.png", "y.png"]
+
+
+def test_parse_json_scalar_string():
+    assert parse_product_image_entries('"solo.jpg"') == ["solo.jpg"]
+
+
+def test_parse_legacy_plain():
+    assert parse_product_image_entries("legacy.png") == ["legacy.png"]
+
+
+def test_first_matches_parse_first():
+    assert first_product_image_blob_name('["a.jpg", "b.jpg"]') == "a.jpg"
+    assert first_product_image_blob_name("only.png") == "only.png"

--- a/backend/tests/test_script_creation_worker.py
+++ b/backend/tests/test_script_creation_worker.py
@@ -118,10 +118,12 @@ class TestBuildScriptPrompt:
             consumer_profile_text="Z",
             campaign_brief="",
         )
-        assert "## Beat 1 — 0–1s (hook)" in out
-        assert "## Beat 2 — 1–3s (setup)" in out
-        assert "## Beat 3 — 3–6s (payoff)" in out
-        assert "## Beat 4 — 6–8s (product moment)" in out
+        assert "## Beat 1 — 0–2s (hook)" in out
+        assert "## Beat 2 — 2–5s (setup)" in out
+        assert "## Beat 3 — 5–9s (payoff)" in out
+        assert "## Beat 4 — 9–12s (product moment)" in out
+        assert "Audio-safe timeline" in out
+        assert "0.5s" in out and "11.35s" in out
 
     def test_includes_per_beat_fields_for_video_model(self):
         out = _build_script_prompt(

--- a/backend/tests/test_script_creation_worker.py
+++ b/backend/tests/test_script_creation_worker.py
@@ -125,6 +125,34 @@ class TestBuildScriptPrompt:
         assert "Audio-safe timeline" in out
         assert "0.5s" in out and "11.35s" in out
 
+    def test_beat_headers_match_video_seconds_eight(self, monkeypatch):
+        monkeypatch.setenv("VIDEO_SECONDS", "8")
+        out = _build_script_prompt(
+            product_name="X",
+            product_description="Y",
+            consumer_profile_text="Z",
+            campaign_brief="",
+        )
+        assert "## Beat 1 — 0–1s (hook)" in out
+        assert "## Beat 2 — 1–3s (setup)" in out
+        assert "## Beat 3 — 3–6s (payoff)" in out
+        assert "## Beat 4 — 6–8s (product moment)" in out
+        assert "8 seconds exactly" in out
+        assert "7.35" in out
+
+    def test_beat_headers_match_video_seconds_four(self, monkeypatch):
+        monkeypatch.setenv("VIDEO_SECONDS", "4")
+        out = _build_script_prompt(
+            product_name="X",
+            product_description="Y",
+            consumer_profile_text="Z",
+            campaign_brief="",
+        )
+        assert "## Beat 1 — 0–1s (hook)" in out
+        assert "## Beat 4 — 3–4s (product moment)" in out
+        assert "4 seconds exactly" in out
+        assert "3.35" in out
+
     def test_includes_per_beat_fields_for_video_model(self):
         out = _build_script_prompt(
             product_name="X",

--- a/backend/tests/test_video_timing.py
+++ b/backend/tests/test_video_timing.py
@@ -1,0 +1,30 @@
+"""Tests for utils.video_timing (VIDEO_SECONDS alignment)."""
+
+import sys
+from pathlib import Path
+
+_backend_dir = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_backend_dir))
+
+import pytest
+
+from utils import video_timing
+
+
+def test_allowed_video_seconds_invalid_falls_back_to_twelve(monkeypatch):
+    monkeypatch.setenv("VIDEO_SECONDS", "99")
+    assert video_timing.allowed_video_seconds() == 12
+
+
+def test_script_block_twelve_has_expected_beats():
+    body = video_timing.script_output_format_block(12)
+    assert "0–12s" in body or "0–12" in body
+    assert "## Beat 1 — 0–2s (hook)" in body
+    assert "11.35" in body
+
+
+def test_script_block_eight_matches_video_dialogue_end():
+    assert video_timing.dialogue_end_seconds(8) == 7.35
+    body = video_timing.script_output_format_block(8)
+    assert "## Beat 4 — 6–8s (product moment)" in body
+    assert "7.35" in body

--- a/backend/tests/test_video_timing.py
+++ b/backend/tests/test_video_timing.py
@@ -28,3 +28,6 @@ def test_script_block_eight_matches_video_dialogue_end():
     body = video_timing.script_output_format_block(8)
     assert "## Beat 4 — 6–8s (product moment)" in body
     assert "7.35" in body
+    # Beat 4 action must start at Beat 4 window (6s), not Beat 3 (3s).
+    assert "6–~7.35" in body
+    assert "3–~7.35" not in body

--- a/backend/utils/__init__.py
+++ b/backend/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Small shared helpers used across routes and workers."""

--- a/backend/utils/product_image_names.py
+++ b/backend/utils/product_image_names.py
@@ -1,0 +1,34 @@
+"""Parse product `image_url` / `image_name` columns (JSON array or legacy plain string)."""
+
+from __future__ import annotations
+
+import json
+from typing import Optional
+
+
+def parse_product_image_entries(raw: str | None) -> list[str]:
+    """Return list of blob names or URLs as stored (same rules as product upload routes).
+
+    - None / empty → []
+    - JSON array string → each non-empty element as str
+    - JSON scalar → single-element list
+    - Legacy non-JSON string → [stripped string]
+    """
+    if raw is None:
+        return []
+    s = str(raw).strip()
+    if not s:
+        return []
+    try:
+        parsed = json.loads(s)
+        if isinstance(parsed, list):
+            return [str(x) for x in parsed if x]
+        return [str(parsed)]
+    except (json.JSONDecodeError, ValueError):
+        return [s]
+
+
+def first_product_image_blob_name(raw: str | None) -> Optional[str]:
+    """First image entry for ad generation (multi-upload uses first image until a primary flag exists)."""
+    names = parse_product_image_entries(raw)
+    return names[0] if names else None

--- a/backend/utils/video_timing.py
+++ b/backend/utils/video_timing.py
@@ -1,0 +1,159 @@
+"""Shared ad clip duration (VIDEO_SECONDS), audio guard rails, and script beat layout.
+
+Used by `script_creation_worker` and `ad_video_generation_worker` so prompts stay aligned.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import List, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Same margins as the video-model prefix (seconds of clip timeline).
+AUDIO_START_GUARD = 0.5
+AUDIO_END_GUARD = 0.65
+
+BeatSpan = Tuple[float, float, str]
+
+
+def allowed_video_seconds() -> int:
+    """Clip length for `videos.create` (API allows 4, 8, 12). Override with VIDEO_SECONDS."""
+    raw = os.getenv("VIDEO_SECONDS", "12").strip()
+    try:
+        v = int(raw)
+    except ValueError:
+        return 12
+    if v in (4, 8, 12):
+        return v
+    logger.warning("VIDEO_SECONDS=%r invalid; using 12 (allowed: 4, 8, 12)", raw)
+    return 12
+
+
+def dialogue_end_seconds(total: int) -> float:
+    """Last moment on the timeline for spoken dialogue (before final ambience-only tail)."""
+    if total == 12:
+        return 11.35
+    if total == 8:
+        return 7.35
+    if total == 4:
+        return 3.35
+    return round(max(0.5, float(total) - 0.73), 2)
+
+
+def video_prompt_audio_prefix(seconds: int) -> str:
+    """Prepended to the script for the video model — speech guard bands scale with clip length."""
+    t_end = dialogue_end_seconds(seconds)
+    return f"""Mastering / timeline (mandatory — follow exactly):
+- First ~{AUDIO_START_GUARD}s: no spoken words — only ambient sound, subtle music bed, room tone, or silence while visuals hook.
+- Last ~{AUDIO_END_GUARD}s: no spoken words — only ambience, music tail, light foley, or silence after the final line has fully ended.
+- All dialogue must live between ~{AUDIO_START_GUARD}s and ~{t_end}s of this clip; finish complete phrases with a short breath of silence before ~{t_end}s, then hold visuals + non-dialogue audio through the end.
+- Avoid hard cuts that start mid-consonant at t≈0 or truncate the final word at the end of the file.
+
+---
+
+"""
+
+
+def _beat_plan(total: int) -> List[BeatSpan]:
+    if total == 12:
+        return [
+            (0, 2, "hook"),
+            (2, 5, "setup"),
+            (5, 9, "payoff"),
+            (9, 12, "product moment"),
+        ]
+    if total == 8:
+        return [
+            (0, 1, "hook"),
+            (1, 3, "setup"),
+            (3, 6, "payoff"),
+            (6, 8, "product moment"),
+        ]
+    if total == 4:
+        return [
+            (0, 1, "hook"),
+            (1, 2, "setup"),
+            (2, 3, "payoff"),
+            (3, 4, "product moment"),
+        ]
+    # Fallback: even quarters
+    q = float(total) / 4.0
+    return [
+        (0 * q, 1 * q, "hook"),
+        (1 * q, 2 * q, "setup"),
+        (2 * q, 3 * q, "payoff"),
+        (3 * q, 4 * q, "product moment"),
+    ]
+
+
+def _fmt_t(t: float) -> str:
+    if t == int(t):
+        return str(int(t))
+    return f"{t:g}"
+
+
+def _fmt_span(start: float, end: float) -> str:
+    return f"{_fmt_t(start)}–{_fmt_t(end)}s"
+
+
+def script_requirement_beat_ranges(total: int) -> str:
+    """Comma-separated beat windows for the Requirements list (e.g. `0–2s, 2–5s, ...`)."""
+    return ", ".join(_fmt_span(a, b) for a, b, _ in _beat_plan(total))
+
+
+def script_output_format_block(total: int) -> str:
+    """MANDATORY script template for the LLM; beat windows match `total` (VIDEO_SECONDS)."""
+    beats = _beat_plan(total)
+    t_end = dialogue_end_seconds(total)
+    b3s, _, _ = beats[2]
+    speech_inner = round(max(0.1, total - AUDIO_START_GUARD - AUDIO_END_GUARD), 2)
+    word_cap = max(6, int(28 * total / 12))
+
+    beat_lines = []
+    for i, (a, b, label) in enumerate(beats, start=1):
+        beat_lines.append(f"## Beat {i} — {_fmt_span(a, b)} ({label})")
+        if i == 1:
+            beat_lines.extend(
+                [
+                    "- What we see: (subjects, environment, product visibility — be specific)",
+                    "- Camera move: (e.g. handheld close-up, slow push-in, whip pan)",
+                    "- Lighting: (time of day, key mood, practicals)",
+                    "- Action: (what moves, gestures, reactions; first ~0.5s of the **full clip** may be silent performance / reaction only)",
+                    '- Line (approx. word count): (if spoken, the first ~0.5s of the **full clip** must remain "none — ambient only"; place any line in the remainder of Beat 1 only)',
+                ]
+            )
+        elif i == 4:
+            beat_lines.extend(
+                [
+                    "- What we see:",
+                    "- Camera move:",
+                    "- Lighting:",
+                    f"- Action: ({_fmt_t(b3s)}–~{_fmt_t(t_end)}s may include performance tied to the last line; ~{_fmt_t(t_end)}–{_fmt_t(total)}s should be product hero, smile, pack shot, or gesture with no new speech)",
+                    f'- Line (approx. word count): (any final spoken line must complete before ~{_fmt_t(t_end)}s; use "none — ambient only" for ~{_fmt_t(t_end)}–{_fmt_t(total)}s — never script dialogue that runs against the final frame boundary)',
+                ]
+            )
+        else:
+            beat_lines.extend(
+                [
+                    "- What we see:",
+                    "- Camera move:",
+                    "- Lighting:",
+                    "- Action:",
+                    "- Line (approx. word count):",
+                ]
+            )
+
+    beats_body = "\n\n".join(beat_lines)
+
+    return f"""MANDATORY OUTPUT FORMAT — your entire reply MUST follow this template. The video generator reads this literally; vague prose will fail. Time ranges must partition 0–{_fmt_t(float(total))}s with no gaps and no overlap (total {float(total)} seconds).
+
+Audio-safe timeline (critical): Spoken dialogue must only occur between ~{AUDIO_START_GUARD}s and ~{_fmt_t(t_end)}s. Use 0–{AUDIO_START_GUARD}s for hook visuals with ambient/music/room tone only (no words). Use ~{_fmt_t(t_end)}–{_fmt_t(total)}s for product moment visuals with ambience or music tail only — the final spoken line must fully complete before ~{_fmt_t(t_end)}s with a tiny natural pause after, so nothing is clipped at export.
+
+## Overview (2–4 sentences max)
+Premise, tone, and single clear comedic or emotional idea. State the chosen creator-native format (e.g. POV, reaction, day-in-the-life). Do not read campaign bullets aloud.
+
+{beats_body}
+
+Rules for beats: Each beat's action and visuals must be producible in that time window. Sum of dialogue across all beats must fit comfortably within the dialogue window (~{speech_inner}s of speech time inside {total}s) (aim for ~{word_cap} spoken words max total unless pacing is very fast — leave air at start and end). The first frame may emphasize the product; after Beat 1, move into story per the brief. No readable on-screen words, stickers, burned-in captions, lower-thirds, or typography gags — only picture and sound; "caption-style" humor must be spoken or acted, not written in-frame."""

--- a/backend/utils/video_timing.py
+++ b/backend/utils/video_timing.py
@@ -107,7 +107,7 @@ def script_output_format_block(total: int) -> str:
     """MANDATORY script template for the LLM; beat windows match `total` (VIDEO_SECONDS)."""
     beats = _beat_plan(total)
     t_end = dialogue_end_seconds(total)
-    b3s, _, _ = beats[2]
+    b4s, _, _ = beats[3]
     speech_inner = round(max(0.1, total - AUDIO_START_GUARD - AUDIO_END_GUARD), 2)
     word_cap = max(6, int(28 * total / 12))
 
@@ -130,7 +130,7 @@ def script_output_format_block(total: int) -> str:
                     "- What we see:",
                     "- Camera move:",
                     "- Lighting:",
-                    f"- Action: ({_fmt_t(b3s)}–~{_fmt_t(t_end)}s may include performance tied to the last line; ~{_fmt_t(t_end)}–{_fmt_t(total)}s should be product hero, smile, pack shot, or gesture with no new speech)",
+                    f"- Action: ({_fmt_t(b4s)}–~{_fmt_t(t_end)}s may include performance tied to the last line; ~{_fmt_t(t_end)}–{_fmt_t(total)}s should be product hero, smile, pack shot, or gesture with no new speech)",
                     f'- Line (approx. word count): (any final spoken line must complete before ~{_fmt_t(t_end)}s; use "none — ambient only" for ~{_fmt_t(t_end)}–{_fmt_t(total)}s — never script dialogue that runs against the final frame boundary)',
                 ]
             )

--- a/backend/workers/ad_job_worker/errors.py
+++ b/backend/workers/ad_job_worker/errors.py
@@ -1,0 +1,5 @@
+"""Errors for ad job execution (sync HTTP routes map some to 4xx)."""
+
+
+class AdJobClientError(Exception):
+    """Bad input or fixable configuration (e.g. missing product image). Maps to HTTP 400 on `/run-ad-job`."""

--- a/backend/workers/ad_job_worker/service.py
+++ b/backend/workers/ad_job_worker/service.py
@@ -2,6 +2,7 @@ import logging
 
 from fastapi import APIRouter, HTTPException
 
+from workers.ad_job_worker.errors import AdJobClientError
 from workers.ad_job_worker.worker import (
     execute_ad_job,
     generate_campaign_preview as run_generate_campaign_preview,
@@ -15,14 +16,17 @@ logger = logging.getLogger(__name__)
 async def run_ad_job(campaign_id: int, product_id: int, consumer_id: int, version_number: int):
     try:
         ad_variant_id = await execute_ad_job(campaign_id, product_id, consumer_id, version_number)
-    except ValueError as e:
+    except AdJobClientError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
     return {"status": "completed", "ad_variant_id": ad_variant_id}
 
 
 @router.post("/generate-campaign-preview")
 async def generate_campaign_preview(campaign_id: int, product_id: int, version_number: int):
-    ad_variant_ids = await run_generate_campaign_preview(campaign_id, product_id, version_number)
+    try:
+        ad_variant_ids = await run_generate_campaign_preview(campaign_id, product_id, version_number)
+    except AdJobClientError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
     return {"status": "completed", "ad_variant_ids": ad_variant_ids}
 
 

--- a/backend/workers/ad_job_worker/service.py
+++ b/backend/workers/ad_job_worker/service.py
@@ -1,5 +1,6 @@
-from fastapi import APIRouter
 import logging
+
+from fastapi import APIRouter, HTTPException
 
 from workers.ad_job_worker.worker import (
     execute_ad_job,
@@ -12,7 +13,10 @@ logger = logging.getLogger(__name__)
 
 @router.post("/run-ad-job")
 async def run_ad_job(campaign_id: int, product_id: int, consumer_id: int, version_number: int):
-    ad_variant_id = await execute_ad_job(campaign_id, product_id, consumer_id, version_number)
+    try:
+        ad_variant_id = await execute_ad_job(campaign_id, product_id, consumer_id, version_number)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
     return {"status": "completed", "ad_variant_id": ad_variant_id}
 
 

--- a/backend/workers/ad_job_worker/worker.py
+++ b/backend/workers/ad_job_worker/worker.py
@@ -124,17 +124,18 @@ async def execute_ad_job(campaign_id: int, product_id: int, consumer_id: int, ve
             container_name="product-images",
             blob_name=product_image_filename,
         )
+        blob_name_for_error = product_image_filename
         try:
             product_image_download = product_image_blob_client.download_blob()
+            product_image_bytes = product_image_download.readall()
+            props = product_image_blob_client.get_blob_properties()
+            product_image_type = props.content_settings.content_type or "image/png"
+            product_image_filename = props.name
         except ResourceNotFoundError as e:
             raise AdJobClientError(
-                f"Product image not found in storage (container product-images, blob {product_image_filename!r}). "
+                f"Product image not found in storage (container product-images, blob {blob_name_for_error!r}). "
                 "Re-upload the product image or fix image_name in the database."
             ) from e
-        product_image_bytes = product_image_download.readall()
-        props = product_image_blob_client.get_blob_properties()
-        product_image_type = props.content_settings.content_type or "image/png"
-        product_image_filename = props.name
         product_image_bytes, product_image_type = _resize_product_image(
             product_image_bytes, product_image_type
         )

--- a/backend/workers/ad_job_worker/worker.py
+++ b/backend/workers/ad_job_worker/worker.py
@@ -30,6 +30,7 @@ from services.consumer_traits_description import consumer_profile_text_for_scrip
 from workers.script_creation_worker.worker import generate_ad_script
 from workers.ad_video_generation_worker.worker import generate_ad_video
 from workers.script_moderation_worker.worker import evaluate_script
+from azure.core.exceptions import ResourceNotFoundError
 from azure.storage.blob import BlobClient, ContentSettings
 
 load_dotenv()
@@ -81,6 +82,26 @@ def _brief_for_version(brief_json: Optional[str], version_number: int) -> str:
         return ""
 
 
+def _first_product_image_blob_name(raw: Optional[str]) -> Optional[str]:
+    """Resolve blob name for ad generation from DB `image_name` (matches product routes).
+
+    Upload stores JSON arrays; legacy rows may be a single blob name or URL string.
+    """
+    if raw is None:
+        return None
+    s = str(raw).strip()
+    if not s:
+        return None
+    try:
+        parsed = json.loads(s)
+        if isinstance(parsed, list):
+            names = [str(x) for x in parsed if x]
+            return names[0] if names else None
+        return str(parsed).strip() if parsed is not None else None
+    except (json.JSONDecodeError, ValueError):
+        return s
+
+
 async def execute_ad_job(campaign_id: int, product_id: int, consumer_id: int, version_number: int, is_preview: bool = False) -> int:
     logger.info(
         "Executing ad job for campaign %s, product %s, consumer %s, version %s",
@@ -108,18 +129,24 @@ async def execute_ad_job(campaign_id: int, product_id: int, consumer_id: int, ve
         product = get_product(db, product_id)
         if product is None:
             raise ValueError(f"Product not found: {product_id}")
-        if not product.image_name or not product.image_name.strip():
+        product_image_filename = _first_product_image_blob_name(product.image_name)
+        if not product_image_filename:
             raise ValueError(f"Product {product_id} has no image (image_name required for ad generation)")
         product_name = product.name
         product_description = product.description
-        product_image_filename = product.image_name
 
         product_image_blob_client = BlobClient.from_connection_string(
             conn_str=os.getenv("AZURE_STORAGE_CONNECTION_STRING", "").strip(),
             container_name="product-images",
-            blob_name=f"{product_image_filename}",
+            blob_name=product_image_filename,
         )
-        product_image_download = product_image_blob_client.download_blob()
+        try:
+            product_image_download = product_image_blob_client.download_blob()
+        except ResourceNotFoundError as e:
+            raise ValueError(
+                f"Product image not found in storage (container product-images, blob {product_image_filename!r}). "
+                "Re-upload the product image or fix image_name in the database."
+            ) from e
         product_image_bytes = product_image_download.readall()
         props = product_image_blob_client.get_blob_properties()
         product_image_type = props.content_settings.content_type or "image/png"

--- a/backend/workers/ad_job_worker/worker.py
+++ b/backend/workers/ad_job_worker/worker.py
@@ -12,6 +12,8 @@ from PIL import Image, UnidentifiedImageError
 from sqlalchemy.orm import Session
 
 from database import _get_session_factory
+from utils.product_image_names import first_product_image_blob_name
+from workers.ad_job_worker.errors import AdJobClientError
 from crud.ad_variant import (
     create_ad_variant,
     update_ad_variant,
@@ -82,26 +84,6 @@ def _brief_for_version(brief_json: Optional[str], version_number: int) -> str:
         return ""
 
 
-def _first_product_image_blob_name(raw: Optional[str]) -> Optional[str]:
-    """Resolve blob name for ad generation from DB `image_name` (matches product routes).
-
-    Upload stores JSON arrays; legacy rows may be a single blob name or URL string.
-    """
-    if raw is None:
-        return None
-    s = str(raw).strip()
-    if not s:
-        return None
-    try:
-        parsed = json.loads(s)
-        if isinstance(parsed, list):
-            names = [str(x) for x in parsed if x]
-            return names[0] if names else None
-        return str(parsed).strip() if parsed is not None else None
-    except (json.JSONDecodeError, ValueError):
-        return s
-
-
 async def execute_ad_job(campaign_id: int, product_id: int, consumer_id: int, version_number: int, is_preview: bool = False) -> int:
     logger.info(
         "Executing ad job for campaign %s, product %s, consumer %s, version %s",
@@ -118,20 +100,22 @@ async def execute_ad_job(campaign_id: int, product_id: int, consumer_id: int, ve
     try:
         campaign = get_campaign(db, campaign_id)
         if campaign is None:
-            raise ValueError(f"Campaign not found: {campaign_id}")
+            raise AdJobClientError(f"Campaign not found: {campaign_id}")
         campaign_brief = _brief_for_version(campaign.brief, version_number)
 
         consumer = get_consumer(db, consumer_id)
         if consumer is None:
-            raise ValueError(f"Consumer not found: {consumer_id}")
+            raise AdJobClientError(f"Consumer not found: {consumer_id}")
         consumer_traits_string = consumer_profile_text_for_script(consumer)
 
         product = get_product(db, product_id)
         if product is None:
-            raise ValueError(f"Product not found: {product_id}")
-        product_image_filename = _first_product_image_blob_name(product.image_name)
+            raise AdJobClientError(f"Product not found: {product_id}")
+        product_image_filename = first_product_image_blob_name(product.image_name)
         if not product_image_filename:
-            raise ValueError(f"Product {product_id} has no image (image_name required for ad generation)")
+            raise AdJobClientError(
+                f"Product {product_id} has no image (image_name required for ad generation)"
+            )
         product_name = product.name
         product_description = product.description
 
@@ -143,7 +127,7 @@ async def execute_ad_job(campaign_id: int, product_id: int, consumer_id: int, ve
         try:
             product_image_download = product_image_blob_client.download_blob()
         except ResourceNotFoundError as e:
-            raise ValueError(
+            raise AdJobClientError(
                 f"Product image not found in storage (container product-images, blob {product_image_filename!r}). "
                 "Re-upload the product image or fix image_name in the database."
             ) from e
@@ -206,11 +190,40 @@ async def execute_ad_job(campaign_id: int, product_id: int, consumer_id: int, ve
         update_ad_variant(db, ad_variant_id, AdVariantUpdate(media_url=media_url, status="completed"))
     except Exception:
         # Error replaces meta entirely (script, if any, is not preserved)
-        update_ad_variant(
-            db,
-            ad_variant_id,
-            AdVariantUpdate(status="failed", meta=json.dumps({"error": traceback.format_exc()})),
-        )
+        err_meta = json.dumps({"error": traceback.format_exc()})
+        try:
+            db.rollback()
+        except Exception:
+            logger.warning("rollback after ad job failure failed", exc_info=True)
+        try:
+            update_ad_variant(
+                db,
+                ad_variant_id,
+                AdVariantUpdate(status="failed", meta=err_meta),
+            )
+        except Exception:
+            logger.warning(
+                "Failed to persist ad_variant failure on primary session; retrying with new session",
+                exc_info=True,
+            )
+            try:
+                db.close()
+            except Exception:
+                pass
+            retry_db: Session = factory()
+            try:
+                update_ad_variant(
+                    retry_db,
+                    ad_variant_id,
+                    AdVariantUpdate(status="failed", meta=err_meta),
+                )
+            except Exception:
+                logger.exception(
+                    "Could not persist ad_variant failed status for id=%s",
+                    ad_variant_id,
+                )
+            finally:
+                retry_db.close()
         raise
     finally:
         db.close()
@@ -226,7 +239,7 @@ async def generate_campaign_preview(
     try:
         campaign = get_campaign(db, campaign_id)
         if campaign is None:
-            raise ValueError(f"Campaign not found: {campaign_id}")
+            raise AdJobClientError(f"Campaign not found: {campaign_id}")
 
         personas = get_personas(db)
         selected_personas = random.sample(personas, min(6, len(personas)))

--- a/backend/workers/ad_video_generation_worker/worker.py
+++ b/backend/workers/ad_video_generation_worker/worker.py
@@ -10,6 +10,17 @@ load_dotenv()
 
 logger = logging.getLogger(__name__)
 
+# Prepended to every script for the video model so speech is not flush with 0s / hard end (reduces clipped audio).
+VIDEO_PROMPT_AUDIO_PREFIX = """Mastering / timeline (mandatory — follow exactly):
+- First ~0.5s: no spoken words — only ambient sound, subtle music bed, room tone, or silence while visuals hook.
+- Last ~0.65s: no spoken words — only ambience, music tail, light foley, or silence after the final line has fully ended.
+- All dialogue must live between ~0.5s and ~11.35s of this clip; finish complete phrases with a short breath of silence before ~11.35s, then hold visuals + non-dialogue audio through the end.
+- Avoid hard cuts that start mid-consonant at t≈0 or truncate the final word at the end of the file.
+
+---
+
+"""
+
 POLL_INTERVAL_SECONDS = 5
 MAX_POLL_ATTEMPTS = 120  # 10 minutes at 5s interval
 TERMINAL_FAILURE_STATUS = "failed"
@@ -28,9 +39,9 @@ async def generate_ad_video(
     video_client = AsyncOpenAI(api_key=api_key)
     
     creation_response = await video_client.videos.create(
-        prompt=script,
+        prompt=VIDEO_PROMPT_AUDIO_PREFIX + script,
         size="720x1280",
-        seconds=8,
+        seconds=12,
         input_reference=(product_image_filename, io.BytesIO(product_image_bytes), product_image_type),
     )
 

--- a/backend/workers/ad_video_generation_worker/worker.py
+++ b/backend/workers/ad_video_generation_worker/worker.py
@@ -6,46 +6,13 @@ import logging
 from dotenv import load_dotenv
 from openai import AsyncOpenAI
 
+from utils.video_timing import allowed_video_seconds, video_prompt_audio_prefix
+
 load_dotenv()
 
 logger = logging.getLogger(__name__)
 
 POLL_INTERVAL_SECONDS = 5
-
-
-def allowed_video_seconds() -> int:
-    """Clip length for `videos.create` (API allows 4, 8, 12). Override with VIDEO_SECONDS."""
-    raw = os.getenv("VIDEO_SECONDS", "12").strip()
-    try:
-        v = int(raw)
-    except ValueError:
-        return 12
-    if v in (4, 8, 12):
-        return v
-    logger.warning("VIDEO_SECONDS=%r invalid; using 12 (allowed: 4, 8, 12)", raw)
-    return 12
-
-
-def video_prompt_audio_prefix(seconds: int) -> str:
-    """Prepended to the script for the video model — speech guard bands scale with clip length."""
-    if seconds == 12:
-        t_end = 11.35
-    elif seconds == 8:
-        t_end = 7.35
-    elif seconds == 4:
-        t_end = 3.35
-    else:
-        t_end = round(max(0.5, seconds - 0.73), 2)
-    return f"""Mastering / timeline (mandatory — follow exactly):
-- First ~0.5s: no spoken words — only ambient sound, subtle music bed, room tone, or silence while visuals hook.
-- Last ~0.65s: no spoken words — only ambience, music tail, light foley, or silence after the final line has fully ended.
-- All dialogue must live between ~0.5s and ~{t_end}s of this clip; finish complete phrases with a short breath of silence before ~{t_end}s, then hold visuals + non-dialogue audio through the end.
-- Avoid hard cuts that start mid-consonant at t≈0 or truncate the final word at the end of the file.
-
----
-
-"""
-
 
 MAX_POLL_ATTEMPTS = 120  # 10 minutes at 5s interval
 TERMINAL_FAILURE_STATUS = "failed"

--- a/backend/workers/ad_video_generation_worker/worker.py
+++ b/backend/workers/ad_video_generation_worker/worker.py
@@ -10,18 +10,43 @@ load_dotenv()
 
 logger = logging.getLogger(__name__)
 
-# Prepended to every script for the video model so speech is not flush with 0s / hard end (reduces clipped audio).
-VIDEO_PROMPT_AUDIO_PREFIX = """Mastering / timeline (mandatory — follow exactly):
+POLL_INTERVAL_SECONDS = 5
+
+
+def allowed_video_seconds() -> int:
+    """Clip length for `videos.create` (API allows 4, 8, 12). Override with VIDEO_SECONDS."""
+    raw = os.getenv("VIDEO_SECONDS", "12").strip()
+    try:
+        v = int(raw)
+    except ValueError:
+        return 12
+    if v in (4, 8, 12):
+        return v
+    logger.warning("VIDEO_SECONDS=%r invalid; using 12 (allowed: 4, 8, 12)", raw)
+    return 12
+
+
+def video_prompt_audio_prefix(seconds: int) -> str:
+    """Prepended to the script for the video model — speech guard bands scale with clip length."""
+    if seconds == 12:
+        t_end = 11.35
+    elif seconds == 8:
+        t_end = 7.35
+    elif seconds == 4:
+        t_end = 3.35
+    else:
+        t_end = round(max(0.5, seconds - 0.73), 2)
+    return f"""Mastering / timeline (mandatory — follow exactly):
 - First ~0.5s: no spoken words — only ambient sound, subtle music bed, room tone, or silence while visuals hook.
 - Last ~0.65s: no spoken words — only ambience, music tail, light foley, or silence after the final line has fully ended.
-- All dialogue must live between ~0.5s and ~11.35s of this clip; finish complete phrases with a short breath of silence before ~11.35s, then hold visuals + non-dialogue audio through the end.
+- All dialogue must live between ~0.5s and ~{t_end}s of this clip; finish complete phrases with a short breath of silence before ~{t_end}s, then hold visuals + non-dialogue audio through the end.
 - Avoid hard cuts that start mid-consonant at t≈0 or truncate the final word at the end of the file.
 
 ---
 
 """
 
-POLL_INTERVAL_SECONDS = 5
+
 MAX_POLL_ATTEMPTS = 120  # 10 minutes at 5s interval
 TERMINAL_FAILURE_STATUS = "failed"
 
@@ -37,11 +62,13 @@ async def generate_ad_video(
         raise RuntimeError("Video generation env vars not configured.")
 
     video_client = AsyncOpenAI(api_key=api_key)
-    
+    seconds = allowed_video_seconds()
+    prefix = video_prompt_audio_prefix(seconds)
+
     creation_response = await video_client.videos.create(
-        prompt=VIDEO_PROMPT_AUDIO_PREFIX + script,
+        prompt=prefix + script,
         size="720x1280",
-        seconds=12,
+        seconds=seconds,
         input_reference=(product_image_filename, io.BytesIO(product_image_bytes), product_image_type),
     )
 

--- a/backend/workers/script_creation_worker/worker.py
+++ b/backend/workers/script_creation_worker/worker.py
@@ -70,7 +70,7 @@ Premise, tone, and single clear comedic or emotional idea. State the chosen crea
 - What we see:
 - Camera move:
 - Lighting:
-- Action: (9–~11.3s may include performance tied to the last line; ~11.35–12s should be product hero, smile, pack shot, or gesture with no new speech)
+- Action: (9–~11.35s may include performance tied to the last line; ~11.35–12s should be product hero, smile, pack shot, or gesture with no new speech)
 - Line (approx. word count): (any final spoken line must complete before ~11.35s; use "none — ambient only" for ~11.35–12s — never script dialogue that runs against the final frame boundary)
 
 Rules for beats: Each beat's action and visuals must be producible in that time window. Sum of dialogue across all beats must fit comfortably within the dialogue window (~10.8s of speech time inside 12s) (aim for ~28 spoken words max total unless pacing is very fast — leave air at start and end). The first frame may emphasize the product; after Beat 1, move into story per the brief. No readable on-screen words, stickers, burned-in captions, lower-thirds, or typography gags — only picture and sound; "caption-style" humor must be spoken or acted, not written in-frame."""

--- a/backend/workers/script_creation_worker/worker.py
+++ b/backend/workers/script_creation_worker/worker.py
@@ -5,6 +5,14 @@ import json
 
 from dotenv import load_dotenv
 
+from utils.video_timing import (
+    AUDIO_END_GUARD,
+    AUDIO_START_GUARD,
+    allowed_video_seconds,
+    dialogue_end_seconds,
+    script_output_format_block,
+    script_requirement_beat_ranges,
+)
 from services.consumer_traits_description import consumer_profile_text_for_script
 from openai import AsyncOpenAI
 from xai_sdk import Client
@@ -38,44 +46,6 @@ def _format_campaign_context_block(
     )
 
 
-_SCRIPT_OUTPUT_FORMAT_BLOCK = """MANDATORY OUTPUT FORMAT — your entire reply MUST follow this template. The video generator reads this literally; vague prose will fail. Time ranges must partition 0–12s with no gaps and no overlap (total 12.0 seconds).
-
-Audio-safe timeline (critical): Spoken dialogue must only occur between ~0.5s and ~11.35s. Use 0–0.5s for hook visuals with ambient/music/room tone only (no words). Use ~11.35–12s for product moment visuals with ambience or music tail only — the final spoken line must fully complete before ~11.35s with a tiny natural pause after, so nothing is clipped at export.
-
-## Overview (2–4 sentences max)
-Premise, tone, and single clear comedic or emotional idea. State the chosen creator-native format (e.g. POV, reaction, day-in-the-life). Do not read campaign bullets aloud.
-
-## Beat 1 — 0–2s (hook)
-- What we see: (subjects, environment, product visibility — be specific)
-- Camera move: (e.g. handheld close-up, slow push-in, whip pan)
-- Lighting: (time of day, key mood, practicals)
-- Action: (what moves, gestures, reactions; 0–0.5s may be silent performance / reaction only)
-- Line (approx. word count): (if spoken, place words only in ~0.5–2s — opening ~0.5s must be "none — ambient only"; otherwise "none — ambient only" for full beat)
-
-## Beat 2 — 2–5s (setup)
-- What we see:
-- Camera move:
-- Lighting:
-- Action:
-- Line (approx. word count):
-
-## Beat 3 — 5–9s (payoff)
-- What we see:
-- Camera move:
-- Lighting:
-- Action:
-- Line (approx. word count):
-
-## Beat 4 — 9–12s (product moment)
-- What we see:
-- Camera move:
-- Lighting:
-- Action: (9–~11.35s may include performance tied to the last line; ~11.35–12s should be product hero, smile, pack shot, or gesture with no new speech)
-- Line (approx. word count): (any final spoken line must complete before ~11.35s; use "none — ambient only" for ~11.35–12s — never script dialogue that runs against the final frame boundary)
-
-Rules for beats: Each beat's action and visuals must be producible in that time window. Sum of dialogue across all beats must fit comfortably within the dialogue window (~10.8s of speech time inside 12s) (aim for ~28 spoken words max total unless pacing is very fast — leave air at start and end). The first frame may emphasize the product; after Beat 1, move into story per the brief. No readable on-screen words, stickers, burned-in captions, lower-thirds, or typography gags — only picture and sound; "caption-style" humor must be spoken or acted, not written in-frame."""
-
-
 def _build_script_prompt(
     product_name: str,
     product_description: str,
@@ -88,6 +58,11 @@ def _build_script_prompt(
     campaign_product_context: str = "",
 ) -> str:
     """Build the ad script generation prompt with product and consumer context."""
+    total = allowed_video_seconds()
+    t_end = dialogue_end_seconds(total)
+    beat_ranges = script_requirement_beat_ranges(total)
+    format_block = script_output_format_block(total)
+
     campaign_ctx = _format_campaign_context_block(
         campaign_name=campaign_name,
         campaign_goal=campaign_goal,
@@ -114,23 +89,24 @@ def _build_script_prompt(
 
     Visual/audio constraints (hard rules): No readable text in-frame at any time (including logos-as-typography tricks). Voice, ambient sound, and music are fine; do not script or require open captions, subtitles, or any overlay viewers must read. If the platform would add captions later, that is out of scope — script for a clean image with spoken words only.
 
-    {_SCRIPT_OUTPUT_FORMAT_BLOCK}
+    {format_block}
 
     Requirements:
-    1. 12 seconds exactly — output ONLY the Overview plus the four beats (0–2s, 2–5s, 5–9s, 9–12s) in that order; do not add extra beats, scenes, or alternate timelines.
+    1. {total} seconds exactly — output ONLY the Overview plus the four beats ({beat_ranges}) in that order; do not add extra beats, scenes, or alternate timelines.
     2. Fill every bullet field in every beat; use the reference image for accurate product color, shape, label, and packaging.
     3. Make it feel creator-made, not brand-made.
     4. No obvious call-to-action or sales language.
-    5. Honor the audio-safe timeline: no spoken words in the first ~0.5s or last ~0.65s of the spot; last line fully finished before ~11.35s.
+    5. Honor the audio-safe timeline: no spoken words in the first ~{AUDIO_START_GUARD}s or last ~{AUDIO_END_GUARD}s of the spot; last line fully finished before ~{t_end}s.
 
     Be bold with the creative direction. Surprise me with the format you choose in the Overview.
-    All spoken lines must be complete (with a breath of space) before ~11.35s; only non-dialogue audio may continue to 12s."""
+    All spoken lines must be complete (with a breath of space) before ~{t_end}s; only non-dialogue audio may continue to {total}s."""
 
 
-def _moderation_revision_suffix(moderation_feedback: str) -> str:
+def _moderation_revision_suffix(moderation_feedback: str, *, total_seconds: int) -> str:
+    t_end = dialogue_end_seconds(total_seconds)
     return f"""
 
-IMPORTANT — a previous draft failed content review. Write a complete replacement script that fixes ALL of the following while keeping the same 12-second structured format (Overview plus Beats 1–4 with all fields), the same audio-safe margins (no speech first ~0.5s or last ~0.65s; dialogue ends before ~11.35s), and creative spirit:
+IMPORTANT — a previous draft failed content review. Write a complete replacement script that fixes ALL of the following while keeping the same {total_seconds}-second structured format (Overview plus Beats 1–4 with all fields), the same audio-safe margins (no speech first ~{AUDIO_START_GUARD}s or last ~{AUDIO_END_GUARD}s; dialogue ends before ~{t_end}s), and creative spirit:
 {moderation_feedback}
 
 Output only the new script; do not include meta-commentary about the review."""
@@ -154,6 +130,7 @@ async def generate_ad_script(
     base_url = os.getenv("SCRIPT_BASE_URL", "").strip()
     script_client = AsyncOpenAI(api_key=api_key, base_url=base_url)
 
+    total = allowed_video_seconds()
     prompt = _build_script_prompt(
         product_name,
         product_description,
@@ -165,7 +142,7 @@ async def generate_ad_script(
         campaign_product_context=campaign_product_context,
     )
     if moderation_feedback:
-        prompt += _moderation_revision_suffix(moderation_feedback)
+        prompt += _moderation_revision_suffix(moderation_feedback, total_seconds=total)
 
     response = await script_client.responses.create(
         model=model,

--- a/backend/workers/script_creation_worker/worker.py
+++ b/backend/workers/script_creation_worker/worker.py
@@ -38,40 +38,42 @@ def _format_campaign_context_block(
     )
 
 
-_SCRIPT_OUTPUT_FORMAT_BLOCK = """MANDATORY OUTPUT FORMAT — your entire reply MUST follow this template. The video generator reads this literally; vague prose will fail. Time ranges must partition 0–8s with no gaps and no overlap (total 8.0 seconds).
+_SCRIPT_OUTPUT_FORMAT_BLOCK = """MANDATORY OUTPUT FORMAT — your entire reply MUST follow this template. The video generator reads this literally; vague prose will fail. Time ranges must partition 0–12s with no gaps and no overlap (total 12.0 seconds).
+
+Audio-safe timeline (critical): Spoken dialogue must only occur between ~0.5s and ~11.35s. Use 0–0.5s for hook visuals with ambient/music/room tone only (no words). Use ~11.35–12s for product moment visuals with ambience or music tail only — the final spoken line must fully complete before ~11.35s with a tiny natural pause after, so nothing is clipped at export.
 
 ## Overview (2–4 sentences max)
 Premise, tone, and single clear comedic or emotional idea. State the chosen creator-native format (e.g. POV, reaction, day-in-the-life). Do not read campaign bullets aloud.
 
-## Beat 1 — 0–1s (hook)
+## Beat 1 — 0–2s (hook)
 - What we see: (subjects, environment, product visibility — be specific)
 - Camera move: (e.g. handheld close-up, slow push-in, whip pan)
 - Lighting: (time of day, key mood, practicals)
-- Action: (what moves, gestures, reactions)
-- Line (approx. word count): (spoken line or "none — ambient only" with ~0 words)
+- Action: (what moves, gestures, reactions; 0–0.5s may be silent performance / reaction only)
+- Line (approx. word count): (if spoken, place words only in ~0.5–2s — opening ~0.5s must be "none — ambient only"; otherwise "none — ambient only" for full beat)
 
-## Beat 2 — 1–3s (setup)
+## Beat 2 — 2–5s (setup)
 - What we see:
 - Camera move:
 - Lighting:
 - Action:
 - Line (approx. word count):
 
-## Beat 3 — 3–6s (payoff)
+## Beat 3 — 5–9s (payoff)
 - What we see:
 - Camera move:
 - Lighting:
 - Action:
 - Line (approx. word count):
 
-## Beat 4 — 6–8s (product moment)
+## Beat 4 — 9–12s (product moment)
 - What we see:
 - Camera move:
 - Lighting:
-- Action:
-- Line (approx. word count):
+- Action: (9–~11.3s may include performance tied to the last line; ~11.35–12s should be product hero, smile, pack shot, or gesture with no new speech)
+- Line (approx. word count): (any final spoken line must complete before ~11.35s; use "none — ambient only" for ~11.35–12s — never script dialogue that runs against the final frame boundary)
 
-Rules for beats: Each beat's action and visuals must be producible in that time window. Sum of dialogue across all beats must fit comfortably within 8 seconds (aim for ~20 spoken words max total unless pacing is very fast). The first frame may emphasize the product; after Beat 1, move into story per the brief. No readable on-screen words, stickers, burned-in captions, lower-thirds, or typography gags — only picture and sound; "caption-style" humor must be spoken or acted, not written in-frame."""
+Rules for beats: Each beat's action and visuals must be producible in that time window. Sum of dialogue across all beats must fit comfortably within the dialogue window (~10.8s of speech time inside 12s) (aim for ~28 spoken words max total unless pacing is very fast — leave air at start and end). The first frame may emphasize the product; after Beat 1, move into story per the brief. No readable on-screen words, stickers, burned-in captions, lower-thirds, or typography gags — only picture and sound; "caption-style" humor must be spoken or acted, not written in-frame."""
 
 
 def _build_script_prompt(
@@ -115,19 +117,20 @@ def _build_script_prompt(
     {_SCRIPT_OUTPUT_FORMAT_BLOCK}
 
     Requirements:
-    1. 8 seconds exactly — output ONLY the Overview plus the four beats (0–1s, 1–3s, 3–6s, 6–8s) in that order; do not add extra beats, scenes, or alternate timelines.
+    1. 12 seconds exactly — output ONLY the Overview plus the four beats (0–2s, 2–5s, 5–9s, 9–12s) in that order; do not add extra beats, scenes, or alternate timelines.
     2. Fill every bullet field in every beat; use the reference image for accurate product color, shape, label, and packaging.
     3. Make it feel creator-made, not brand-made.
     4. No obvious call-to-action or sales language.
+    5. Honor the audio-safe timeline: no spoken words in the first ~0.5s or last ~0.65s of the spot; last line fully finished before ~11.35s.
 
     Be bold with the creative direction. Surprise me with the format you choose in the Overview.
-    All spoken lines must be complete or naturally trailing off by the end of Beat 4 (8s)."""
+    All spoken lines must be complete (with a breath of space) before ~11.35s; only non-dialogue audio may continue to 12s."""
 
 
 def _moderation_revision_suffix(moderation_feedback: str) -> str:
     return f"""
 
-IMPORTANT — a previous draft failed content review. Write a complete replacement script that fixes ALL of the following while keeping the same 8-second structured format (Overview plus Beats 1–4 with all fields) and creative spirit:
+IMPORTANT — a previous draft failed content review. Write a complete replacement script that fixes ALL of the following while keeping the same 12-second structured format (Overview plus Beats 1–4 with all fields), the same audio-safe margins (no speech first ~0.5s or last ~0.65s; dialogue ends before ~11.35s), and creative spirit:
 {moderation_feedback}
 
 Output only the new script; do not include meta-commentary about the review."""


### PR DESCRIPTION
## Changes
- Product images: Centralizes image_url / image_name parsing in utils/product_image_names.py (JSON arrays from multi-upload, legacy plain strings). The ad job worker uses the first blob name for Azure download and maps missing blobs to a clear AdJobClientError instead of an opaque 500.
- HTTP API: /run-ad-job and /generate-campaign-preview return 400 with a clear detail for AdJobClientError (missing campaign/consumer/product, missing image, blob not found).
- Creative length & audio: Scripts target 12s beats with explicit audio-safe margins; the video worker prepends a matching audio/timeline prefix, supports VIDEO_SECONDS (4 / 8 / 12), and documents alignment with script length in .env.example.
- Database: Drops post-commit refresh() on ad variant updates, sets expire_on_commit=False, and on job failure rolls back then persists failed status, with a retry on a new session if the primary connection is dead.

## Testing
- Extended/updated unit tests for the ad job worker, script/video workers, product routes, and new product_image_names helpers. 
