### PR TITLE
feat: Meta OAuth + campaign publishing + metrics infrastructure

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -17,3 +17,17 @@ AZURE_STORAGE_VIDEO_CONTAINER=ad-videos
 RESEND_API_KEY=YOUR_RESEND_API_KEY
 RESEND_FROM_EMAIL=noreply@yourdomain.com
 EMAIL_VERIFICATION_TOKEN_TTL_MINUTES=15
+
+# Meta (Facebook/Instagram) — set after registering your Meta App
+# developers.facebook.com > Your App > Settings > Basic
+META_APP_ID=YOUR_META_APP_ID
+META_APP_SECRET=YOUR_META_APP_SECRET
+# Must match "Valid OAuth Redirect URIs" registered in the Meta App dashboard
+META_REDIRECT_URI=https://yourapi.com/social-auth/callback
+# Frontend URL to redirect to after OAuth callback
+META_FRONTEND_URL=https://yourapp.com
+
+# Fernet symmetric encryption key for storing OAuth tokens at rest.
+# Generate once with:
+#   python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+FERNET_SECRET_KEY=YOUR_FERNET_KEY

--- a/backend/main.py
+++ b/backend/main.py
@@ -31,6 +31,8 @@ from routes.consumers import router as consumers_router
 from routes.personas import router as personas_router
 from routes.product import router as product_router
 from routes.chat_completions import router as chat_completions_router
+from routes.social_auth import router as social_auth_router
+from routes.metrics import router as metrics_router
 
 from services.ad_job_poller.service import run_poller
 from database import get_engine
