### PR TITLE
fix bugs with graph api usage

### DIFF
--- a/backend/routes/ad_variants.py
+++ b/backend/routes/ad_variants.py
@@ -1,13 +1,9 @@
 """API routes for ad_variants — full CRUD endpoints."""
 
-import os
-from datetime import datetime, timedelta, timezone
 from typing import Optional
-from urllib.parse import urlsplit, urlunsplit
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
-from azure.storage.blob import BlobSasPermissions, generate_blob_sas
 
 from database import get_db
 from dependencies import get_current_client_id
@@ -20,42 +16,9 @@ from crud.ad_variant import (
     update_ad_variant,
     delete_ad_variant,
 )
+from services.storage.ad_video_media_url import API_SAS_EXPIRY_HOURS, signed_ad_video_media_url
 
 router = APIRouter()
-SAS_EXPIRY_HOURS = 1
-VIDEO_CONTAINER_NAME = "ad-videos"
-
-
-def _parse_conn_str(conn_str: str) -> tuple[str, str]:
-    """Extract account_name and account_key from an Azure Storage connection string."""
-    parts = dict(part.split("=", 1) for part in conn_str.split(";") if "=" in part)
-    return parts["AccountName"], parts["AccountKey"]
-
-
-def _extract_blob_name(media_url: str) -> Optional[str]:
-    """Extract blob path from a media URL when it points to the ad-videos container."""
-    try:
-        parsed = urlsplit(media_url)
-        if not parsed.scheme or not parsed.netloc:
-            return None
-        if ".blob.core.windows.net" not in parsed.netloc:
-            return None
-        path = parsed.path.lstrip("/")
-        if not path:
-            return None
-        container, sep, blob_name = path.partition("/")
-        if sep == "" or container != VIDEO_CONTAINER_NAME or not blob_name:
-            return None
-        return blob_name
-    except ValueError:
-        return None
-
-
-def _append_query(url: str, query_fragment: str) -> str:
-    """Append a query fragment while preserving existing query params."""
-    parsed = urlsplit(url)
-    merged_query = f"{parsed.query}&{query_fragment}" if parsed.query else query_fragment
-    return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, merged_query, parsed.fragment))
 
 
 def _sign_ad_variant(ad_variant) -> AdVariantResponse:
@@ -63,25 +26,10 @@ def _sign_ad_variant(ad_variant) -> AdVariantResponse:
     resp = AdVariantResponse.model_validate(ad_variant, from_attributes=True)
     if not resp.media_url:
         return resp