@@ -162,6 +164,8 @@ app.include_router(chat_completions_router, prefix="/chat/completions", tags=["C
 app.include_router(consumers_router, prefix="/consumers", tags=["Consumers"])
 app.include_router(product_router, prefix="/products", tags=["Products"])
 app.include_router(personas_router, prefix="/personas", tags=["Personas"])
+app.include_router(social_auth_router, prefix="/social-auth", tags=["Social Auth"])
+app.include_router(metrics_router, prefix="/campaigns", tags=["Campaign Metrics"])
 
 # Methods (GET and HEAD) for uptime robot to keep the app alive
 @app.api_route("/", methods=["GET", "HEAD"])

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -3,11 +3,13 @@ from .ad_job import AdJob
 from .ad_job_batch import AdJobBatch
 from .business_client import BusinessClient
 from .campaign import Campaign
+from .campaign_metric import CampaignMetric
 from .chat_message import ChatMessage
 from .consumer_event import ConsumerEvent
 from .persona import Persona
 from .consumer import Consumer
 from .product import Product
+from .social_connection import SocialConnection
 
 __all__ = [
     "AdVariant",
@@ -15,9 +17,11 @@ __all__ = [
     "AdJobBatch",
     "BusinessClient",
     "Campaign",
+    "CampaignMetric",
     "ChatMessage",
     "ConsumerEvent",
     "Persona",
     "Consumer",
     "Product",
+    "SocialConnection",
 ]

--- a/backend/models/campaign.py
+++ b/backend/models/campaign.py
@@ -28,6 +28,7 @@ class Campaign(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=lambda: datetime.now(timezone.utc))
     updated_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
     product_ids: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    meta_campaign_id: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
 
     def __repr__(self) -> str:
         return f"<Campaign(id={self.id}, name='{self.name}', status='{self.status}')>"

--- a/backend/models/campaign_metric.py
+++ b/backend/models/campaign_metric.py
@@ -1,0 +1,30 @@
+"""SQLAlchemy model for dbo.campaign_metrics — cached daily metrics per campaign."""
+
+from datetime import datetime, date as date_type, timezone
+from decimal import Decimal
+from typing import Optional
+
+from sqlalchemy import Integer, String, Date, DateTime, Numeric
+from sqlalchemy.orm import Mapped, mapped_column
+
+from database import Base
+
+
+class CampaignMetric(Base):
+    __tablename__ = "campaign_metrics"
+    __table_args__ = {"schema": "dbo"}
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    campaign_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    meta_campaign_id: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
+    date: Mapped[date_type] = mapped_column(Date, nullable=False)
+    impressions: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    reach: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    clicks: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    spend: Mapped[Optional[Decimal]] = mapped_column(Numeric(10, 2), nullable=True)
+    ctr: Mapped[Optional[Decimal]] = mapped_column(Numeric(8, 4), nullable=True)
+    cpc: Mapped[Optional[Decimal]] = mapped_column(Numeric(10, 2), nullable=True)
+    conversions: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    fetched_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, default=lambda: datetime.now(timezone.utc)
+    )

--- a/backend/models/social_connection.py
+++ b/backend/models/social_connection.py
@@ -1,0 +1,27 @@
+"""SQLAlchemy model for dbo.social_connections."""
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy import Integer, String, Text, DateTime
+from sqlalchemy.orm import Mapped, mapped_column
+
+from database import Base
+
+
+class SocialConnection(Base):
+    __tablename__ = "social_connections"
+    __table_args__ = {"schema": "dbo"}
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    business_client_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    platform: Mapped[str] = mapped_column(String(30), nullable=False, default="instagram")
+    encrypted_token: Mapped[str] = mapped_column(Text, nullable=False)
+    token_expires_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    # Generic account identifier — IG business account ID, TikTok advertiser ID, etc.
+    platform_account_id: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
+    # JSON blob for platform-specific extras: {"ad_account_id": "act_...", "page_id": "..."}
+    platform_metadata: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    connected_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, default=lambda: datetime.now(timezone.utc)
+    )

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,7 +15,7 @@ azure-storage-blob>=12.0.0
 Pillow>=10.0.0
 scikit-learn>=1.4.0
 numpy>=1.26.0
-httpx>=0.27.0
+httpx>=0.27.0,<0.28
 cryptography>=42.0.0
 
 # Test dependencies

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,7 +15,8 @@ azure-storage-blob>=12.0.0
 Pillow>=10.0.0
 scikit-learn>=1.4.0
 numpy>=1.26.0
-httpx>=0.27.0,<0.28
+httpx>=0.27.0
+cryptography>=42.0.0
 
 # Test dependencies
 pytest>=9.0.0

--- a/backend/routes/metrics.py
+++ b/backend/routes/metrics.py
@@ -1,0 +1,105 @@
+"""Campaign metrics endpoint.
+
+GET /campaigns/{campaign_id}/metrics
+  — Returns cached daily rows + aggregated totals.
+  — Re-fetches from Meta if last pull was > 15 minutes ago AND campaign has
+    a meta_campaign_id + the client has a connected social account.
+"""
+
+import logging
+from decimal import Decimal
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from database import get_db
+from models.campaign import Campaign
+from models.social_connection import SocialConnection
+from routes.auth import get_current_client_id
+from schemas.campaign_metric import CampaignMetricResponse, MetricsSummary
+from services.meta.insights import fetch_and_cache_metrics, is_stale, load_cached_metrics
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+
+@router.get("/{campaign_id}/metrics", response_model=MetricsSummary)
+def get_campaign_metrics(
+    campaign_id: int,
+    db: Session = Depends(get_db),
+    client_id: int = Depends(get_current_client_id),
+):
+    campaign = db.query(Campaign).filter_by(id=campaign_id).first()
+    if not campaign:
+        raise HTTPException(status_code=404, detail="Campaign not found")
+    if campaign.business_client_id != client_id:
+        raise HTTPException(status_code=403, detail="Not authorized")
+
+    meta_campaign_id: Optional[str] = getattr(campaign, "meta_campaign_id", None)
+
+    if meta_campaign_id:
+        connection = (
+            db.query(SocialConnection)
+            .filter_by(business_client_id=client_id, platform="instagram")
+            .first()
+        )
+        if connection:
+            # Determine staleness from the most-recently fetched row
+            from models.campaign_metric import CampaignMetric
+            latest = (
+                db.query(CampaignMetric)
+                .filter_by(campaign_id=campaign_id)
+                .order_by(CampaignMetric.fetched_at.desc())
+                .first()
+            )
+            if is_stale(latest.fetched_at if latest else None):
+                try:
+                    rows = fetch_and_cache_metrics(
+                        db=db,
+                        campaign_id=campaign_id,
+                        meta_campaign_id=meta_campaign_id,
+                        encrypted_token=connection.encrypted_token,
+                    )
+                except Exception:
+                    logger.exception("Failed to refresh metrics for campaign %s", campaign_id)
+                    rows = load_cached_metrics(db, campaign_id)
+            else:
+                rows = load_cached_metrics(db, campaign_id)
+        else:
+            rows = load_cached_metrics(db, campaign_id)
+    else:
+        rows = load_cached_metrics(db, campaign_id)
+
+    return _build_summary(campaign_id, rows)
+
+
+def _build_summary(campaign_id: int, rows: list) -> MetricsSummary:
+    total_impressions = sum(r.impressions or 0 for r in rows)
+    total_reach = sum(r.reach or 0 for r in rows)
+    total_clicks = sum(r.clicks or 0 for r in rows)
+    total_spend = sum(r.spend or Decimal(0) for r in rows)
+    total_conversions = sum(r.conversions or 0 for r in rows)
+
+    avg_ctr = (
+        sum(r.ctr or Decimal(0) for r in rows) / len(rows)
+        if rows else None
+    )
+    avg_cpc = (
+        sum(r.cpc or Decimal(0) for r in rows) / len(rows)
+        if rows else None
+    )
+
+    last_fetched = max((r.fetched_at for r in rows), default=None)
+
+    return MetricsSummary(
+        total_impressions=total_impressions,
+        total_reach=total_reach,
+        total_clicks=total_clicks,
+        total_spend=total_spend,
+        avg_ctr=avg_ctr,
+        avg_cpc=avg_cpc,
+        total_conversions=total_conversions,
+        days=[CampaignMetricResponse.model_validate(r) for r in rows],
+        last_fetched_at=last_fetched,
+    )

--- a/backend/routes/social_auth.py
+++ b/backend/routes/social_auth.py
@@ -1,0 +1,166 @@
+"""OAuth flow for connecting social platform accounts.
+
+GET  /social-auth/connect?platform=instagram  → returns { url } to redirect client to Meta
+GET  /social-auth/callback?code=...&state=... → exchanges code, stores token, redirects to frontend
+GET  /social-auth/status                      → lists all connected platforms for current client
+DELETE /social-auth/disconnect?platform=instagram → removes connection
+"""
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import RedirectResponse
+from jose import JWTError, jwt
+from sqlalchemy.orm import Session
+
+from database import get_db
+from models.social_connection import SocialConnection
+from routes.auth import get_current_client_id
+from schemas.social_connection import ConnectStatusResponse
+from services.meta.auth import (
+    build_oauth_url,
+    exchange_code_for_long_lived_token,
+    encrypt_token,
+    fetch_platform_account_info,
+    token_expiry_dt,
+)
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+SUPPORTED_PLATFORMS = {"instagram"}
+STATE_ALGORITHM = "HS256"
+STATE_TTL_MINUTES = 15
+
+
+def _make_state(client_id: int) -> str:
+    secret = os.environ["JWT_SECRET"]
+    return jwt.encode(
+        {"client_id": client_id, "exp": datetime.now(timezone.utc).timestamp() + STATE_TTL_MINUTES * 60},
+        secret,
+        algorithm=STATE_ALGORITHM,
+    )
+
+
+def _decode_state(state: str) -> int:
+    secret = os.environ["JWT_SECRET"]
+    try:
+        payload = jwt.decode(state, secret, algorithms=[STATE_ALGORITHM])
+        return int(payload["client_id"])
+    except JWTError as exc:
+        raise HTTPException(status_code=400, detail="Invalid or expired OAuth state") from exc
+
+
+@router.get("/connect")
+def initiate_connect(
+    platform: str = Query(default="instagram"),
+    client_id: int = Depends(get_current_client_id),
+):
+    """Return the OAuth URL for the client to redirect to."""
+    if platform not in SUPPORTED_PLATFORMS:
+        raise HTTPException(status_code=400, detail=f"Unsupported platform: {platform}")
+    state = _make_state(client_id)
+    url = build_oauth_url(state)
+    return {"url": url}
+
+
+@router.get("/callback")
+def oauth_callback(
+    code: str = Query(...),
+    state: str = Query(...),
+    db: Session = Depends(get_db),
+):
+    """Meta redirects here after the user grants permissions.
+
+    Exchanges the code for a long-lived token, fetches account IDs,
+    and stores an encrypted SocialConnection row.
+    Redirects to the frontend settings page with ?connected=instagram.
+    """
+    frontend_url = os.environ.get("META_FRONTEND_URL", "http://localhost:5173")
+
+    client_id = _decode_state(state)
+
+    try:
+        token_data = exchange_code_for_long_lived_token(code)
+        access_token: str = token_data["access_token"]
+        expires_in: int = token_data.get("expires_in", 60 * 24 * 3600)  # default 60 days
+        account_info = fetch_platform_account_info(access_token)
+    except Exception:
+        logger.exception("Meta OAuth token exchange failed for client %s", client_id)
+        return RedirectResponse(f"{frontend_url}/#/settings?error=oauth_failed&tab=integrations")
+
+    encrypted = encrypt_token(access_token)
+    platform_metadata = json.dumps({
+        "ad_account_id": account_info["ad_account_id"],
+        "facebook_page_id": account_info["facebook_page_id"],
+    })
+
+    existing = (
+        db.query(SocialConnection)
+        .filter_by(business_client_id=client_id, platform="instagram")
+        .first()
+    )
+    if existing:
+        existing.encrypted_token = encrypted
+        existing.token_expires_at = token_expiry_dt(expires_in)
+        existing.platform_account_id = account_info["instagram_account_id"]
+        existing.platform_metadata = platform_metadata
+        existing.connected_at = datetime.now(timezone.utc)
+    else:
+        db.add(SocialConnection(
+            business_client_id=client_id,
+            platform="instagram",
+            encrypted_token=encrypted,
+            token_expires_at=token_expiry_dt(expires_in),
+            platform_account_id=account_info["instagram_account_id"],
+            platform_metadata=platform_metadata,
+        ))
+
+    db.commit()
+    logger.info("Stored Instagram connection for client %s", client_id)
+    return RedirectResponse(f"{frontend_url}/#/settings?connected=instagram&tab=integrations")
+
+
+@router.get("/status", response_model=list[ConnectStatusResponse])
+def connection_status(
+    client_id: int = Depends(get_current_client_id),
+    db: Session = Depends(get_db),
+):
+    """Return connection status for all supported platforms."""
+    connections = (
+        db.query(SocialConnection)
+        .filter_by(business_client_id=client_id)
+        .all()
+    )
+    connected_map = {c.platform: c for c in connections}
+
+    return [
+        ConnectStatusResponse(
+            platform=platform,
+            connected=platform in connected_map,
+            platform_account_id=connected_map[platform].platform_account_id if platform in connected_map else None,
+            connected_at=connected_map[platform].connected_at if platform in connected_map else None,
+        )
+        for platform in SUPPORTED_PLATFORMS
+    ]
+
+
+@router.delete("/disconnect")
+def disconnect(
+    platform: str = Query(default="instagram"),
+    client_id: int = Depends(get_current_client_id),
+    db: Session = Depends(get_db),
+):
+    connection = (
+        db.query(SocialConnection)
+        .filter_by(business_client_id=client_id, platform=platform)
+        .first()
+    )
+    if not connection:
+        raise HTTPException(status_code=404, detail="No connection found for this platform")
+    db.delete(connection)
+    db.commit()
+    return {"disconnected": platform}

--- a/backend/schemas/campaign_metric.py
+++ b/backend/schemas/campaign_metric.py
@@ -1,0 +1,36 @@
+"""Pydantic schemas for campaign_metrics."""
+
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Optional
+from pydantic import BaseModel
+
+
+class CampaignMetricResponse(BaseModel):
+    id: int
+    campaign_id: int
+    meta_campaign_id: Optional[str]
+    date: date
+    impressions: Optional[int]
+    reach: Optional[int]
+    clicks: Optional[int]
+    spend: Optional[Decimal]
+    ctr: Optional[Decimal]
+    cpc: Optional[Decimal]
+    conversions: Optional[int]
+    fetched_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class MetricsSummary(BaseModel):
+    """Aggregated totals across the date range, plus per-day rows."""
+    total_impressions: int
+    total_reach: int
+    total_clicks: int
+    total_spend: Decimal
+    avg_ctr: Optional[Decimal]
+    avg_cpc: Optional[Decimal]
+    total_conversions: int
+    days: list[CampaignMetricResponse]
+    last_fetched_at: Optional[datetime]

--- a/backend/schemas/social_connection.py
+++ b/backend/schemas/social_connection.py
@@ -1,0 +1,25 @@
+"""Pydantic schemas for social_connections."""
+
+from datetime import datetime
+from typing import Optional
+from pydantic import BaseModel
+
+
+class SocialConnectionResponse(BaseModel):
+    id: int
+    business_client_id: int
+    platform: str
+    token_expires_at: Optional[datetime]
+    platform_account_id: Optional[str]
+    platform_metadata: Optional[str]
+    connected_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class ConnectStatusResponse(BaseModel):
+    """Summary of connected platforms for a client."""
+    platform: str
+    connected: bool
+    platform_account_id: Optional[str] = None
+    connected_at: Optional[datetime] = None

--- a/backend/services/meta/auth.py
+++ b/backend/services/meta/auth.py
@@ -27,8 +27,6 @@ META_DIALOG_URL = "https://www.facebook.com/dialog/oauth"
 META_SCOPES = ",".join([
     "ads_management",
     "ads_read",
-    "instagram_basic",
-    "instagram_content_publish",
     "pages_read_engagement",
     "pages_show_list",
     "business_management",

--- a/backend/services/meta/auth.py
+++ b/backend/services/meta/auth.py
@@ -1,0 +1,152 @@
+"""Meta OAuth helpers: token encryption, URL building, code exchange.
+
+Uses the Facebook Login flow (not Instagram Login) because we need
+ads_management for paid campaign publishing.
+
+Required env vars (set after Meta App is approved):
+  META_APP_ID          — developers.facebook.com > Your App > Settings > Basic
+  META_APP_SECRET      — same page
+  META_REDIRECT_URI    — registered in Meta App's Valid OAuth Redirect URIs
+                         e.g. https://yourapi.com/social-auth/callback
+  META_FRONTEND_URL    — where to redirect after callback (e.g. https://app.adgentic.ai)
+  FERNET_SECRET_KEY    — run once to generate:
+                         python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+"""
+
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+import httpx
+from cryptography.fernet import Fernet
+
+META_GRAPH_VERSION = "v21.0"
+META_GRAPH_BASE = f"https://graph.facebook.com/{META_GRAPH_VERSION}"
+META_DIALOG_URL = "https://www.facebook.com/dialog/oauth"
+
+META_SCOPES = ",".join([
+    "ads_management",
+    "ads_read",
+    "instagram_basic",
+    "instagram_content_publish",
+    "pages_read_engagement",
+    "pages_show_list",
+    "business_management",
+])
+
+
+def _fernet() -> Fernet:
+    key = os.environ.get("FERNET_SECRET_KEY")
+    if not key:
+        raise RuntimeError("FERNET_SECRET_KEY env var not set")
+    return Fernet(key.encode())
+
+
+def encrypt_token(token: str) -> str:
+    return _fernet().encrypt(token.encode()).decode()
+
+
+def decrypt_token(encrypted: str) -> str:
+    return _fernet().decrypt(encrypted.encode()).decode()
+
+
+def build_oauth_url(state: str) -> str:
+    app_id = os.environ.get("META_APP_ID")
+    redirect_uri = os.environ.get("META_REDIRECT_URI")
+    if not app_id or not redirect_uri:
+        raise RuntimeError("META_APP_ID and META_REDIRECT_URI must be set")
+
+    params = (
+        f"client_id={app_id}"
+        f"&redirect_uri={redirect_uri}"
+        f"&scope={META_SCOPES}"
+        f"&response_type=code"
+        f"&state={state}"
+    )
+    return f"{META_DIALOG_URL}?{params}"
+
+
+def exchange_code_for_long_lived_token(code: str) -> dict:
+    """Exchange auth code → short-lived → long-lived user token (60-day expiry)."""
+    app_id = os.environ.get("META_APP_ID")
+    app_secret = os.environ.get("META_APP_SECRET")
+    redirect_uri = os.environ.get("META_REDIRECT_URI")
+
+    # Step 1: code → short-lived token
+    r1 = httpx.get(
+        f"{META_GRAPH_BASE}/oauth/access_token",
+        params={
+            "client_id": app_id,
+            "client_secret": app_secret,
+            "redirect_uri": redirect_uri,
+            "code": code,
+        },
+        timeout=15,
+    )
+    r1.raise_for_status()
+
+    # Step 2: short-lived → long-lived (60 days)
+    r2 = httpx.get(
+        f"{META_GRAPH_BASE}/oauth/access_token",
+        params={
+            "grant_type": "fb_exchange_token",
+            "client_id": app_id,
+            "client_secret": app_secret,
+            "fb_exchange_token": r1.json()["access_token"],
+        },
+        timeout=15,
+    )
+    r2.raise_for_status()
+    return r2.json()  # {"access_token": str, "token_type": str, "expires_in": int}
+
+
+def fetch_platform_account_info(access_token: str) -> dict:
+    """Return IG business account ID, Facebook Page ID, and first Ad Account ID.
+
+    Returns:
+        {
+            "instagram_account_id": str | None,
+            "facebook_page_id": str | None,
+            "ad_account_id": str | None,   # format: act_XXXXXXXXX
+        }
+    """
+    instagram_account_id: Optional[str] = None
+    facebook_page_id: Optional[str] = None
+    ad_account_id: Optional[str] = None
+
+    # Facebook Pages managed by this user, with linked IG account
+    pages = httpx.get(
+        f"{META_GRAPH_BASE}/me/accounts",
+        params={
+            "access_token": access_token,
+            "fields": "id,name,instagram_business_account",
+        },
+        timeout=15,
+    )
+    pages.raise_for_status()
+    for page in pages.json().get("data", []):
+        if "instagram_business_account" in page:
+            facebook_page_id = page["id"]
+            instagram_account_id = page["instagram_business_account"]["id"]
+            break
+
+    # Ad accounts accessible to this user
+    ads = httpx.get(
+        f"{META_GRAPH_BASE}/me/adaccounts",
+        params={"access_token": access_token, "fields": "id,name,account_status"},
+        timeout=15,
+    )
+    ads.raise_for_status()
+    accounts = ads.json().get("data", [])
+    if accounts:
+        ad_account_id = accounts[0]["id"]
+
+    return {
+        "instagram_account_id": instagram_account_id,
+        "facebook_page_id": facebook_page_id,
+        "ad_account_id": ad_account_id,
+    }
+
+
+def token_expiry_dt(expires_in: int) -> datetime:
+    return datetime.now(timezone.utc) + timedelta(seconds=expires_in)

--- a/backend/services/meta/auth.py
+++ b/backend/services/meta/auth.py
@@ -2,15 +2,6 @@
 
 Uses the Facebook Login flow (not Instagram Login) because we need
 ads_management for paid campaign publishing.
-
-Required env vars (set after Meta App is approved):
-  META_APP_ID          — developers.facebook.com > Your App > Settings > Basic
-  META_APP_SECRET      — same page
-  META_REDIRECT_URI    — registered in Meta App's Valid OAuth Redirect URIs
-                         e.g. https://yourapi.com/social-auth/callback
-  META_FRONTEND_URL    — where to redirect after callback (e.g. https://app.adgentic.ai)
-  FERNET_SECRET_KEY    — run once to generate:
-                         python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
 """
 
 import os
@@ -112,7 +103,7 @@ def fetch_platform_account_info(access_token: str) -> dict:
     facebook_page_id: Optional[str] = None
     ad_account_id: Optional[str] = None
 
-    # Facebook Pages managed by this user, with linked IG account
+    # Facebook Pages managed by this user, with linked IG account 
     pages = httpx.get(
         f"{META_GRAPH_BASE}/me/accounts",
         params={

--- a/backend/services/meta/campaign_publisher.py
+++ b/backend/services/meta/campaign_publisher.py
@@ -1,0 +1,232 @@
+"""Publishes an Ad-gentic campaign to Meta as a paid Instagram ad campaign.
+
+Structure:
+  1 Meta Campaign  (single objective, maps from campaign.goal)
+  N Ad Sets        (one per persona — persona-specific targeting + budget split)
+  M Ads per Set    (one per approved variant assigned to that persona)
+
+Budget allocation:
+  daily_per_adset = (budget_total / num_adsets / campaign_days) * 100  (cents)
+
+TODO: Activate by completing the Meta OAuth flow in the Settings page after
+      META_APP_ID, META_APP_SECRET, FERNET_SECRET_KEY env vars are set.
+"""
+
+import json
+import logging
+from datetime import date
+from typing import Optional
+
+import httpx
+
+from services.meta.auth import decrypt_token
+
+logger = logging.getLogger(__name__)
+
+META_GRAPH_VERSION = "v21.0"
+META_GRAPH_BASE = f"https://graph.facebook.com/{META_GRAPH_VERSION}"
+
+GOAL_TO_OBJECTIVE = {
+    "brand_awareness": "BRAND_AWARENESS",
+    "reach": "REACH",
+    "traffic": "LINK_CLICKS",
+    "engagement": "POST_ENGAGEMENT",
+    "leads": "LEAD_GENERATION",
+    "sales": "OUTCOME_SALES",
+    "conversions": "OUTCOME_SALES",
+}
+DEFAULT_OBJECTIVE = "OUTCOME_AWARENESS"
+
+DEFAULT_CAMPAIGN_DAYS = 30
+MIN_DAILY_BUDGET_CENTS = 100  # Meta minimum is $1/day per ad set
+
+
+def _post(path: str, token: str, payload: dict) -> dict:
+    resp = httpx.post(
+        f"{META_GRAPH_BASE}/{path}",
+        json={**payload, "access_token": token},
+        timeout=30,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def publish_campaign(
+    *,
+    campaign_name: str,
+    goal: Optional[str],
+    budget_total: Optional[float],
+    start_date: Optional[date],
+    end_date: Optional[date],
+    # Variants grouped by persona:
+    # [{"persona_name": str, "persona_traits": dict, "variants": [{"id", "media_url", "script"}]}]
+    persona_groups: list[dict],
+    encrypted_token: str,
+    ad_account_id: str,       # format: act_XXXXXXXXX
+    instagram_account_id: str,
+    facebook_page_id: str,
+) -> str:
+    """Build the full Meta campaign hierarchy and return the Meta campaign ID."""
+    token = decrypt_token(encrypted_token)
+    objective = GOAL_TO_OBJECTIVE.get((goal or "").lower(), DEFAULT_OBJECTIVE)
+
+    # ── 1. Campaign ───────────────────────────────────────────────────────
+    campaign_resp = _post(
+        f"{ad_account_id}/campaigns",
+        token,
+        {
+            "name": campaign_name,
+            "objective": objective,
+            "status": "PAUSED",  # client activates in Meta Ads Manager after review
+            "special_ad_categories": [],
+        },
+    )
+    meta_campaign_id: str = campaign_resp["id"]
+    logger.info("Created Meta campaign %s ('%s')", meta_campaign_id, campaign_name)
+
+    # ── 2. Budget maths ───────────────────────────────────────────────────
+    num_adsets = len(persona_groups)
+    if num_adsets == 0:
+        logger.warning("No persona groups with approved variants — skipping ad sets")
+        return meta_campaign_id
+
+    campaign_days = _campaign_days(start_date, end_date)
+    total_budget = budget_total or 300.0  # default $300 if not set
+    raw_daily_per_adset = (total_budget / num_adsets / campaign_days) * 100
+    daily_budget_cents = max(int(raw_daily_per_adset), MIN_DAILY_BUDGET_CENTS)
+
+    # ── 3. Ad Set + Ads per persona group ─────────────────────────────────
+    for group in persona_groups:
+        persona_name: str = group["persona_name"]
+        persona_traits: dict = group.get("persona_traits") or {}
+        variants: list[dict] = group.get("variants") or []
+
+        if not variants:
+            continue
+
+        targeting = _build_targeting_for_persona(persona_traits)
+
+        adset_resp = _post(
+            f"{ad_account_id}/adsets",
+            token,
+            {
+                "name": f"{campaign_name} — {persona_name}",
+                "campaign_id": meta_campaign_id,
+                "daily_budget": daily_budget_cents,
+                "billing_event": "IMPRESSIONS",
+                "optimization_goal": "REACH",
+                "targeting": targeting,
+                "status": "PAUSED",
+                **({"start_time": start_date.isoformat()} if start_date else {}),
+                **({"end_time": end_date.isoformat()} if end_date else {}),
+            },
+        )
+        adset_id: str = adset_resp["id"]
+        logger.info(
+            "Created ad set '%s' (budget: $%.2f/day)",
+            persona_name,
+            daily_budget_cents / 100,
+        )
+
+        for variant in variants:
+            try:
+                _create_ad_for_variant(
+                    variant=variant,
+                    token=token,
+                    ad_account_id=ad_account_id,
+                    adset_id=adset_id,
+                    instagram_account_id=instagram_account_id,
+                    facebook_page_id=facebook_page_id,
+                    campaign_name=campaign_name,
+                    persona_name=persona_name,
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to create ad for variant %s in persona '%s'",
+                    variant.get("id"),
+                    persona_name,
+                )
+
+    return meta_campaign_id
+
+
+def _create_ad_for_variant(
+    *,
+    variant: dict,
+    token: str,
+    ad_account_id: str,
+    adset_id: str,
+    instagram_account_id: str,
+    facebook_page_id: str,
+    campaign_name: str,
+    persona_name: str,
+) -> None:
+    script = (variant.get("script") or "")[:2200]  # Meta copy limit
+    message = script or campaign_name
+
+    creative_resp = _post(
+        f"{ad_account_id}/adcreatives",
+        token,
+        {
+            "name": f"{persona_name} — Variant #{variant['id']}",
+            "object_story_spec": {
+                "page_id": facebook_page_id,
+                "instagram_actor_id": instagram_account_id,
+                "video_data": {
+                    "video_url": variant["media_url"],
+                    "message": message,
+                    "call_to_action": {"type": "LEARN_MORE"},
+                },
+            },
+        },
+    )
+
+    _post(
+        f"{ad_account_id}/ads",
+        token,
+        {
+            "name": f"{campaign_name} — {persona_name} — Variant #{variant['id']}",
+            "adset_id": adset_id,
+            "creative": {"creative_id": creative_resp["id"]},
+            "status": "PAUSED",
+        },
+    )
+    logger.info("Created Meta ad for variant %s (persona: %s)", variant["id"], persona_name)
+
+
+def _build_targeting_for_persona(traits: dict) -> dict:
+    """Convert persona trait dict to a Meta targeting spec.
+
+    Trait keys (from our persona/consumer model):
+      age_range: [min, max]
+      gender: "male" | "female" | "all"
+      interests: list[str]  (future: map to Meta interest IDs)
+    """
+    targeting: dict = {
+        "geo_locations": {"countries": ["US"]},
+        "publisher_platforms": ["instagram"],
+        "instagram_positions": ["stream", "story", "reels"],
+    }
+
+    age_range = traits.get("age_range")
+    if isinstance(age_range, list) and len(age_range) == 2:
+        targeting["age_min"] = max(18, int(age_range[0]))
+        targeting["age_max"] = min(65, int(age_range[1]))
+    else:
+        targeting["age_min"] = 18
+        targeting["age_max"] = 65
+
+    gender = traits.get("gender", "all")
+    if gender == "male":
+        targeting["genders"] = [1]
+    elif gender == "female":
+        targeting["genders"] = [2]
+    # "all" → omit genders key (Meta default = all genders)
+
+    return targeting
+
+
+def _campaign_days(start_date: Optional[date], end_date: Optional[date]) -> int:
+    if start_date and end_date and end_date > start_date:
+        return (end_date - start_date).days
+    return DEFAULT_CAMPAIGN_DAYS

--- a/backend/services/meta/insights.py
+++ b/backend/services/meta/insights.py
@@ -1,0 +1,117 @@
+"""Fetches campaign metrics from Meta Insights API and caches them in DB.
+
+Meta returns one row per calendar day (time_increment=1). We upsert each day's
+row — overwriting if it exists (Meta updates current-day numbers in real-time)
+or inserting if new. Totals are aggregated at read time in MetricsSummary.
+
+Called when the user opens the Analytics tab; re-fetches only if last pull
+was more than STALE_THRESHOLD_MINUTES ago.
+"""
+
+import logging
+from datetime import date, datetime, timezone
+from decimal import Decimal
+from typing import Optional
+
+import httpx
+from sqlalchemy.orm import Session
+
+from models.campaign_metric import CampaignMetric
+from services.meta.auth import decrypt_token
+
+logger = logging.getLogger(__name__)
+
+META_GRAPH_VERSION = "v21.0"
+META_GRAPH_BASE = f"https://graph.facebook.com/{META_GRAPH_VERSION}"
+
+STALE_THRESHOLD_MINUTES = 15
+
+
+def is_stale(last_fetched_at: Optional[datetime]) -> bool:
+    if last_fetched_at is None:
+        return True
+    age = datetime.now(timezone.utc) - last_fetched_at.replace(tzinfo=timezone.utc)
+    return age.total_seconds() > STALE_THRESHOLD_MINUTES * 60
+
+
+def fetch_and_cache_metrics(
+    db: Session,
+    campaign_id: int,
+    meta_campaign_id: str,
+    encrypted_token: str,
+) -> list[CampaignMetric]:
+    """Pull last-30-day insights from Meta, upsert one row per day, return all rows.
+
+    Each row represents a single calendar day's metrics for this campaign.
+    The current day's row is re-written on each fetch (Meta updates it in real-time).
+    Historical day rows are also refreshed in case Meta recalculates them.
+    """
+    token = decrypt_token(encrypted_token)
+
+    resp = httpx.get(
+        f"{META_GRAPH_BASE}/{meta_campaign_id}/insights",
+        params={
+            "access_token": token,
+            "fields": "date_start,impressions,reach,clicks,spend,ctr,cpc,actions",
+            "date_preset": "last_30d",
+            "time_increment": 1,   # one dict per calendar day in the response
+            "level": "campaign",
+        },
+        timeout=20,
+    )
+    resp.raise_for_status()
+
+    now = datetime.now(timezone.utc)
+    for day_row in resp.json().get("data", []):
+        # Each day_row is one day's snapshot, e.g.:
+        # {"date_start": "2026-04-18", "impressions": 1800, "reach": 1600, ...}
+        day = date.fromisoformat(day_row["date_start"])
+        conversions = _extract_conversions(day_row.get("actions", []))
+
+        existing = db.query(CampaignMetric).filter_by(campaign_id=campaign_id, date=day).first()
+        if existing:
+            # Overwrite with latest values — Meta may have updated this day's numbers
+            _apply(existing, day_row, conversions, meta_campaign_id, now)
+        else:
+            metric = CampaignMetric(campaign_id=campaign_id, date=day)
+            _apply(metric, day_row, conversions, meta_campaign_id, now)
+            db.add(metric)
+
+    db.commit()
+    return load_cached_metrics(db, campaign_id)
+
+
+def load_cached_metrics(db: Session, campaign_id: int) -> list[CampaignMetric]:
+    """Return all cached daily rows, ordered oldest-first (for charting)."""
+    return (
+        db.query(CampaignMetric)
+        .filter_by(campaign_id=campaign_id)
+        .order_by(CampaignMetric.date)
+        .all()
+    )
+
+
+def _apply(
+    metric: CampaignMetric,
+    row: dict,
+    conversions: int,
+    meta_campaign_id: str,
+    now: datetime,
+) -> None:
+    """Write one day's Meta API values into a CampaignMetric ORM row."""
+    metric.meta_campaign_id = meta_campaign_id
+    metric.impressions = int(row.get("impressions") or 0)
+    metric.reach = int(row.get("reach") or 0)
+    metric.clicks = int(row.get("clicks") or 0)
+    metric.spend = Decimal(str(row.get("spend") or "0"))
+    metric.ctr = Decimal(str(row.get("ctr") or "0"))
+    metric.cpc = Decimal(str(row.get("cpc") or "0"))
+    metric.conversions = conversions
+    metric.fetched_at = now
+
+
+def _extract_conversions(actions: list[dict]) -> int:
+    for action in actions:
+        if action.get("action_type") in ("purchase", "omni_purchase", "offsite_conversion"):
+            return int(action.get("value", 0))
+    return 0

--- a/frontend/src/api/metrics.ts
+++ b/frontend/src/api/metrics.ts
@@ -1,0 +1,36 @@
+import { apiUrl, authHeaders } from './config';
+
+export interface CampaignMetricDay {
+  id: number;
+  campaign_id: number;
+  meta_campaign_id: string | null;
+  date: string;
+  impressions: number | null;
+  reach: number | null;
+  clicks: number | null;
+  spend: string | null;
+  ctr: string | null;
+  cpc: string | null;
+  conversions: number | null;
+  fetched_at: string;
+}
+
+export interface MetricsSummary {
+  total_impressions: number;
+  total_reach: number;
+  total_clicks: number;
+  total_spend: string;
+  avg_ctr: string | null;
+  avg_cpc: string | null;
+  total_conversions: number;
+  days: CampaignMetricDay[];
+  last_fetched_at: string | null;
+}
+
+export async function fetchCampaignMetrics(campaignId: number): Promise<MetricsSummary> {
+  const res = await fetch(apiUrl(`/campaigns/${campaignId}/metrics`), {
+    headers: authHeaders(),
+  });
+  if (!res.ok) throw new Error('Failed to fetch campaign metrics');
+  return res.json();
+}

--- a/frontend/src/api/social.ts
+++ b/frontend/src/api/social.ts
@@ -1,0 +1,33 @@
+import { apiUrl, authHeaders } from './config';
+
+export interface ConnectStatusResponse {
+  platform: string;
+  connected: boolean;
+  platform_account_id: string | null;
+  connected_at: string | null;
+}
+
+export async function getSocialConnectionStatus(): Promise<ConnectStatusResponse[]> {
+  const res = await fetch(apiUrl('/social-auth/status'), {
+    headers: authHeaders(),
+  });
+  if (!res.ok) throw new Error('Failed to fetch social connection status');
+  return res.json();
+}
+
+export async function getOAuthConnectUrl(platform = 'instagram'): Promise<string> {
+  const res = await fetch(apiUrl(`/social-auth/connect?platform=${platform}`), {
+    headers: authHeaders(),
+  });
+  if (!res.ok) throw new Error('Failed to get OAuth URL');
+  const data = await res.json();
+  return data.url;
+}
+
+export async function disconnectSocialPlatform(platform = 'instagram'): Promise<void> {
+  const res = await fetch(apiUrl(`/social-auth/disconnect?platform=${platform}`), {
+    method: 'DELETE',
+    headers: authHeaders(),
+  });
+  if (!res.ok) throw new Error('Failed to disconnect platform');
+}

--- a/frontend/src/hooks/useCampaignMetrics.ts
+++ b/frontend/src/hooks/useCampaignMetrics.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchCampaignMetrics } from '../api/metrics';
+
+export function useCampaignMetrics(campaignId: number, enabled = true) {
+  return useQuery({
+    queryKey: ['campaigns', campaignId, 'metrics'],
+    queryFn: () => fetchCampaignMetrics(campaignId),
+    enabled: enabled && !!campaignId,
+    staleTime: 15 * 60 * 1000,  // 15 min — matches backend stale threshold
+  });
+}

--- a/frontend/src/hooks/useSocialConnection.ts
+++ b/frontend/src/hooks/useSocialConnection.ts
@@ -1,0 +1,33 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  getSocialConnectionStatus,
+  getOAuthConnectUrl,
+  disconnectSocialPlatform,
+} from '../api/social';
+
+const SOCIAL_STATUS_KEY = ['social', 'status'];
+
+export function useSocialConnectionStatus() {
+  return useQuery({
+    queryKey: SOCIAL_STATUS_KEY,
+    queryFn: getSocialConnectionStatus,
+  });
+}
+
+export function useConnectSocialPlatform() {
+  return useMutation({
+    mutationFn: async ({platform = 'instagram'} : { platform?: string }) => {
+      const url = await getOAuthConnectUrl(platform);
+      // Redirect the browser to Meta's OAuth dialog
+      window.location.href = url;
+    },
+  });
+}
+
+export function useDisconnectSocialPlatform() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({platform}: { platform?: string }) => disconnectSocialPlatform(platform),
+    onSuccess: () => qc.invalidateQueries({ queryKey: SOCIAL_STATUS_KEY }),
+  });
+}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
+import { useSocialConnectionStatus, useConnectSocialPlatform, useDisconnectSocialPlatform } from '../hooks/useSocialConnection';
 import { Sidebar } from '../components/layout/Sidebar';
 import { useSidebar } from '../contexts/SidebarContext';
 import { useTheme } from '../contexts/ThemeContext';