-
-    conn_str = os.getenv("AZURE_STORAGE_CONNECTION_STRING", "").strip()
-    if not conn_str:
-        return resp
-
-    blob_name = _extract_blob_name(resp.media_url)
-    if not blob_name:
-        return resp
-
-    account_name, account_key = _parse_conn_str(conn_str)
-    sas_token = generate_blob_sas(
-        account_name=account_name,
-        container_name=VIDEO_CONTAINER_NAME,
-        blob_name=blob_name,
-        account_key=account_key,
-        permission=BlobSasPermissions(read=True),
-        expiry=datetime.now(timezone.utc) + timedelta(hours=SAS_EXPIRY_HOURS),
+    resp.media_url = signed_ad_video_media_url(
+        resp.media_url,
+        expiry_hours=API_SAS_EXPIRY_HOURS,
     )
-    resp.media_url = _append_query(resp.media_url, sas_token)
     return resp
 
 

--- a/backend/routes/campaigns.py
+++ b/backend/routes/campaigns.py
@@ -143,10 +143,14 @@ def run_campaign(
             "Meta publish failed for campaign %d (partial meta_campaign_id=%s)",
             campaign_id, exc.meta_campaign_id,
         )
+        hint = str(exc)
+        if len(hint) > 500:
+            hint = hint[:500] + "…"
         raise HTTPException(
             status_code=502,
             detail=(
                 "We couldn't publish this campaign to Meta right now. "
+                f"{hint} "
                 "We've saved your progress — click Run Campaign again to retry. "
                 "If it keeps failing, check Settings → Integrations or contact support."
             ),

--- a/backend/services/meta/auth.py
+++ b/backend/services/meta/auth.py
@@ -1,7 +1,8 @@
 """Meta OAuth helpers: token encryption, URL building, code exchange.
 
 Uses the Facebook Login flow (not Instagram Login) because we need
-ads_management for paid campaign publishing.
+ads_management for paid campaign publishing, and instagram_basic so
+/me/accounts returns the Page's linked Instagram business account.
 """
 
 import os
@@ -18,6 +19,7 @@ META_DIALOG_URL = "https://www.facebook.com/dialog/oauth"
 META_SCOPES = ",".join([
     "ads_management",
     "ads_read",
+    "instagram_basic",
     "pages_read_engagement",
     "pages_show_list",
     "business_management",
@@ -40,6 +42,9 @@ def decrypt_token(encrypted: str) -> str:
 
 
 def build_oauth_url(state: str) -> str:
+    """Build Facebook Login URL with auth_type=rerequest so Meta re-opens the permissions
+    dialog when scopes change (otherwise repeat logins can reuse the old grant).
+    """
     app_id = os.environ.get("META_APP_ID")
     redirect_uri = os.environ.get("META_REDIRECT_URI")
     if not app_id or not redirect_uri:
@@ -50,6 +55,7 @@ def build_oauth_url(state: str) -> str:
         f"&redirect_uri={redirect_uri}"
         f"&scope={META_SCOPES}"
         f"&response_type=code"
+        f"&auth_type=rerequest"
         f"&state={state}"
     )
     return f"{META_DIALOG_URL}?{params}"

--- a/backend/services/meta/campaign_publisher.py
+++ b/backend/services/meta/campaign_publisher.py
@@ -12,14 +12,24 @@ TODO: Activate by completing the Meta OAuth flow in the Settings page after
       META_APP_ID, META_APP_SECRET, FERNET_SECRET_KEY env vars are set.
 """
 
+import base64
+import json
 import logging
+import tempfile
 import time
 from datetime import date
-from typing import Optional
+from io import BytesIO
+from typing import BinaryIO, Optional
+from urllib.parse import urlparse
 
 import httpx
+from PIL import Image
 
 from services.meta.auth import decrypt_token
+from services.storage.ad_video_media_url import (
+    PUBLISH_SAS_EXPIRY_HOURS,
+    signed_ad_video_media_url,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +63,17 @@ _OBJECTIVE_TO_OPTIMIZATION_GOAL = {
 
 DEFAULT_CAMPAIGN_DAYS = 30
 MIN_DAILY_BUDGET_CENTS = 100  # Meta minimum is $1/day per ad set
+
+# Pulling remote video into the ad library can take several minutes (transcode).
+_ADVVIDEO_TIMEOUT_SECONDS = 600.0
+# Download blob / CDN URL into a spool before multipart upload (Meta often cannot fetch Azure URLs).
+_VIDEO_DOWNLOAD_TIMEOUT = httpx.Timeout(600.0, connect=60.0)
+# Hold up to 512MB in RAM before spilling to disk while buffering the download.
+_SPOOL_MAX_IN_MEMORY = 512 * 1024 * 1024
+
+# Meta often returns empty ``thumbnails`` until the Ad Video finishes processing.
+_VIDEO_THUMB_POLL_ATTEMPTS = 15
+_VIDEO_THUMB_POLL_INTERVAL_SEC = 2.0
 
 # Retry tuning for transient Meta Graph failures (network / 5xx / 429).
 # Auth and validation errors (4xx other than 429) fail fast.
@@ -110,15 +131,27 @@ def _is_transient(exc: Exception) -> bool:
     return False
 
 
-def _post(path: str, token: str, payload: dict) -> dict:
-    """POST to Meta Graph with retry on transient errors."""
+def _post(
+    path: str,
+    token: str,
+    payload: dict,
+    *,
+    timeout: float = 30.0,
+) -> dict:
+    """POST JSON to Meta Graph with retry on transient errors."""
     last_exc: Optional[Exception] = None
     for attempt in range(_RETRY_ATTEMPTS):
         try:
+            safe_body = {**payload, "access_token": "***REDACTED***"}
+            logger.info(
+                "Meta Graph POST /%s body=%s",
+                path,
+                json.dumps(safe_body, default=str),
+            )
             resp = httpx.post(
                 f"{META_GRAPH_BASE}/{path}",
                 json={**payload, "access_token": token},
-                timeout=30,
+                timeout=timeout,
             )
             try:
                 resp.raise_for_status()
@@ -146,6 +179,384 @@ def _post(path: str, token: str, payload: dict) -> dict:
     # Unreachable — loop either returns or re-raises.
     assert last_exc is not None
     raise last_exc
+
+
+def _post_form(
+    path: str,
+    token: str,
+    fields: dict,
+    *,
+    timeout: float = 30.0,
+) -> dict:
+    """POST ``application/x-www-form-urlencoded`` (Graph documents ``advideos`` this way)."""
+    form = {k: v for k, v in fields.items() if v is not None}
+    form["access_token"] = token
+    last_exc: Optional[Exception] = None
+    for attempt in range(_RETRY_ATTEMPTS):
+        try:
+            safe_log = {k: ("***REDACTED***" if k == "access_token" else v) for k, v in form.items()}
+            logger.info(
+                "Meta Graph POST (form) /%s fields=%s",
+                path,
+                json.dumps(safe_log, default=str),
+            )
+            resp = httpx.post(
+                f"{META_GRAPH_BASE}/{path}",
+                data=form,
+                timeout=timeout,
+            )
+            try:
+                resp.raise_for_status()
+            except httpx.HTTPStatusError as exc:
+                graph_msg = _graph_error_message(exc.response)
+                if graph_msg:
+                    raise httpx.HTTPStatusError(
+                        f"{exc.response.status_code} {exc.response.reason_phrase} "
+                        f"for {exc.request.url!s}: {graph_msg}",
+                        request=exc.request,
+                        response=exc.response,
+                    ) from exc
+                raise
+            return resp.json()
+        except Exception as exc:
+            last_exc = exc
+            if not _is_transient(exc) or attempt == _RETRY_ATTEMPTS - 1:
+                raise
+            delay = _RETRY_BACKOFF_SECONDS[attempt]
+            logger.warning(
+                "Transient Meta error on %s (attempt %d/%d): %s — retrying in %ds",
+                path, attempt + 1, _RETRY_ATTEMPTS, exc, delay,
+            )
+            time.sleep(delay)
+    assert last_exc is not None
+    raise last_exc
+
+
+def _is_meta_file_url_fetch_failure(exc: httpx.HTTPStatusError) -> bool:
+    """True when Meta could not pull ``file_url`` (e.g. Azure private / SAS / code 389)."""
+    if exc.response.status_code != 400:
+        return False
+    try:
+        body = exc.response.json()
+        err = body.get("error")
+        if not isinstance(err, dict):
+            return False
+        if err.get("error_subcode") == 1363057:
+            return True
+        if err.get("code") == 389:
+            return True
+        msg = (err.get("message") or "").lower()
+        return "unable to fetch" in msg and "video" in msg
+    except (ValueError, TypeError):
+        return "unable to fetch" in (exc.response.text or "").lower()
+
+
+def _video_filename_hint(file_url: str) -> str:
+    leaf = urlparse(file_url).path.rstrip("/").rsplit("/", maxsplit=1)[-1] or "video.mp4"
+    if not any(leaf.lower().endswith(ext) for ext in (".mp4", ".mov", ".webm", ".m4v")):
+        return "video.mp4"
+    return leaf
+
+
+def _download_video_from_url(file_url: str) -> tuple[tempfile.SpooledTemporaryFile, int]:
+    """Stream ``file_url`` into a spool; return (spool at position 0, byte size)."""
+    spool: tempfile.SpooledTemporaryFile = tempfile.SpooledTemporaryFile(
+        max_size=_SPOOL_MAX_IN_MEMORY,
+        mode="w+b",
+    )
+    total = 0
+    try:
+        with httpx.Client(timeout=_VIDEO_DOWNLOAD_TIMEOUT) as client:
+            with client.stream("GET", file_url, follow_redirects=True) as resp:
+                resp.raise_for_status()
+                for chunk in resp.iter_bytes(1024 * 1024):
+                    if chunk:
+                        spool.write(chunk)
+                        total += len(chunk)
+        spool.seek(0)
+        logger.info("Downloaded %d bytes from media URL for Meta advideos upload", total)
+        return spool, total
+    except Exception:
+        spool.close()
+        raise
+
+
+def _post_multipart_advideos(
+    ad_account_id: str,
+    token: str,
+    *,
+    name: str,
+    source: BinaryIO,
+    filename: str,
+    timeout: float,
+) -> dict:
+    """POST ``advideos`` with multipart ``source`` (video bytes)."""
+    url = f"{META_GRAPH_BASE}/{ad_account_id}/advideos"
+    last_exc: Optional[Exception] = None
+    for attempt in range(_RETRY_ATTEMPTS):
+        try:
+            source.seek(0)
+            logger.info(
+                "Meta Graph POST (multipart) /%s/advideos name=%s filename=%s",
+                ad_account_id,
+                name,
+                filename,
+            )
+            resp = httpx.post(
+                url,
+                data={"name": name, "access_token": token},
+                files={"source": (filename, source, "video/mp4")},
+                timeout=timeout,
+            )
+            try:
+                resp.raise_for_status()
+            except httpx.HTTPStatusError as exc:
+                graph_msg = _graph_error_message(exc.response)
+                if graph_msg:
+                    raise httpx.HTTPStatusError(
+                        f"{exc.response.status_code} {exc.response.reason_phrase} "
+                        f"for {exc.request.url!s}: {graph_msg}",
+                        request=exc.request,
+                        response=exc.response,
+                    ) from exc
+                raise
+            return resp.json()
+        except Exception as exc:
+            last_exc = exc
+            if not _is_transient(exc) or attempt == _RETRY_ATTEMPTS - 1:
+                raise
+            delay = _RETRY_BACKOFF_SECONDS[attempt]
+            logger.warning(
+                "Transient Meta error on advideos multipart (attempt %d/%d): %s — retrying in %ds",
+                attempt + 1,
+                _RETRY_ATTEMPTS,
+                exc,
+                delay,
+            )
+            time.sleep(delay)
+    assert last_exc is not None
+    raise last_exc
+
+
+def _upload_video_to_ad_library(
+    *,
+    ad_account_id: str,
+    token: str,
+    file_url: str,
+    name: str,
+) -> str:
+    """Register video in the ad account library; return Graph ``video_id``.
+
+    Tries ``file_url`` first. If Meta cannot fetch the URL (common for Azure Blob),
+    downloads the file on this server and uploads it as multipart ``source``.
+
+    Unsigned Azure blob URLs (stored in DB) get a read SAS when
+    ``AZURE_STORAGE_CONNECTION_STRING`` is set so Meta and this server can read the blob.
+    """
+    file_url = signed_ad_video_media_url(
+        file_url.strip(),
+        expiry_hours=PUBLISH_SAS_EXPIRY_HOURS,
+    )
+    title = (name or "Ad video")[:255]
+    try:
+        data = _post_form(
+            f"{ad_account_id}/advideos",
+            token,
+            {"file_url": file_url, "name": title},
+            timeout=_ADVVIDEO_TIMEOUT_SECONDS,
+        )
+        vid = data.get("video_id") or data.get("id")
+        if not vid:
+            raise RuntimeError(f"advideos response missing id/video_id: {data!r}")
+        logger.info("Registered video in ad library via file_url id=%s", vid)
+        return str(vid)
+    except httpx.HTTPStatusError as exc:
+        if not _is_meta_file_url_fetch_failure(exc):
+            raise
+        logger.warning(
+            "Meta could not fetch file_url (code/subcode in response); "
+            "uploading video bytes from this server instead.",
+        )
+
+    spool, _size = _download_video_from_url(file_url)
+    try:
+        fname = _video_filename_hint(file_url)
+        data = _post_multipart_advideos(
+            ad_account_id,
+            token,
+            name=title,
+            source=spool,
+            filename=fname,
+            timeout=_ADVVIDEO_TIMEOUT_SECONDS,
+        )
+        vid = data.get("video_id") or data.get("id")
+        if not vid:
+            raise RuntimeError(f"advideos multipart response missing id/video_id: {data!r}")
+        logger.info("Registered video in ad library via multipart source id=%s", vid)
+        return str(vid)
+    finally:
+        spool.close()
+
+
+def _fetch_ad_video_thumbnail_uri_once(token: str, video_id: str) -> Optional[str]:
+    """Return a single thumbnail ``uri`` from Graph if available (may be empty while video processes)."""
+    try:
+        resp = httpx.get(
+            f"{META_GRAPH_BASE}/{video_id}",
+            params={"fields": "thumbnails", "access_token": token},
+            timeout=30.0,
+        )
+        resp.raise_for_status()
+        body = resp.json()
+        thumbs = body.get("thumbnails")
+        if not isinstance(thumbs, dict):
+            return None
+        rows = thumbs.get("data")
+        if not isinstance(rows, list) or len(rows) == 0:
+            return None
+        for row in rows:
+            if isinstance(row, dict) and row.get("is_preferred") and row.get("uri"):
+                return str(row["uri"])
+        for row in rows:
+            if isinstance(row, dict) and row.get("uri"):
+                return str(row["uri"])
+    except Exception:
+        logger.debug("Could not fetch thumbnails for video %s", video_id, exc_info=True)
+    return None
+
+
+def _poll_video_thumbnail_uri(token: str, video_id: str) -> Optional[str]:
+    """Wait until Meta exposes at least one generated thumbnail URI."""
+    for attempt in range(1, _VIDEO_THUMB_POLL_ATTEMPTS + 1):
+        uri = _fetch_ad_video_thumbnail_uri_once(token, video_id)
+        if uri:
+            logger.info("Got Ad Video thumbnail URI after %d attempt(s)", attempt)
+            return uri
+        time.sleep(_VIDEO_THUMB_POLL_INTERVAL_SEC)
+    logger.warning(
+        "No thumbnail URI after %d polls for video %s",
+        _VIDEO_THUMB_POLL_ATTEMPTS,
+        video_id,
+    )
+    return None
+
+
+def _download_url_bytes(url: str) -> bytes:
+    r = httpx.get(url, follow_redirects=True, timeout=60.0)
+    r.raise_for_status()
+    return r.content
+
+
+def _placeholder_thumbnail_png_bytes() -> bytes:
+    """1200×628 PNG when Meta has no usable thumbnail (common feed / link aspect)."""
+    buf = BytesIO()
+    Image.new("RGB", (1200, 628), (45, 45, 48)).save(buf, format="PNG", compress_level=6)
+    return buf.getvalue()
+
+
+def _guess_thumbnail_filename(image_bytes: bytes) -> str:
+    if len(image_bytes) >= 8 and image_bytes[:8] == b"\x89PNG\r\n\x1a\n":
+        return "video_thumb.png"
+    if len(image_bytes) >= 2 and image_bytes[:2] == b"\xff\xd8":
+        return "video_thumb.jpg"
+    return "video_thumb.jpg"
+
+
+def _post_adimages(
+    ad_account_id: str,
+    token: str,
+    *,
+    image_bytes: bytes,
+    filename: str,
+    timeout: float = 120.0,
+) -> dict:
+    """POST ``/adimages`` using base64 ``bytes`` (Marketing API form style).
+
+    Multipart raw file uploads often return *Invalid image format* (2446496); Meta documents
+    ``bytes`` as a Base64 UTF-8 string for this edge.
+    """
+    url = f"{META_GRAPH_BASE}/{ad_account_id}/adimages"
+    b64 = base64.b64encode(image_bytes).decode("ascii")
+    logger.info(
+        "Meta Graph POST /%s/adimages filename=%s raw_size=%d b64_len=%d",
+        ad_account_id,
+        filename,
+        len(image_bytes),
+        len(b64),
+    )
+    resp = httpx.post(
+        url,
+        data={
+            "access_token": token,
+            "filename": filename,
+            "bytes": b64,
+        },
+        timeout=timeout,
+    )
+    try:
+        resp.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        graph_msg = _graph_error_message(exc.response)
+        if graph_msg:
+            raise httpx.HTTPStatusError(
+                f"{exc.response.status_code} {exc.response.reason_phrase} "
+                f"for {exc.request.url!s}: {graph_msg}",
+                request=exc.request,
+                response=exc.response,
+            ) from exc
+        raise
+    return resp.json()
+
+
+def _adimages_response_hash(body: dict) -> str:
+    imgs = body.get("images")
+    if not isinstance(imgs, dict):
+        raise RuntimeError(f"adimages response missing images: {body!r}")
+    for v in imgs.values():
+        if isinstance(v, dict) and v.get("hash"):
+            return str(v["hash"])
+    raise RuntimeError(f"adimages response missing hash: {body!r}")
+
+
+def _resolve_video_thumbnail_image_hash(
+    ad_account_id: str,
+    token: str,
+    video_id: str,
+) -> str:
+    """Upload a thumbnail to the ad image library and return ``image_hash`` for ``video_data``.
+
+    Meta rejects many ``fbcdn`` URLs as ``image_url``; uploading bytes to ``adimages`` is reliable.
+    """
+    uri = _poll_video_thumbnail_uri(token, video_id)
+    if uri:
+        try:
+            raw = _download_url_bytes(uri)
+            if len(raw) < 100:
+                raise ValueError("thumbnail download suspiciously small")
+            body = _post_adimages(
+                ad_account_id,
+                token,
+                image_bytes=raw,
+                filename=_guess_thumbnail_filename(raw),
+            )
+            h = _adimages_response_hash(body)
+            logger.info("Using Meta-generated video thumbnail as image_hash=%s", h)
+            return h
+        except Exception:
+            logger.warning(
+                "Could not use Meta thumbnail URI for adimages; using placeholder PNG",
+                exc_info=True,
+            )
+    raw = _placeholder_thumbnail_png_bytes()
+    body = _post_adimages(
+        ad_account_id,
+        token,
+        image_bytes=raw,
+        filename="placeholder_thumb.png",
+    )
+    h = _adimages_response_hash(body)
+    logger.info("Using placeholder thumbnail image_hash=%s", h)
+    return h
 
 
 def publish_campaign(
@@ -285,6 +696,20 @@ def _create_ad_for_variant(
 ) -> None:
     script = (variant.get("script") or "")[:2200]  # Meta copy limit
     message = script or campaign_name
+    file_url = variant["media_url"]
+    video_id = _upload_video_to_ad_library(
+        ad_account_id=ad_account_id,
+        token=token,
+        file_url=file_url,
+        name=f"{campaign_name} — variant {variant['id']}",
+    )
+    thumb_hash = _resolve_video_thumbnail_image_hash(ad_account_id, token, video_id)
+    video_data: dict = {
+        "video_id": video_id,
+        "message": message,
+        "image_hash": thumb_hash,
+        "call_to_action": {"type": "LEARN_MORE"},
+    }
 
     creative_resp = _post(
         f"{ad_account_id}/adcreatives",
@@ -293,12 +718,9 @@ def _create_ad_for_variant(
             "name": f"{persona_name} — Variant #{variant['id']}",
             "object_story_spec": {
                 "page_id": facebook_page_id,
-                "instagram_actor_id": instagram_account_id,
-                "video_data": {
-                    "video_url": variant["media_url"],
-                    "message": message,
-                    "call_to_action": {"type": "LEARN_MORE"},
-                },
+                # Marketing API: object_story_spec uses instagram_user_id (not instagram_actor_id).
+                "instagram_user_id": instagram_account_id,
+                "video_data": video_data,
             },
         },
     )

--- a/backend/services/meta/campaign_publisher.py
+++ b/backend/services/meta/campaign_publisher.py
@@ -26,16 +26,30 @@ logger = logging.getLogger(__name__)
 META_GRAPH_VERSION = "v21.0"
 META_GRAPH_BASE = f"https://graph.facebook.com/{META_GRAPH_VERSION}"
 
+# Use ODAX (Outcome-Driven) objectives — legacy values (e.g. LINK_CLICKS,
+# POST_ENGAGEMENT) often return 400 on Marketing API v17+ / v21.
 GOAL_TO_OBJECTIVE = {
-    "brand_awareness": "BRAND_AWARENESS",
-    "reach": "REACH",
-    "traffic": "LINK_CLICKS",
-    "engagement": "POST_ENGAGEMENT",
-    "leads": "LEAD_GENERATION",
+    "brand_awareness": "OUTCOME_AWARENESS",
+    "reach": "OUTCOME_AWARENESS",
+    "traffic": "OUTCOME_TRAFFIC",
+    "engagement": "OUTCOME_ENGAGEMENT",
+    "leads": "OUTCOME_LEADS",
     "sales": "OUTCOME_SALES",
     "conversions": "OUTCOME_SALES",
 }
 DEFAULT_OBJECTIVE = "OUTCOME_AWARENESS"
+
+# Ad set optimization must align with campaign objective (Meta validation).
+_OBJECTIVE_TO_OPTIMIZATION_GOAL = {
+    "OUTCOME_AWARENESS": "REACH",
+    "OUTCOME_TRAFFIC": "LINK_CLICKS",
+    "OUTCOME_ENGAGEMENT": "POST_ENGAGEMENT",
+    "OUTCOME_LEADS": "LEAD_GENERATION",
+    # Without a pixel, OFFSITE_CONVERSIONS would fail; LINK_CLICKS is a reasonable
+    # traffic-style default until conversion tracking is wired.
+    "OUTCOME_SALES": "LINK_CLICKS",
+    "OUTCOME_APP_PROMOTION": "APP_INSTALLS",
+}
 
 DEFAULT_CAMPAIGN_DAYS = 30
 MIN_DAILY_BUDGET_CENTS = 100  # Meta minimum is $1/day per ad set
@@ -59,6 +73,35 @@ class MetaPublishError(Exception):
         self.meta_campaign_id = meta_campaign_id
 
 
+def _optimization_goal_for_objective(campaign_objective: str) -> str:
+    return _OBJECTIVE_TO_OPTIMIZATION_GOAL.get(
+        campaign_objective, _OBJECTIVE_TO_OPTIMIZATION_GOAL["OUTCOME_AWARENESS"]
+    )
+
+
+def _graph_error_message(resp: httpx.Response) -> str:
+    """Best-effort parse of Graph API JSON error (400 responses are usually here)."""
+    try:
+        body = resp.json()
+    except ValueError:
+        return (resp.text or "")[:800]
+    err = body.get("error")
+    if not isinstance(err, dict):
+        return (resp.text or "")[:800]
+    parts: list[str] = []
+    for key in ("message", "error_user_msg", "error_user_title"):
+        val = err.get(key)
+        if isinstance(val, str) and val.strip():
+            parts.append(val.strip())
+    if err.get("code") is not None:
+        sub = err.get("error_subcode")
+        code_part = f"code={err['code']}"
+        if sub is not None:
+            code_part += f", subcode={sub}"
+        parts.append(code_part)
+    return " — ".join(parts) if parts else (resp.text or "")[:800]
+
+
 def _is_transient(exc: Exception) -> bool:
     if isinstance(exc, (httpx.TimeoutException, httpx.NetworkError, httpx.RemoteProtocolError)):
         return True
@@ -77,7 +120,18 @@ def _post(path: str, token: str, payload: dict) -> dict:
                 json={**payload, "access_token": token},
                 timeout=30,
             )
-            resp.raise_for_status()
+            try:
+                resp.raise_for_status()
+            except httpx.HTTPStatusError as exc:
+                graph_msg = _graph_error_message(exc.response)
+                if graph_msg:
+                    raise httpx.HTTPStatusError(
+                        f"{exc.response.status_code} {exc.response.reason_phrase} "
+                        f"for {exc.request.url!s}: {graph_msg}",
+                        request=exc.request,
+                        response=exc.response,
+                    ) from exc
+                raise
             return resp.json()
         except Exception as exc:
             last_exc = exc
@@ -134,6 +188,9 @@ def publish_campaign(
                     "objective": objective,
                     "status": "PAUSED",  # client activates in Meta Ads Manager after review
                     "special_ad_categories": [],
+                    # Required when budgets live on ad sets (not CBO). Matches Meta's
+                    # POST /act_<id>/campaigns examples for v21+.
+                    "is_adset_budget_sharing_enabled": False,
                 },
             )
         except Exception as exc:
@@ -162,6 +219,7 @@ def publish_campaign(
             continue
 
         targeting = _build_targeting_for_persona(persona_traits)
+        optimization_goal = _optimization_goal_for_objective(objective)
 
         try:
             adset_resp = _post(
@@ -172,7 +230,8 @@ def publish_campaign(
                     "campaign_id": meta_campaign_id,
                     "daily_budget": daily_budget_cents,
                     "billing_event": "IMPRESSIONS",
-                    "optimization_goal": "REACH",
+                    "bid_strategy": "LOWEST_COST_WITHOUT_CAP",
+                    "optimization_goal": optimization_goal,
                     "targeting": targeting,
                     "status": "PAUSED",
                     **({"start_time": start_date.isoformat()} if start_date else {}),

--- a/backend/services/meta/campaign_publisher.py
+++ b/backend/services/meta/campaign_publisher.py
@@ -28,6 +28,8 @@ from PIL import Image
 from services.meta.auth import decrypt_token
 from services.storage.ad_video_media_url import (
     PUBLISH_SAS_EXPIRY_HOURS,
+    VIDEO_CONTAINER_NAME,
+    is_trusted_ad_video_backend_download_url,
     signed_ad_video_media_url,
 )
 
@@ -70,6 +72,8 @@ _ADVVIDEO_TIMEOUT_SECONDS = 600.0
 _VIDEO_DOWNLOAD_TIMEOUT = httpx.Timeout(600.0, connect=60.0)
 # Hold up to 512MB in RAM before spilling to disk while buffering the download.
 _SPOOL_MAX_IN_MEMORY = 512 * 1024 * 1024
+# Hard cap on server-side fallback download (per variant) to bound disk/IO under abuse or errors.
+_MAX_FALLBACK_VIDEO_DOWNLOAD_BYTES = 500 * 1024 * 1024  # 500 MiB
 
 # Meta often returns empty ``thumbnails`` until the Ad Video finishes processing.
 _VIDEO_THUMB_POLL_ATTEMPTS = 15
@@ -105,6 +109,9 @@ def _graph_error_message(resp: httpx.Response) -> str:
     try:
         body = resp.json()
     except ValueError:
+        return (resp.text or "")[:800]
+    # Graph normally returns {"error": {...}}; proxies or edge cases may return a JSON array/string.
+    if not isinstance(body, dict):
         return (resp.text or "")[:800]
     err = body.get("error")
     if not isinstance(err, dict):
@@ -259,7 +266,12 @@ def _video_filename_hint(file_url: str) -> str:
 
 
 def _download_video_from_url(file_url: str) -> tuple[tempfile.SpooledTemporaryFile, int]:
-    """Stream ``file_url`` into a spool; return (spool at position 0, byte size)."""
+    """Stream ``file_url`` into a spool; return (spool at position 0, byte size).
+
+    Raises ``ValueError`` if the response is larger than
+    ``_MAX_FALLBACK_VIDEO_DOWNLOAD_BYTES`` (checked via ``Content-Length`` when
+    present and while streaming).
+    """
     spool: tempfile.SpooledTemporaryFile = tempfile.SpooledTemporaryFile(
         max_size=_SPOOL_MAX_IN_MEMORY,
         mode="w+b",
@@ -269,10 +281,27 @@ def _download_video_from_url(file_url: str) -> tuple[tempfile.SpooledTemporaryFi
         with httpx.Client(timeout=_VIDEO_DOWNLOAD_TIMEOUT) as client:
             with client.stream("GET", file_url, follow_redirects=True) as resp:
                 resp.raise_for_status()
+                cl_header = resp.headers.get("content-length")
+                if cl_header is not None:
+                    try:
+                        cl_val = int(cl_header.strip())
+                    except ValueError:
+                        cl_val = -1
+                    if cl_val > _MAX_FALLBACK_VIDEO_DOWNLOAD_BYTES:
+                        raise ValueError(
+                            f"Video download refused: Content-Length {cl_val} exceeds "
+                            f"maximum {_MAX_FALLBACK_VIDEO_DOWNLOAD_BYTES} bytes"
+                        )
                 for chunk in resp.iter_bytes(1024 * 1024):
-                    if chunk:
-                        spool.write(chunk)
-                        total += len(chunk)
+                    if not chunk:
+                        continue
+                    if total + len(chunk) > _MAX_FALLBACK_VIDEO_DOWNLOAD_BYTES:
+                        raise ValueError(
+                            f"Video download exceeded maximum size "
+                            f"({_MAX_FALLBACK_VIDEO_DOWNLOAD_BYTES} bytes) while streaming"
+                        )
+                    spool.write(chunk)
+                    total += len(chunk)
         spool.seek(0)
         logger.info("Downloaded %d bytes from media URL for Meta advideos upload", total)
         return spool, total
@@ -377,6 +406,13 @@ def _upload_video_to_ad_library(
             "Meta could not fetch file_url (code/subcode in response); "
             "uploading video bytes from this server instead.",
         )
+        if not is_trusted_ad_video_backend_download_url(file_url):
+            raise ValueError(
+                "Server-side video download is not allowed for this media_url: "
+                f"only https Azure Blob URLs in container "
+                f"{VIDEO_CONTAINER_NAME!r} for the configured storage account "
+                "(AZURE_STORAGE_CONNECTION_STRING) are permitted."
+            ) from exc
 
     spool, _size = _download_video_from_url(file_url)
     try:

--- a/backend/services/meta/persona_grouping.py
+++ b/backend/services/meta/persona_grouping.py
@@ -65,8 +65,8 @@ def group_approved_variants_by_persona(
         .filter(
             AdVariant.campaign_id == campaign_id,
             AdVariant.status == "completed",
-            AdVariant.is_approved.is_(True),
-            AdVariant.is_preview.is_(False),
+            AdVariant.is_approved == True,  # noqa: E712 — MSSQL: .is_() becomes invalid "IS 1"
+            AdVariant.is_preview == False,  # noqa: E712
             AdVariant.media_url.isnot(None),
         )
         .all()

--- a/backend/services/storage/__init__.py
+++ b/backend/services/storage/__init__.py
@@ -1,0 +1,1 @@
+"""Shared helpers for blob-backed assets."""

--- a/backend/services/storage/ad_video_media_url.py
+++ b/backend/services/storage/ad_video_media_url.py
@@ -10,6 +10,8 @@ from urllib.parse import urlsplit, urlunsplit
 from azure.storage.blob import BlobSasPermissions, generate_blob_sas
 
 VIDEO_CONTAINER_NAME = "ad-videos"
+# Public Azure Blob host suffix (avoid sovereign-cloud SSRF until explicitly supported).
+_AZURE_PUBLIC_BLOB_SUFFIX = ".blob.core.windows.net"
 # API responses: short-lived links for browsers.
 API_SAS_EXPIRY_HOURS = 1
 # Meta publish (download + multipart): allow slow networks / large files.
@@ -20,6 +22,41 @@ def parse_storage_account_key(conn_str: str) -> tuple[str, str]:
     """Return ``(account_name, account_key)`` from an Azure Storage connection string."""
     parts = dict(part.split("=", 1) for part in conn_str.split(";") if "=" in part)
     return parts["AccountName"], parts["AccountKey"]
+
+
+def expected_ad_video_blob_hostname() -> Optional[str]:
+    """Return ``<account>.blob.core.windows.net`` lowercased when connection string is set."""
+    conn_str = os.getenv("AZURE_STORAGE_CONNECTION_STRING", "").strip()
+    if not conn_str:
+        return None
+    try:
+        account_name, _ = parse_storage_account_key(conn_str)
+    except KeyError:
+        return None
+    return f"{account_name}{_AZURE_PUBLIC_BLOB_SUFFIX}".lower()
+
+
+def is_trusted_ad_video_backend_download_url(url: str) -> bool:
+    """True only for https URLs to this app's Azure ``ad-videos`` blobs (safe for server-side GET).
+
+    Used to gate the Meta ``advideos`` fallback that downloads ``media_url`` on this server,
+    avoiding SSRF via attacker-controlled ``media_url`` values. Requires
+    ``AZURE_STORAGE_CONNECTION_STRING`` so the storage account host can be pinned.
+    """
+    if not (url or "").strip():
+        return False
+    expected_host = expected_ad_video_blob_hostname()
+    if expected_host is None:
+        return False
+    if extract_ad_video_blob_name(url) is None:
+        return False
+    try:
+        parsed = urlsplit(url.strip())
+    except ValueError:
+        return False
+    if parsed.scheme.lower() != "https":
+        return False
+    return (parsed.hostname or "").lower() == expected_host
 
 
 def extract_ad_video_blob_name(media_url: str) -> Optional[str]:

--- a/backend/services/storage/ad_video_media_url.py
+++ b/backend/services/storage/ad_video_media_url.py
@@ -1,0 +1,81 @@
+"""Append read-only SAS to Azure ``ad-videos`` blob URLs when the account is private."""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+from urllib.parse import urlsplit, urlunsplit
+
+from azure.storage.blob import BlobSasPermissions, generate_blob_sas
+
+VIDEO_CONTAINER_NAME = "ad-videos"
+# API responses: short-lived links for browsers.
+API_SAS_EXPIRY_HOURS = 1
+# Meta publish (download + multipart): allow slow networks / large files.
+PUBLISH_SAS_EXPIRY_HOURS = 24
+
+
+def parse_storage_account_key(conn_str: str) -> tuple[str, str]:
+    """Return ``(account_name, account_key)`` from an Azure Storage connection string."""
+    parts = dict(part.split("=", 1) for part in conn_str.split(";") if "=" in part)
+    return parts["AccountName"], parts["AccountKey"]
+
+
+def extract_ad_video_blob_name(media_url: str) -> Optional[str]:
+    """Return blob path within ``ad-videos`` or ``None`` if URL is not that container."""
+    try:
+        parsed = urlsplit(media_url)
+        if not parsed.scheme or not parsed.netloc:
+            return None
+        if ".blob.core.windows.net" not in parsed.netloc:
+            return None
+        path = parsed.path.lstrip("/")
+        if not path:
+            return None
+        container, sep, blob_name = path.partition("/")
+        if sep == "" or container != VIDEO_CONTAINER_NAME or not blob_name:
+            return None
+        return blob_name
+    except ValueError:
+        return None
+
+
+def append_query(url: str, query_fragment: str) -> str:
+    """Append a query fragment while preserving existing query params."""
+    parsed = urlsplit(url)
+    merged_query = f"{parsed.query}&{query_fragment}" if parsed.query else query_fragment
+    return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, merged_query, parsed.fragment))
+
+
+def _already_has_sas_signature(media_url: str) -> bool:
+    q = urlsplit(media_url).query.lower()
+    return "sig=" in q
+
+
+def signed_ad_video_media_url(
+    media_url: str,
+    *,
+    expiry_hours: int = API_SAS_EXPIRY_HOURS,
+) -> str:
+    """Return ``media_url`` with read SAS if it is our Azure ad-videos blob and lacks ``sig``."""
+    if not (media_url or "").strip():
+        return media_url
+    if _already_has_sas_signature(media_url):
+        return media_url
+    conn_str = os.getenv("AZURE_STORAGE_CONNECTION_STRING", "").strip()
+    if not conn_str:
+        return media_url
+    blob_name = extract_ad_video_blob_name(media_url)
+    if not blob_name:
+        return media_url
+    account_name, account_key = parse_storage_account_key(conn_str)
+    sas_token = generate_blob_sas(
+        account_name=account_name,
+        container_name=VIDEO_CONTAINER_NAME,
+        blob_name=blob_name,
+        account_key=account_key,
+        permission=BlobSasPermissions(read=True),
+        expiry=datetime.now(timezone.utc) + timedelta(hours=expiry_hours),
+    )
+    return append_query(media_url, sas_token)

--- a/backend/tests/test_ad_variants.py
+++ b/backend/tests/test_ad_variants.py
@@ -64,7 +64,7 @@ def test_list_ad_variants_signs_media_url(monkeypatch):
             ],
         )
         monkeypatch.setattr(
-            "routes.ad_variants.generate_blob_sas",
+            "services.storage.ad_video_media_url.generate_blob_sas",
             lambda **kwargs: "sig=abc123",
         )
 
@@ -108,7 +108,7 @@ def test_list_ad_variants_appends_sas_to_existing_query(monkeypatch):
             ],
         )
         monkeypatch.setattr(
-            "routes.ad_variants.generate_blob_sas",
+            "services.storage.ad_video_media_url.generate_blob_sas",
             lambda **kwargs: "sig=abc123",
         )
 
@@ -131,7 +131,7 @@ def test_read_ad_variant_leaves_non_azure_media_url_unchanged(monkeypatch):
         raw_url = "https://cdn.example.com/video.mp4"
         monkeypatch.setattr("routes.ad_variants.get_ad_variant", lambda *args, **kwargs: _variant(raw_url))
         monkeypatch.setattr(
-            "routes.ad_variants.generate_blob_sas",
+            "services.storage.ad_video_media_url.generate_blob_sas",
             lambda **kwargs: "sig=abc123",
         )
 

--- a/backend/tests/test_ad_video_media_url.py
+++ b/backend/tests/test_ad_video_media_url.py
@@ -1,0 +1,61 @@
+"""Tests for Azure ad-video URL helpers (SAS + SSRF-safe download allowlist)."""
+
+import pytest
+
+from services.storage import ad_video_media_url as m
+
+
+@pytest.fixture(autouse=True)
+def clear_conn(monkeypatch):
+    monkeypatch.delenv("AZURE_STORAGE_CONNECTION_STRING", raising=False)
+    yield
+
+
+def test_is_trusted_backend_download_false_without_connection_string(monkeypatch):
+    url = "https://myacct.blob.core.windows.net/ad-videos/ad-videos/x.mp4"
+    assert m.is_trusted_ad_video_backend_download_url(url) is False
+
+
+def test_is_trusted_backend_download_true_when_host_and_container_match(monkeypatch):
+    monkeypatch.setenv(
+        "AZURE_STORAGE_CONNECTION_STRING",
+        "AccountName=myacct;AccountKey=c2VjcmV0;EndpointSuffix=core.windows.net",
+    )
+    url = "https://myacct.blob.core.windows.net/ad-videos/ad-videos/x.mp4"
+    assert m.is_trusted_ad_video_backend_download_url(url) is True
+
+
+def test_is_trusted_backend_download_false_wrong_storage_account(monkeypatch):
+    monkeypatch.setenv(
+        "AZURE_STORAGE_CONNECTION_STRING",
+        "AccountName=myacct;AccountKey=c2VjcmV0;EndpointSuffix=core.windows.net",
+    )
+    url = "https://other.blob.core.windows.net/ad-videos/ad-videos/x.mp4"
+    assert m.is_trusted_ad_video_backend_download_url(url) is False
+
+
+def test_is_trusted_backend_download_false_http(monkeypatch):
+    monkeypatch.setenv(
+        "AZURE_STORAGE_CONNECTION_STRING",
+        "AccountName=myacct;AccountKey=c2VjcmV0;EndpointSuffix=core.windows.net",
+    )
+    url = "http://myacct.blob.core.windows.net/ad-videos/ad-videos/x.mp4"
+    assert m.is_trusted_ad_video_backend_download_url(url) is False
+
+
+def test_is_trusted_backend_download_false_wrong_container(monkeypatch):
+    monkeypatch.setenv(
+        "AZURE_STORAGE_CONNECTION_STRING",
+        "AccountName=myacct;AccountKey=c2VjcmV0;EndpointSuffix=core.windows.net",
+    )
+    url = "https://myacct.blob.core.windows.net/other/x.mp4"
+    assert m.is_trusted_ad_video_backend_download_url(url) is False
+
+
+def test_is_trusted_backend_download_allows_query_sas(monkeypatch):
+    monkeypatch.setenv(
+        "AZURE_STORAGE_CONNECTION_STRING",
+        "AccountName=myacct;AccountKey=c2VjcmV0;EndpointSuffix=core.windows.net",
+    )
+    url = "https://myacct.blob.core.windows.net/ad-videos/ad-videos/x.mp4?sv=2021&sig=abc"
+    assert m.is_trusted_ad_video_backend_download_url(url) is True


### PR DESCRIPTION
## Changes
- Map campaign goals to ODAX objectives and set ad set optimization_goal to match (avoids objective / optimization mismatches on v21).
- Set is_adset_budget_sharing_enabled: false on campaign create when budgets live on ad sets.
- Set ad set bid_strategy: LOWEST_COST_WITHOUT_CAP so Meta does not require bid caps / bid constraints.
- Parse Graph error JSON on failed requests and include it in HTTPStatusError messages.
- Include a truncated exception hint in the 502 detail when Meta publish fails.
- OAuth: add instagram_basic, document it, and add auth_type=rerequest so scope changes re-prompt.
- Persona grouping: use == True / == False for booleans (MSSQL rejects IS 1 from .is_(True)).