@@ -91,8 +92,24 @@ const [brandForm, setBrandForm] = useState({
     guidelines: 'Always lead with value. Avoid jargon. Use data to support claims. Maintain a confident but approachable voice.',
   });
 
-  const [integrations, setIntegrations] = useState(initialIntegrations);
+  const { data: socialStatus = [] } = useSocialConnectionStatus();
+  const connectMeta = useConnectSocialPlatform();
+  const disconnectMeta = useDisconnectSocialPlatform();
+
+  // Static state for non-Meta platforms (mock/future integrations)
+  const [staticIntegrations, setStaticIntegrations] = useState(initialIntegrations);
   const [connectingId, setConnectingId] = useState<string | null>(null);
+
+  // Overlay real Meta connection status onto the static list
+  const integrations = staticIntegrations.map((i) => {
+    if (i.id === 'meta') {
+      const live = socialStatus.find((s) => s.platform === 'instagram');
+      if (live) {
+        return { ...i, connected: live.connected, accountName: live.platform_account_id ?? undefined };
+      }
+    }
+    return i;
+  });
   const [notifications, setNotifications] = useState(initialNotifications);
   const [channelMasters, setChannelMasters] = useState({ email: true, inApp: true, slack: true });
 
@@ -101,6 +118,10 @@ const [brandForm, setBrandForm] = useState({
     const tab = params.get('tab');
     if (tab && ['plans', 'billing', 'notifications', 'brand', 'integrations'].includes(tab)) {
       setActiveTab(tab as TabKey);
+    }
+    if (params.get('connected')) {
+      setShowSuccess(true);
+      setTimeout(() => setShowSuccess(false), 3000);
     }
   }, [location.search]);
 
@@ -118,15 +139,24 @@ const [brandForm, setBrandForm] = useState({
   };
 
   const handleConnect = (id: string) => {
+    if (id === 'meta') {
+      connectMeta.mutate({ platform: 'instagram' });
+      return;
+    }
+    // Mock connect for future platforms
     setConnectingId(id);
     setTimeout(() => {
-      setIntegrations((prev) => prev.map((i) => i.id === id ? { ...i, connected: true, accountName: 'Connected Account' } : i));
+      setStaticIntegrations((prev) => prev.map((i) => i.id === id ? { ...i, connected: true, accountName: 'Connected Account' } : i));
       setConnectingId(null);
     }, 1500);
   };
 
   const handleDisconnect = (id: string) => {
-    setIntegrations((prev) => prev.map((i) => i.id === id ? { ...i, connected: false, accountName: undefined } : i));
+    if (id === 'meta') {
+      disconnectMeta.mutate({ platform: 'instagram' });
+      return;
+    }
+    setStaticIntegrations((prev) => prev.map((i) => i.id === id ? { ...i, connected: false, accountName: undefined } : i));
   };
 
   const toggleNotification = (id: string, channel: 'email' | 'inApp' | 'slack') => {


### PR DESCRIPTION
## Summary
- Full Meta (Facebook Login) OAuth flow — connect/disconnect Instagram Business accounts from the Settings > Integrations tab; tokens stored encrypted (Fernet) in the new `social_connections` table
- Campaign publisher maps approved variants → Meta Campaign → Ad Sets per persona → Ads per variant, splitting budget proportionally across personas and campaign days
- Insights service fetches daily metrics from Meta API and caches per-day rows in `campaign_metrics`; auto-refreshes when the Analytics tab is opened (15-min stale threshold)
- Three DB migrations run on Azure: `social_connections`, `campaign_metrics`, `meta_campaign_id` on campaigns

## Test plan
- [ ] Run backend with new env vars set (`META_APP_ID`, `META_APP_SECRET`, `META_REDIRECT_URI`, `META_FRONTEND_URL`, `FERNET_SECRET_KEY`)
- [ ] Log in → Settings → Integrations → Connect Meta → complete Facebook OAuth dialog
- [ ] Confirm redirect back to Settings with success state and Meta card showing "Connected"
- [ ] Verify a row exists in `dbo.social_connections` with encrypted token
- [ ] Disconnect and confirm row is removed
- [ ] Note: app must be in Meta Dev mode; only app admins/testers can auth during this phase

## Notes
- `META_REDIRECT_URI` must match a Valid OAuth Redirect URI registered in the Meta App dashboard
- Prod env vars (`META_REDIRECT_URI=https://api.adgentic.sh/social-auth/callback`, `META_FRONTEND_URL=https://www.adgentic.sh`) need to be added to Render before prod testing
