### PR TITLE
Fix campaign deletion with cascade delete and bulk delete API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,7 @@ This section is the repo-specific **design-doc gate**; [CLAUDE.md](CLAUDE.md) co
 | [agent_resources/BACKEND.md](agent_resources/BACKEND.md) | FastAPI layers, auth, jobs, API conventions. |
 | [agent_resources/FRONTEND.md](agent_resources/FRONTEND.md) | Vite/React structure, state, styling, pitfalls. |
 | [agent_resources/TESTING.md](agent_resources/TESTING.md) | Test pyramid, pytest, CI, fixtures. |
+| [agent_resources/SCHEMA.md](agent_resources/SCHEMA.md) | SQL Server tables, columns, FK relationships. |
 | [agent_resources/references/](agent_resources/references/) | Lookup tables (API, env, routes, DB, CI). |
 | [agent_resources/design-docs/](agent_resources/design-docs/) | Design docs for major changes (before implementation). |
 | [exec-plans/](exec-plans/) | Task execution plans (read before implementing assigned work). |

--- a/agent_resources/ARCHITECTURE.md
+++ b/agent_resources/ARCHITECTURE.md
@@ -64,6 +64,8 @@ There is **no separate message broker** (e.g. Redis/RabbitMQ) in the current dep
 
 Browser → **FastAPI routes** (`routes/*`) → **SQLAlchemy** sessions (`get_db`) → **CRUD** + **Pydantic schemas** → JSON responses. Routes that use **`get_current_client_id`** validate **`JWT_SECRET`**-signed bearer tokens (`dependencies.py`). **Not every resource route is JWT-scoped today** (e.g. parts of **`/campaigns`**); see [BACKEND.md](./BACKEND.md).
 
+**Campaign delete:** `DELETE /campaigns/{id}` and `POST /campaigns/bulk-delete` run application-level cascade in **`crud/campaign.py`** (children then campaign; one transaction for bulk). See [references/persistence.md](./references/persistence.md) and [references/backend-api.md](./references/backend-api.md).
+
 ### 2. Product images
 
 Uploads flow through **`routes/product.py`**: files land in Azure Blob (**`product-images`** container). Ad generation later **downloads** the same blob by `image_name` when building a variant.
@@ -102,7 +104,7 @@ Failures are recorded on the variant **`meta`** (e.g. error trace) and statuses 
 | **Caches** | None required for core flow; clients may be cached in-process (e.g. OpenAI client LRU) |
 | **Queues** | **Database** (`ad_jobs` + locks), not a separate queue service |
 | **LLM / media APIs** | **OpenAI-compatible** clients (chat, video, moderation, primary script path), **xAI SDK** (batch scripts), env-driven keys/URLs (`backend/.env.example`) |
-| **Meta** | OAuth token storage, insights fetch, campaign publish — `services/meta/`, `routes/social_auth.py`, `routes/metrics.py` |
+| **Meta** | OAuth token storage, insights fetch, campaign publish — `services/ad_platforms/meta/`, `routes/social_auth.py`, `routes/metrics.py` |
 
 ---
 
@@ -146,6 +148,8 @@ with **DB-backed job processing** instead of a visible Celery deployment in code
 | [FRONTEND.md](./FRONTEND.md) | Frontend structure and house style |
 | [TESTING.md](./TESTING.md) | How to validate changes |
 | [references/](./references/) | Lookup: API paths, env vars, routes, tables, CI |
+| [SCHEMA.md](./SCHEMA.md) | SQL Server schema and FK graph |
+| [exec-plans/](../exec-plans/) | Task-level implementation plans |
 | [design-docs/](./design-docs/) | Design write-ups for major changes (before implementation) |
 | [README.md](../README.md) | Product narrative, diagram, setup, Docker/Make |
 | [backend/README.md](../backend/README.md) | Backend ports, worker route prefixes, local run |

--- a/agent_resources/BACKEND.md
+++ b/agent_resources/BACKEND.md
@@ -88,7 +88,7 @@ There is **no Celery/Redis** queue in this repo: **the database is the queue**.
 | **Azure SQL / ODBC** | **`database.py`** | **`DB_CONNECTION_STRING`**, **`DB_PASSWORD`**, or **`USE_AZURE_AD`** + **`DB_ODBC_CONNECTION_STRING`** |
 | **OpenAI-compatible** | Chat, moderation, video worker, script **`AsyncOpenAI`** path, shared clients | **`OPENAI_API_KEY`**, **`SCRIPT_*`**, **`VIDEO_API_KEY`** |
 | **xAI SDK** | Batch script creation (`batch_generate_ad_scripts`) | **`xai_sdk`** + **`SCRIPT_*`** in **`script_creation_worker`** |
-| **Meta Graph / OAuth** | Social connect, insights, publish helpers | **`META_*`**, **`FERNET_SECRET_KEY`**, `services/meta/` |
+| **Meta Graph / OAuth** | Social connect, insights, publish helpers | **`META_*`**, **`FERNET_SECRET_KEY`**, `services/ad_platforms/meta/` |
 | **Resend** | Email verification and password reset | **`RESEND_*`** |
 | **Google** | **`POST /auth/google`** | **`GOOGLE_CLIENT_SECRET`** |
 
@@ -112,7 +112,7 @@ Client singletons: **`get_openai_client`** is **`lru_cache`**’d; tests can **`
 
 - **Input:** **Pydantic** schemas on route bodies; FastAPI returns **422** on validation failure.
 - **App errors:** Raise **`HTTPException(status_code=…, detail=…)`** with **string** or structured **`detail`** (FastAPI serializes).
-- **DB integrity:** e.g. **`IntegrityError`** in **`consumers`** CSV path—catch and map to a **409** or clear message.
+- **DB integrity:** e.g. **`IntegrityError`** in **`consumers`** CSV path—catch and map to a **409** or clear message. **Campaign delete:** `crud/campaign.py` **`delete_campaign`** / **`delete_campaigns_bulk`** cascade-delete children then the campaign; remaining FK issues raise **`CampaignDeleteConflict`** → **409** on **`DELETE /campaigns/{id}`** and **`POST /campaigns/bulk-delete`**. SQL Server deadlocks (**1205**) are retried up to 3 times inside **`_commit_cascade_delete`** before surfacing as **500**.
 - **Workers/poller:** **`execute_ad_job`** catches exceptions, sets **`ad_variant`** to **`failed`** with traceback in **`meta`**, re-raises; poller marks **`ad_job`** failed and increments batch **`failed_jobs`**. Invalid **`input_json`** → job **failed** without bumping **`attempt_count`** (parse before claim).
 
 There is **no** global exception handler in `main.py` for logging/masking—**add carefully** if you introduce one (preserve **`HTTPException`** behavior).
@@ -165,6 +165,8 @@ When adding endpoints: **register router in `main.py`**, add **`tags`**, and mir
 | [PRODUCT.md](./PRODUCT.md) | Business behavior the backend should implement. |
 | [TESTING.md](./TESTING.md) | pytest, fixtures, CI workflows. |
 | [references/](./references/) | HTTP paths, env vars, tables (lookup). |
+| [SCHEMA.md](./SCHEMA.md) | SQL Server columns and FK relationships. |
+| [exec-plans/](../exec-plans/) | Task execution plans (e.g. [campaign cascade delete](../exec-plans/2026-05-20-campaign-cascade-delete.md), [bulk delete API](../exec-plans/2026-05-20-campaign-bulk-delete-api.md)). |
 | [design-docs/](./design-docs/) | Major changes: write design here before coding. |
 | [backend/README.md](../backend/README.md) | Runbook, ports, worker prefixes. |
 | [AGENTS.md](../AGENTS.md) | How to run the repo and CI summary. |

--- a/agent_resources/FRONTEND.md
+++ b/agent_resources/FRONTEND.md
@@ -20,7 +20,7 @@ This document answers: **“How do I make frontend changes in the house style?�
 | `pages/` | Route-level screens (compose layout + data hooks). |
 | `components/layout/` | App chrome (e.g. `Sidebar`). |
 | `components/ui/` | Reusable primitives (`Button`, `Input`, `Card`, `Select`, …). |
-| `components/campaigns/` | Campaign-specific UI (tables, modals, analytics). |
+| `components/campaigns/` | Campaign list/detail UI: **`CampaignGridCard`** (checkbox-only selection; card body links to detail), **`DeleteCampaignModal`** (lists cascade targets; bulk/single delete), table + analytics. List bulk delete → **`POST /campaigns/bulk-delete`** when 2+ selected ([references/frontend.md](./references/frontend.md)). |
 | `components/generate/` | Generate / chat / variants experience; `index.ts` re-exports. |
 | `api/` | Plain `fetch` wrappers — **no data caching here**. |
 | `hooks/` | TanStack Query hooks (`use*`) + small UI hooks (`useFilterState`, `useResizablePanel`). |

--- a/agent_resources/PRODUCT.md
+++ b/agent_resources/PRODUCT.md
@@ -31,7 +31,7 @@ This document answers: **“What behavior is the code trying to implement?”** 
 
 | Feature | Intended behavior (from code) |
 |---------|----------------------------------|
-| **Campaigns** | CRUD by `business_client_id`; `brief` can hold **JSON** whose keys are **version numbers** (string or int) mapping to brief text for that creative version. |
+| **Campaigns** | CRUD by `business_client_id`; `brief` can hold **JSON** whose keys are **version numbers** (string or int) mapping to brief text for that creative version. **Delete** removes the campaign plus **`ad_variants`**, **`chat_messages`**, **`campaign_metrics`**, and related **`consumer_events`** (cascade in one transaction). List page: select via checkbox only; **Delete Selected** uses **`POST /campaigns/bulk-delete`** (one request for 2+ campaigns). Detail page: **`DELETE /campaigns/{id}`**. Confirmation modal lists what will be deleted ([`DeleteCampaignModal`](../frontend/src/components/campaigns/DeleteCampaignModal.tsx)). |
 | **Products** | CRUD; images uploaded to Azure **`product-images`**; **`image_name`** is required for automated ad generation (worker loads blob by name). |
 | **Consumers** | CRUD; **unique (business_client_id, email)** when email is used; **traits** JSON drives script personalization; **persona** links for segmentation. |
 | **Personas** | Global persona library (UUID id, unique name); JSON lists for motivators, pain points, optional tone preferences. |

--- a/agent_resources/SCHEMA.md
+++ b/agent_resources/SCHEMA.md
@@ -1,5 +1,9 @@
 # Database Schema Summary
 
+Authoritative **SQL Server** shape for `dbo.*` tables (columns and FKs). SQLAlchemy models live in **`backend/models/`**; see [references/persistence.md](./references/persistence.md) for ORM mapping notes (e.g. `ad_variants.metadata` → model field `meta`, optional `session_id` mapped in ORM but not on API schemas).
+
+When this file and code disagree, verify the live database, then update **both** SCHEMA and models.
+
 ## Tables
 
 ### ad_job_batches
@@ -207,3 +211,15 @@
 - `consumers.secondary_persona_id` → `personas.id`
 - `products.business_client_id` → `business_clients.id`
 - `social_connections.business_client_id` → `business_clients.id`
+
+## Application delete (campaigns)
+
+There are **no `ON DELETE CASCADE`** FKs in SQL Server for campaign children. **`DELETE /campaigns/{id}`** and **`POST /campaigns/bulk-delete`** delete in this order (see `backend/crud/campaign.py`):
+
+1. `consumer_events` (via `ad_variants` on the campaign)
+2. `ad_variants`
+3. `campaign_metrics`
+4. `chat_messages` (`campaign_id` only)
+5. `campaigns`
+
+`ad_jobs` are not FK-linked to `campaigns`. Blob objects for variant videos are not removed on delete.

--- a/agent_resources/TESTING.md
+++ b/agent_resources/TESTING.md
@@ -25,6 +25,7 @@ We aim for a **short, fast base** of **unit tests**, a **middle layer** of **int
 ### Backend (`backend/tests/`)
 
 - **API integration:** `TestClient` against **`main.app`**, **`dependency_overrides`** for `get_db` and `get_current_client_id`, **in-memory SQLite** (`StaticPool`), temporary removal of **`dbo`** schema on models for SQLite (`test_consumers.py`, `test_product.py`, etc.).
+- **Campaign delete:** **`test_delete_campaign.py`** (single `DELETE`, cascade order, 404/409); **`test_bulk_delete_campaigns.py`** (bulk partial success, dedupe, limits).
 - **Route unit behavior:** e.g. **`test_ad_variants.py`** uses **`monkeypatch`** on env and CRUD functions to test SAS URL signing without Azure.
 - **Services:** **`test_persona_assignment_service.py`**, **`test_consumer_persona_processor.py`**, **`test_script_moderation_worker.py`** — mocks for LLM clients, **no network**.
 - **Workers / poller:** **`test_ad_job_worker.py`**, **`test_ad_job_poller.py`** — **`pytest.importorskip("azure.storage.blob")`** when imports pull Azure; **`patch`** / **`AsyncMock`** for `execute_ad_job`, `claim_ad_job`, etc.
@@ -40,7 +41,7 @@ We aim for a **short, fast base** of **unit tests**, a **middle layer** of **int
 
 | Workflow | What it proves |
 |----------|----------------|
-| **`run-tests.yml`** | `python -m pytest tests -v` in **`backend/`** with **`JWT_SECRET`**, **`DB_CONNECTION_STRING=sqlite:///test.db`**, **`ALLOWED_ORIGINS`**. |
+| **`run-tests.yml`** | `python -m pytest tests -v` in **`backend/`** with **`JWT_SECRET`**, **`DB_CONNECTION_STRING=sqlite:///test.db`**, **`ALLOWED_ORIGINS`**. **`conftest.py`** sets **`VEO_GENERATION_ENABLED=true`** for tests by default. |
 | **`backend-build.yaml`** | `python -c "from main import app"` with same env pattern. |
 | **`lint.yaml`** | Frontend **ESLint**. |
 | **`frontend-build.yaml`** | Frontend **Vite build**. |

--- a/agent_resources/references/README.md
+++ b/agent_resources/references/README.md
@@ -9,6 +9,7 @@ Short, **stable lookup tables** for day-to-day work. For narrative explanations,
 | [FRONTEND.md](../FRONTEND.md) | UI structure, patterns |
 | [BACKEND.md](../BACKEND.md) | Layers, auth, jobs |
 | [TESTING.md](../TESTING.md) | How to validate |
+| [SCHEMA.md](../SCHEMA.md) | Database tables, columns, FK relationships (authoritative for SQL Server) |
 | [design-docs/README.md](../design-docs/README.md) | Major-change design process (before implementation) |
 | [exec-plans/README.md](../../exec-plans/README.md) | Task-level execution plans (repo root) |
 
@@ -21,7 +22,8 @@ Repo-root [AGENTS.md](../../AGENTS.md) is the contributor quick map (run, test, 
 | [backend-api.md](./backend-api.md) | HTTP path + verb cheat sheet |
 | [environment.md](./environment.md) | Env vars (backend + frontend) |
 | [frontend.md](./frontend.md) | Hash routes, API base, React Query keys, storage keys |
-| [persistence.md](./persistence.md) | SQLAlchemy models / tables overview |
+| [persistence.md](./persistence.md) | SQLAlchemy models / tables overview; campaign cascade delete (ORM notes; links to SCHEMA) |
+| [SCHEMA.md](../SCHEMA.md) | Full `dbo` column + FK reference (SQL Server) |
 | [ci-and-tooling.md](./ci-and-tooling.md) | GitHub Actions, local commands |
 | [integrations.md](./integrations.md) | External APIs and SDK touchpoints |
 | [generation-preferences.md](./generation-preferences.md) | Ad Studio preference snapshot JSON (brief + script pipeline) |

--- a/agent_resources/references/backend-api.md
+++ b/agent_resources/references/backend-api.md
@@ -95,7 +95,31 @@ JWT required except **`GET /social-auth/callback`** (browser redirect from Meta)
 | POST | `/campaigns/` |
 | PUT | `/campaigns/{campaign_id}` |
 | DELETE | `/campaigns/{campaign_id}` |
+| POST | `/campaigns/bulk-delete` |
 | PATCH | `/campaigns/{campaign_id}/run` |
+
+**`DELETE /campaigns/{id}`:** Cascade-deletes `consumer_events` (via variants), `ad_variants`, `campaign_metrics`, and `chat_messages`, then the campaign (**204**). **404** if missing; **409** if a FK still blocks delete after cascade (`CampaignDeleteConflict`).
+
+**`POST /campaigns/bulk-delete`:** Request body:
+
+```json
+{ "campaign_ids": [1, 2, 3] }
+```
+
+- **1–50** unique ids (deduped server-side; order preserved for `not_found_ids`).
+- One transaction per request (same cascade order as single delete); avoids parallel-delete deadlocks on SQL Server.
+- **200** response:
+
+```json
+{ "deleted_ids": [1, 2], "not_found_ids": [3] }
+```
+
+Deletes all **found** ids; ids with no row are listed in `not_found_ids` (no error if some missing).
+
+- **409** — FK still blocks after cascade.
+- **422** — empty list or more than 50 ids.
+
+Frontend: campaigns list uses bulk when **2+** selected; single id uses **`DELETE /campaigns/{id}`** ([`deleteCampaignsBulk`](../frontend/src/api/campaigns.ts)).
 
 **Campaign metrics** (separate router file; same URL prefix **`/campaigns`** — registered after core campaign routes in `main.py`):
 

--- a/agent_resources/references/environment.md
+++ b/agent_resources/references/environment.md
@@ -33,6 +33,16 @@ Loaded via **`python-dotenv`** from **`backend/.env`** (`database.py`, several w
 | `VIDEO_API_KEY` | OpenAI-compatible video generation (`ad_video_generation_worker`) |
 | `VIDEO_SECONDS` | Clip length for video API: **`4`**, **`8`**, or **`12`** (default **`12`**). Drives script beat template and audio guards (`utils/video_timing.py`). |
 
+### Video provider (Sora vs Google Veo)
+
+| Variable | Role |
+|----------|------|
+| `VEO_GENERATION_ENABLED` | When `false`, Grok routing always uses Sora (`VIDEO_API_KEY`); default **`true`** if unset (`utils/video_provider_config.py`) |
+| `GOOGLE_VEO_API_KEY` / `GOOGLE_API_KEY` / `GEMINI_API_KEY` | First non-empty wins for Veo (Gemini Developer API path) |
+| `GOOGLE_VEO_MODEL` | Optional Veo model id (see `backend/.env.example`) |
+
+Do **not** set `GOOGLE_GENAI_USE_VERTEXAI` for the built-in Veo path (Vertex/GCS not supported in-repo).
+
 ### Email (verification / password reset)
 
 | Variable | Role |

--- a/agent_resources/references/frontend.md
+++ b/agent_resources/references/frontend.md
@@ -85,7 +85,7 @@ Invalidation often uses **prefix** queries—see `frontend/src/hooks/*.ts`.
 | Table row delete | `src/components/campaigns/CampaignTable.tsx` |
 | Delete confirm modal | `src/components/campaigns/DeleteCampaignModal.tsx` (portal to `document.body`) |
 
-**Selection (grid view):** Checkbox top-left toggles selection; clicking the card body navigates to **`#/campaign/:id`** (campaign name is a link). Selected cards use blue border/ring/background.
+**Selection (grid view):** Checkbox top-left toggles selection; clicking the card body navigates to **`#/campaign/:id`** (campaign name is a link). Selected cards use blue border/ring/background. Selection persists across date/search filters; bulk delete resolves names from the full loaded list (`rawCampaigns`), not the date-filtered view.
 
 **Selection (table view):** Row checkbox + row highlight; per-row **Delete** opens the same modal as bulk.
 

--- a/agent_resources/references/frontend.md
+++ b/agent_resources/references/frontend.md
@@ -75,3 +75,25 @@ Invalidation often uses **prefix** queries—see `frontend/src/hooks/*.ts`.
 
 - `localStorage` key: `theme` (`light` | `dark`)
 - `document.documentElement` class: `dark` when dark mode
+
+## Campaigns list (`CampaignsPage`)
+
+| Area | Path / symbol |
+|------|----------------|
+| Page | `src/pages/CampaignsPage.tsx` |
+| Grid card | `src/components/campaigns/CampaignGridCard.tsx` |
+| Table row delete | `src/components/campaigns/CampaignTable.tsx` |
+| Delete confirm modal | `src/components/campaigns/DeleteCampaignModal.tsx` (portal to `document.body`) |
+
+**Selection (grid view):** Checkbox top-left toggles selection; clicking the card body navigates to **`#/campaign/:id`** (campaign name is a link). Selected cards use blue border/ring/background.
+
+**Selection (table view):** Row checkbox + row highlight; per-row **Delete** opens the same modal as bulk.
+
+**Delete flows:**
+
+| Action | API |
+|--------|-----|
+| 1 campaign (detail or list) | `DELETE /campaigns/{id}` — `deleteCampaign` / `useDeleteCampaign` |
+| 2+ campaigns (list, **Delete Selected**) | `POST /campaigns/bulk-delete` — `deleteCampaignsBulk` / `useDeleteCampaignsBulk` |
+
+Modal lists campaign name(s) and data removed (campaign, chat, variants, metrics, consumer events). Confirm via **Cancel** / **Delete** (no type-to-confirm). Bulk delete capped at **50** (`BULK_DELETE_MAX_CAMPAIGNS`). Partial bulk: amber banner when some `not_found_ids`; modal stays open if none were deleted.

--- a/agent_resources/references/integrations.md
+++ b/agent_resources/references/integrations.md
@@ -8,7 +8,7 @@ Where the code talks to the outside world (excluding the browser).
 | **Azure identity** | `azure-identity` | `database.py` (`DefaultAzureCredential`) when `USE_AZURE_AD=true` | `DB_ODBC_CONNECTION_STRING` |
 | **OpenAI API** | `openai` (`AsyncOpenAI`) | `core/openai_client.py`, video worker, moderation worker, persona code paths | `OPENAI_API_KEY`, `VIDEO_API_KEY`, `SCRIPT_*` |
 | **xAI / Grok** | `openai` (`AsyncOpenAI`) + **`xai_sdk`** (`Client`, batch chat) | `services/chat_ai/service.py` (chat); `workers/script_creation_worker/worker.py` (sync + batch script paths) | `SCRIPT_API_KEY`, `SCRIPT_BASE_URL`, `SCRIPT_MODEL` |
-| **Meta Marketing API** | `httpx` / Graph calls via `services/meta/` | OAuth (`routes/social_auth.py`, `services/meta/auth.py`); insights (`services/meta/insights.py`, `routes/metrics.py`) | `META_*`, `FERNET_SECRET_KEY`, stored token on `SocialConnection` |
+| **Meta Marketing API** | `httpx` / Graph calls via `services/ad_platforms/meta/` | OAuth (`routes/social_auth.py`, `services/ad_platforms/meta/auth.py`); insights (`services/ad_platforms/meta/insights.py`, `routes/metrics.py`); publish (`campaign_publisher.py`) | `META_*`, `FERNET_SECRET_KEY`, stored token on `SocialConnection` |
 | **Resend** | HTTP API | `services/email_verification/` | `RESEND_*` |
 | **Google OAuth** | `httpx` | `routes/auth.py` **`POST /auth/google`** | `GOOGLE_CLIENT_SECRET` |
 | **SQL Server / ODBC** | `sqlalchemy`, `pyodbc` | `database.py` | URL or Azure AD ODBC path |

--- a/agent_resources/references/persistence.md
+++ b/agent_resources/references/persistence.md
@@ -2,6 +2,8 @@
 
 ORM models live in **`backend/models/`**. Tables use schema **`dbo`** (SQL Server); tests may strip schema for SQLite.
 
+**Column-level FK reference:** [SCHEMA.md](../SCHEMA.md) (SQL Server). This file summarizes ORM modules and behavioral notes.
+
 | Module | Table (`dbo`) | Primary identifiers | Notes |
 |--------|---------------|---------------------|--------|
 | `business_client.py` | `business_clients` | `id` int | Email unique; `stripe_customer_id` placeholder default |
@@ -9,7 +11,7 @@ ORM models live in **`backend/models/`**. Tables use schema **`dbo`** (SQL Serve
 | `product.py` | `products` | `id` int | `business_client_id`; `image_name` / blob for generation |
 | `consumer.py` | `consumers` | `id` int | `business_client_id`; FK to `personas`; unique `(business_client_id, email)`; `traits` JSON text; **`consumer_traits_description`** narrative for script LLM (refreshed on consumer create/CSV and `seed_consumer_traits.py` — not automatic for other traits writes) |
 | `persona.py` | `personas` | `id` string UUID | Unique `name`; JSON string columns for lists |
-| `ad_variant.py` | `ad_variants` | `id` int | `campaign_id`, `consumer_id`, `version_number`, `is_preview`, `is_approved`, `status`, `media_url`, `metadata` column mapped as `meta` |
+| `ad_variant.py` | `ad_variants` | `id` int | `campaign_id`, `consumer_id`, `version_number`, `is_preview`, `is_approved`, `status`, `media_url`, `metadata` column mapped as `meta`; optional `session_id` (int, no FK, ORM-only — not exposed on API schemas) |
 | `ad_job.py` | `ad_jobs` | `id` UUID | `batch_id` UUID; lock columns; `input_json` / `output_json` |
 | `ad_job_batch.py` | `ad_job_batches` | `id` UUID | Progress counters; optional `idempotency_key` |
 | `chat_message.py` | `chat_messages` | `id` int | `campaign_id`, `business_client_id`, `role`, `message_type`, `content`, `version_ref` |
@@ -22,3 +24,28 @@ ORM models live in **`backend/models/`**. Tables use schema **`dbo`** (SQL Serve
 **CRUD:** `backend/crud/*` per aggregate.
 
 For concurrency on jobs, see **`crud/ad_job.py`** (`claim_ad_job`, `release_job_lock`).
+
+### Campaign delete (cascade)
+
+Implemented in **`backend/crud/campaign.py`**:
+
+| Function | Use |
+|----------|-----|
+| `_cascade_delete_campaign_ids(db, ids)` | Bulk `DELETE` children + campaigns (no commit) |
+| `_commit_cascade_delete(db, ids)` | Cascade + `commit`; retries SQL Server deadlock **1205** up to 3× |
+| `delete_campaign(db, id)` | Single id; returns `False` if missing |
+| `delete_campaigns_bulk(db, ids)` | Returns `(deleted_ids, not_found_ids)` |
+
+**Cascade order** (per [SCHEMA.md](../SCHEMA.md)):
+
+1. `consumer_events` — `ad_variant_id IN (variants for campaign ids)`
+2. `ad_variants` — `campaign_id IN (...)`
+3. `campaign_metrics` — `campaign_id IN (...)`
+4. `chat_messages` — `campaign_id IN (...)` only (not filtered by `business_client_id`)
+5. `campaigns` — `id IN (...)`
+
+**Routes:** `DELETE /campaigns/{id}` → `delete_campaign`; `POST /campaigns/bulk-delete` → `delete_campaigns_bulk`.
+
+**Errors:** `CampaignDeleteConflict` (`IntegrityError` after cascade) → HTTP **409**.
+
+**Not deleted:** `ad_jobs` / `ad_job_batches` (no FK to `campaigns`; `campaign_id` only in `input_json`). Azure blobs for variant videos are not removed.

--- a/backend/crud/__init__.py
+++ b/backend/crud/__init__.py
@@ -12,6 +12,7 @@ from .campaign import (
     create_campaign,
     update_campaign,
     delete_campaign,
+    delete_campaigns_bulk,
 )
 from .chat_message import (
     get_chat_messages,
@@ -31,6 +32,7 @@ __all__ = [
     "create_campaign",
     "update_campaign",
     "delete_campaign",
+    "delete_campaigns_bulk",
     "get_chat_messages",
     "create_chat_message",
     "delete_chat_messages_by_campaign",

--- a/backend/crud/campaign.py
+++ b/backend/crud/campaign.py
@@ -1,13 +1,82 @@
 """CRUD operations for campaigns table."""
 
+import time
 from datetime import datetime, timezone
 from typing import Optional
 
-from sqlalchemy import select
+from sqlalchemy import delete as sa_delete, select
+from sqlalchemy.exc import DBAPIError, IntegrityError
 from sqlalchemy.orm import Session
 
+from models.ad_variant import AdVariant
 from models.campaign import Campaign
+from models.campaign_metric import CampaignMetric
+from models.chat_message import ChatMessage
+from models.consumer_event import ConsumerEvent
 from schemas.campaign import CampaignCreate, CampaignUpdate
+
+_MAX_DEADLOCK_RETRIES = 3
+
+
+class CampaignDeleteConflict(Exception):
+    """Raised when campaign delete fails due to remaining FK references."""
+
+
+def _is_deadlock(exc: BaseException) -> bool:
+    """True for SQL Server deadlock victim (error 1205 / 40001)."""
+    if not isinstance(exc, DBAPIError):
+        return False
+    orig = exc.orig
+    if orig is None:
+        return "1205" in str(exc)
+    args = getattr(orig, "args", ())
+    if args and args[0] == "40001":
+        return True
+    return "1205" in str(orig)
+
+
+def _cascade_delete_campaign_ids(db: Session, campaign_ids: list[int]) -> None:
+    """Delete dependent rows then campaign rows for the given IDs (no commit)."""
+    if not campaign_ids:
+        return
+
+    variant_ids_subq = select(AdVariant.id).where(AdVariant.campaign_id.in_(campaign_ids))
+
+    db.execute(
+        sa_delete(ConsumerEvent).where(
+            ConsumerEvent.ad_variant_id.in_(variant_ids_subq)
+        )
+    )
+    db.execute(sa_delete(AdVariant).where(AdVariant.campaign_id.in_(campaign_ids)))
+    db.execute(
+        sa_delete(CampaignMetric).where(CampaignMetric.campaign_id.in_(campaign_ids))
+    )
+    db.execute(sa_delete(ChatMessage).where(ChatMessage.campaign_id.in_(campaign_ids)))
+    db.execute(sa_delete(Campaign).where(Campaign.id.in_(campaign_ids)))
+
+
+def _commit_cascade_delete(db: Session, campaign_ids: list[int]) -> None:
+    """Run cascade deletes and commit, retrying on SQL Server deadlock."""
+    last_error: Optional[BaseException] = None
+    for attempt in range(_MAX_DEADLOCK_RETRIES):
+        try:
+            _cascade_delete_campaign_ids(db, campaign_ids)
+            db.commit()
+            return
+        except IntegrityError as exc:
+            db.rollback()
+            raise CampaignDeleteConflict(
+                "Campaign cannot be deleted because related data still exists."
+            ) from exc
+        except DBAPIError as exc:
+            db.rollback()
+            last_error = exc
+            if _is_deadlock(exc) and attempt < _MAX_DEADLOCK_RETRIES - 1:
+                time.sleep(0.05 * (attempt + 1))
+                continue
+            raise
+    if last_error is not None:
+        raise last_error
 
 
 def get_campaigns(
@@ -55,10 +124,36 @@ def update_campaign(
 
 
 def delete_campaign(db: Session, campaign_id: int) -> bool:
-    """Delete a campaign by ID. Returns True if deleted, False if not found."""
-    campaign = db.get(Campaign, campaign_id)
-    if campaign is None:
+    """Delete a campaign and dependent rows in one transaction.
+
+    Returns True if deleted, False if not found.
+    Raises CampaignDeleteConflict if a FK still blocks delete after cascade.
+    """
+    if db.get(Campaign, campaign_id) is None:
         return False
-    db.delete(campaign)
-    db.commit()
+    _commit_cascade_delete(db, [campaign_id])
     return True
+
+
+def delete_campaigns_bulk(
+    db: Session, campaign_ids: list[int]
+) -> tuple[list[int], list[int]]:
+    """Delete multiple campaigns in one transaction.
+
+    Returns (deleted_ids, not_found_ids). Deduplicates ``campaign_ids`` while
+    preserving first-seen order. Raises CampaignDeleteConflict on FK failure.
+    """
+    unique_ids = list(dict.fromkeys(campaign_ids))
+    if not unique_ids:
+        return [], []
+
+    found = list(
+        db.scalars(select(Campaign.id).where(Campaign.id.in_(unique_ids))).all()
+    )
+    found_set = set(found)
+    not_found = [cid for cid in unique_ids if cid not in found_set]
+
+    if found:
+        _commit_cascade_delete(db, found)
+
+    return found, not_found

--- a/backend/models/ad_variant.py
+++ b/backend/models/ad_variant.py
@@ -14,6 +14,7 @@ class AdVariant(Base):
     __table_args__ = {"schema": "dbo"}
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    session_id: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     campaign_id: Mapped[int] = mapped_column(Integer, nullable=False)
     consumer_id: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     status: Mapped[str] = mapped_column(String, nullable=False)

--- a/backend/routes/campaigns.py
+++ b/backend/routes/campaigns.py
@@ -10,13 +10,21 @@ from cryptography.fernet import InvalidToken
 
 from database import get_db
 from dependencies import get_current_client_id
-from schemas.campaign import CampaignCreate, CampaignUpdate, CampaignResponse
+from schemas.campaign import (
+    CampaignBulkDeleteRequest,
+    CampaignBulkDeleteResponse,
+    CampaignCreate,
+    CampaignUpdate,
+    CampaignResponse,
+)
 from crud.campaign import (
+    CampaignDeleteConflict,
     get_campaigns,
     get_campaign,
     create_campaign,
     update_campaign,
     delete_campaign,
+    delete_campaigns_bulk,
 )
 from services.ad_platforms.meta.campaign_publisher import publish_campaign, MetaPublishError
 from services.ad_platforms.meta.connection_loader import (
@@ -60,6 +68,22 @@ def read_campaign(campaign_id: int, db: Session = Depends(get_db)):
 def create_new_campaign(data: CampaignCreate, db: Session = Depends(get_db)):
     return create_campaign(db, data)
 
+
+@router.post("/bulk-delete", response_model=CampaignBulkDeleteResponse)
+def bulk_remove_campaigns(
+    body: CampaignBulkDeleteRequest, db: Session = Depends(get_db)
+):
+    """Delete multiple campaigns and cascade-delete related rows in one transaction."""
+    try:
+        deleted_ids, not_found_ids = delete_campaigns_bulk(db, body.campaign_ids)
+    except CampaignDeleteConflict as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return CampaignBulkDeleteResponse(
+        deleted_ids=deleted_ids,
+        not_found_ids=not_found_ids,
+    )
+
+
 @router.put("/{campaign_id}", response_model=CampaignResponse)
 def update_existing_campaign(
     campaign_id: int, data: CampaignUpdate, db: Session = Depends(get_db)
@@ -73,8 +97,12 @@ def update_existing_campaign(
 
 @router.delete("/{campaign_id}", status_code=204)
 def remove_campaign(campaign_id: int, db: Session = Depends(get_db)):
-    """Delete a campaign by ID."""
-    if not delete_campaign(db, campaign_id):
+    """Delete a campaign by ID and cascade-delete related rows."""
+    try:
+        deleted = delete_campaign(db, campaign_id)
+    except CampaignDeleteConflict as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    if not deleted:
         raise HTTPException(status_code=404, detail="Campaign not found")
 
 

--- a/backend/schemas/campaign.py
+++ b/backend/schemas/campaign.py
@@ -4,7 +4,7 @@ import json
 from datetime import datetime, date
 from decimal import Decimal
 from typing import Literal, Optional
-from pydantic import BaseModel, field_validator, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 # Valid campaign statuses
 CampaignStatus = Literal["draft", "active", "paused", "completed"]
@@ -83,6 +83,19 @@ class CampaignUpdate(_DateRangeValidator):
     @classmethod
     def coerce_to_json(cls, v: Optional[str]) -> Optional[str]:
         return _ensure_json(v)
+
+
+class CampaignBulkDeleteRequest(BaseModel):
+    """Delete multiple campaigns in one request."""
+
+    campaign_ids: list[int] = Field(..., min_length=1, max_length=50)
+
+
+class CampaignBulkDeleteResponse(BaseModel):
+    """Result of a bulk campaign delete."""
+
+    deleted_ids: list[int]
+    not_found_ids: list[int]
 
 
 # ---------- Response schema ----------

--- a/backend/tests/test_bulk_delete_campaigns.py
+++ b/backend/tests/test_bulk_delete_campaigns.py
@@ -1,0 +1,159 @@
+"""Tests for POST /campaigns/bulk-delete."""
+
+import os
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+_backend_dir = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_backend_dir))
+
+os.environ.setdefault("ALLOWED_ORIGINS", "http://localhost")
+os.environ.setdefault("JWT_SECRET", "test-secret")
+
+from database import Base, get_db
+from dependencies import get_current_client_id
+from main import app
+from models.ad_variant import AdVariant
+from models.campaign import Campaign
+from models.campaign_metric import CampaignMetric
+from models.chat_message import ChatMessage
+from models.consumer_event import ConsumerEvent
+
+_MODELS = (Campaign, AdVariant, ChatMessage, CampaignMetric, ConsumerEvent)
+_ORIGINAL_SCHEMAS = {m: m.__table__.schema for m in _MODELS}
+_CLIENT_ID = 42
+
+
+@pytest.fixture()
+def db_session():
+    for model in _MODELS:
+        model.__table__.schema = None
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine, tables=[m.__table__ for m in _MODELS])
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine, tables=[m.__table__ for m in _MODELS])
+        for model in _MODELS:
+            model.__table__.schema = _ORIGINAL_SCHEMAS[model]
+
+
+@pytest.fixture()
+def client(db_session):
+    def _override_get_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[get_current_client_id] = lambda: _CLIENT_ID
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def _seed_campaign(db_session, *, name: str = "Test Campaign") -> Campaign:
+    now = datetime.now(timezone.utc)
+    campaign = Campaign(
+        business_client_id=_CLIENT_ID,
+        name=name,
+        status="draft",
+        created_at=now,
+        updated_at=now,
+    )
+    db_session.add(campaign)
+    db_session.commit()
+    db_session.refresh(campaign)
+    return campaign
+
+
+def _seed_variant(db_session, campaign_id: int) -> AdVariant:
+    variant = AdVariant(
+        campaign_id=campaign_id,
+        status="completed",
+        version_number=1,
+        is_preview=False,
+        is_approved=False,
+    )
+    db_session.add(variant)
+    db_session.commit()
+    db_session.refresh(variant)
+    return variant
+
+
+def _seed_chat_message(db_session, campaign_id: int) -> ChatMessage:
+    msg = ChatMessage(
+        campaign_id=campaign_id,
+        business_client_id=_CLIENT_ID,
+        role="user",
+        message_type="message",
+        content="hello",
+    )
+    db_session.add(msg)
+    db_session.commit()
+    db_session.refresh(msg)
+    return msg
+
+
+def test_bulk_delete_two_campaigns(client, db_session):
+    a = _seed_campaign(db_session, name="A")
+    b = _seed_campaign(db_session, name="B")
+    _seed_variant(db_session, a.id)
+    _seed_variant(db_session, b.id)
+    _seed_chat_message(db_session, a.id)
+
+    resp = client.post(
+        "/campaigns/bulk-delete",
+        json={"campaign_ids": [a.id, b.id]},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert set(body["deleted_ids"]) == {a.id, b.id}
+    assert body["not_found_ids"] == []
+    assert db_session.get(Campaign, a.id) is None
+    assert db_session.get(Campaign, b.id) is None
+
+
+def test_bulk_delete_partial_not_found(client, db_session):
+    c = _seed_campaign(db_session)
+    resp = client.post("/campaigns/bulk-delete", json={"campaign_ids": [c.id, 999]})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["deleted_ids"] == [c.id]
+    assert body["not_found_ids"] == [999]
+    assert db_session.get(Campaign, c.id) is None
+
+
+def test_bulk_delete_empty_ids_rejected(client):
+    resp = client.post("/campaigns/bulk-delete", json={"campaign_ids": []})
+    assert resp.status_code == 422
+
+
+def test_bulk_delete_dedupes_ids(client, db_session):
+    c = _seed_campaign(db_session)
+    resp = client.post(
+        "/campaigns/bulk-delete",
+        json={"campaign_ids": [c.id, c.id]},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["deleted_ids"] == [c.id]
+    assert db_session.get(Campaign, c.id) is None
+
+
+def test_bulk_delete_all_not_found(client, db_session):
+    resp = client.post("/campaigns/bulk-delete", json={"campaign_ids": [888, 999]})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["deleted_ids"] == []
+    assert set(body["not_found_ids"]) == {888, 999}

--- a/backend/tests/test_delete_campaign.py
+++ b/backend/tests/test_delete_campaign.py
@@ -1,0 +1,223 @@
+"""Tests for DELETE /campaigns/{id} — cascade delete of dependent rows."""
+
+import os
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+_backend_dir = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_backend_dir))
+
+os.environ.setdefault("ALLOWED_ORIGINS", "http://localhost")
+os.environ.setdefault("JWT_SECRET", "test-secret")
+
+from database import Base, get_db
+from dependencies import get_current_client_id
+from main import app
+from models.ad_variant import AdVariant
+from models.campaign import Campaign
+from models.campaign_metric import CampaignMetric
+from models.chat_message import ChatMessage
+from models.consumer_event import ConsumerEvent
+
+_MODELS = (Campaign, AdVariant, ChatMessage, CampaignMetric, ConsumerEvent)
+_ORIGINAL_SCHEMAS = {m: m.__table__.schema for m in _MODELS}
+_CLIENT_ID = 42
+
+
+@pytest.fixture()
+def db_session():
+    for model in _MODELS:
+        model.__table__.schema = None
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine, tables=[m.__table__ for m in _MODELS])
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine, tables=[m.__table__ for m in _MODELS])
+        for model in _MODELS:
+            model.__table__.schema = _ORIGINAL_SCHEMAS[model]
+
+
+@pytest.fixture()
+def client(db_session):
+    def _override_get_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[get_current_client_id] = lambda: _CLIENT_ID
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def _seed_campaign(db_session, *, name: str = "Test Campaign", business_client_id: int = _CLIENT_ID) -> Campaign:
+    now = datetime.now(timezone.utc)
+    campaign = Campaign(
+        business_client_id=business_client_id,
+        name=name,
+        status="draft",
+        created_at=now,
+        updated_at=now,
+    )
+    db_session.add(campaign)
+    db_session.commit()
+    db_session.refresh(campaign)
+    return campaign
+
+
+def _seed_variant(db_session, campaign_id: int, *, status: str = "completed") -> AdVariant:
+    variant = AdVariant(
+        campaign_id=campaign_id,
+        status=status,
+        version_number=1,
+        is_preview=False,
+        is_approved=False,
+    )
+    db_session.add(variant)
+    db_session.commit()
+    db_session.refresh(variant)
+    return variant
+
+
+def _seed_chat_message(db_session, campaign_id: int, *, content: str = "hello") -> ChatMessage:
+    msg = ChatMessage(
+        campaign_id=campaign_id,
+        business_client_id=_CLIENT_ID,
+        role="user",
+        message_type="message",
+        content=content,
+    )
+    db_session.add(msg)
+    db_session.commit()
+    db_session.refresh(msg)
+    return msg
+
+
+def _seed_metric(db_session, campaign_id: int) -> CampaignMetric:
+    metric = CampaignMetric(
+        campaign_id=campaign_id,
+        date=date.today(),
+        fetched_at=datetime.now(timezone.utc),
+    )
+    db_session.add(metric)
+    db_session.commit()
+    db_session.refresh(metric)
+    return metric
+
+
+def _seed_consumer_event(db_session, ad_variant_id: int, *, event_id: int = 1) -> ConsumerEvent:
+    # BigInteger PK does not autoincrement on SQLite; set id explicitly in tests.
+    event = ConsumerEvent(
+        id=event_id,
+        ad_variant_id=ad_variant_id,
+        event_type="view",
+    )
+    db_session.add(event)
+    db_session.commit()
+    db_session.refresh(event)
+    return event
+
+
+def test_delete_campaign_with_no_children(client, db_session):
+    campaign = _seed_campaign(db_session)
+    resp = client.delete(f"/campaigns/{campaign.id}")
+    assert resp.status_code == 204
+    assert db_session.get(Campaign, campaign.id) is None
+
+
+def test_delete_campaign_cascades_ad_variants(client, db_session):
+    campaign = _seed_campaign(db_session)
+    _seed_variant(db_session, campaign.id)
+    _seed_variant(db_session, campaign.id, status="failed")
+
+    resp = client.delete(f"/campaigns/{campaign.id}")
+    assert resp.status_code == 204
+    assert db_session.get(Campaign, campaign.id) is None
+    assert db_session.scalars(select(AdVariant).where(AdVariant.campaign_id == campaign.id)).all() == []
+
+
+def test_delete_campaign_cascades_chat_messages(client, db_session):
+    campaign = _seed_campaign(db_session)
+    _seed_chat_message(db_session, campaign.id, content="a")
+    _seed_chat_message(db_session, campaign.id, content="b")
+
+    resp = client.delete(f"/campaigns/{campaign.id}")
+    assert resp.status_code == 204
+    assert (
+        db_session.scalars(
+            select(ChatMessage).where(ChatMessage.campaign_id == campaign.id)
+        ).all()
+        == []
+    )
+
+
+def test_delete_campaign_cascades_metrics(client, db_session):
+    campaign = _seed_campaign(db_session)
+    _seed_metric(db_session, campaign.id)
+
+    resp = client.delete(f"/campaigns/{campaign.id}")
+    assert resp.status_code == 204
+    assert (
+        db_session.scalars(
+            select(CampaignMetric).where(CampaignMetric.campaign_id == campaign.id)
+        ).all()
+        == []
+    )
+
+
+def test_delete_campaign_cascades_consumer_events(client, db_session):
+    campaign = _seed_campaign(db_session)
+    variant = _seed_variant(db_session, campaign.id)
+    variant_id = variant.id
+    _seed_consumer_event(db_session, variant_id)
+
+    resp = client.delete(f"/campaigns/{campaign.id}")
+    assert resp.status_code == 204
+    assert db_session.get(AdVariant, variant_id) is None
+    assert (
+        db_session.scalars(
+            select(ConsumerEvent).where(ConsumerEvent.ad_variant_id == variant_id)
+        ).all()
+        == []
+    )
+
+
+def test_delete_campaign_not_found(client):
+    resp = client.delete("/campaigns/999")
+    assert resp.status_code == 404
+
+
+def test_delete_does_not_affect_other_campaigns(client, db_session):
+    camp_a = _seed_campaign(db_session, name="A")
+    camp_b = _seed_campaign(db_session, name="B")
+    _seed_variant(db_session, camp_a.id)
+    _seed_variant(db_session, camp_b.id)
+    _seed_chat_message(db_session, camp_a.id)
+    _seed_chat_message(db_session, camp_b.id)
+
+    resp = client.delete(f"/campaigns/{camp_a.id}")
+    assert resp.status_code == 204
+
+    assert db_session.get(Campaign, camp_a.id) is None
+    assert db_session.get(Campaign, camp_b.id) is not None
+    assert len(
+        db_session.scalars(select(AdVariant).where(AdVariant.campaign_id == camp_b.id)).all()
+    ) == 1
+    assert len(
+        db_session.scalars(
+            select(ChatMessage).where(ChatMessage.campaign_id == camp_b.id)
+        ).all()
+    ) == 1

--- a/exec-plans/README.md
+++ b/exec-plans/README.md
@@ -14,6 +14,8 @@ Add a Markdown file per task or epic slice, for example:
 
 - `feature-name.md`
 - `2026-04-14-fix-campaign-list-auth.md`
+- `2026-05-20-campaign-cascade-delete.md` (campaign `DELETE` cascade — shipped)
+- `2026-05-20-campaign-bulk-delete-api.md` (bulk delete API — shipped)
 
 **Include** where helpful:
 

--- a/frontend/src/api/campaigns.ts
+++ b/frontend/src/api/campaigns.ts
@@ -1,4 +1,7 @@
-import { apiUrl, authHeaders } from './config';
+import { apiUrl, authHeaders, formatApiDetail } from './config';
+
+/** Must match backend ``CampaignBulkDeleteRequest`` max_length. */
+export const BULK_DELETE_MAX_CAMPAIGNS = 50;
 import type {
   Campaign,
   CreateCampaignPayload,
@@ -88,6 +91,11 @@ export async function runCampaign(campaignId: number): Promise<Campaign> {
   return (await res.json()) as Campaign;
 }
 
+export interface CampaignBulkDeleteResponse {
+  deleted_ids: number[];
+  not_found_ids: number[];
+}
+
 export async function deleteCampaign(campaignId: number): Promise<void> {
   const res = await fetch(apiUrl(`/campaigns/${campaignId}`), {
     method: 'DELETE',
@@ -96,6 +104,26 @@ export async function deleteCampaign(campaignId: number): Promise<void> {
 
   if (!res.ok) {
     const body = await res.json().catch(() => ({}));
-    throw new Error(body.detail || 'Failed to delete campaign.');
+    throw new Error(formatApiDetail(body.detail, 'Failed to delete campaign.'));
   }
+}
+
+export async function deleteCampaignsBulk(
+  campaignIds: number[],
+): Promise<CampaignBulkDeleteResponse> {
+  const res = await fetch(apiUrl('/campaigns/bulk-delete'), {
+    method: 'POST',
+    headers: {
+      ...authHeaders(),
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ campaign_ids: campaignIds }),
+  });
+
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(formatApiDetail(body.detail, 'Failed to delete campaigns.'));
+  }
+
+  return (await res.json()) as CampaignBulkDeleteResponse;
 }

--- a/frontend/src/api/config.ts
+++ b/frontend/src/api/config.ts
@@ -38,3 +38,24 @@ export function authHeaders(isJson = true): HeadersInit {
     }
     return headers;
 }
+
+/** Turn FastAPI ``detail`` (string, validation array, etc.) into a user-facing message. */
+export function formatApiDetail(detail: unknown, fallback: string): string {
+    if (typeof detail === 'string' && detail.length > 0) {
+        return detail;
+    }
+    if (Array.isArray(detail)) {
+        const parts = detail
+            .map((item) => {
+                if (item && typeof item === 'object' && 'msg' in item) {
+                    return String((item as { msg: unknown }).msg);
+                }
+                return typeof item === 'string' ? item : '';
+            })
+            .filter(Boolean);
+        if (parts.length > 0) {
+            return parts.join(' ');
+        }
+    }
+    return fallback;
+}

--- a/frontend/src/components/campaigns/CampaignGridCard.tsx
+++ b/frontend/src/components/campaigns/CampaignGridCard.tsx
@@ -17,8 +17,6 @@ export const statusColors = {
   paused: 'info',
 } as const;
 
-// ---------- Component ----------
-
 interface CampaignGridCardProps {
   campaign: CampaignItem;
   isSelected: boolean;
@@ -28,24 +26,44 @@ interface CampaignGridCardProps {
 export function CampaignGridCard({ campaign, isSelected, onToggleSelection }: CampaignGridCardProps) {
   return (
     <div className="relative">
-      <div className="absolute top-3 left-3 z-10" onClick={(e) => e.preventDefault()}>
+      <div
+        className="absolute top-3 left-3 z-10"
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+        }}
+      >
         <input
           type="checkbox"
           checked={isSelected}
           onChange={() => onToggleSelection(campaign.id)}
-          className="w-4 h-4 rounded border-border text-blue-600 focus:ring-blue-500 cursor-pointer"
+          onClick={(e) => e.stopPropagation()}
+          aria-label={`Select ${campaign.name}`}
+          className="h-5 w-5 rounded border-border text-blue-600 focus:ring-blue-500 cursor-pointer"
         />
       </div>
-      <Link to={`/campaign/${campaign.id}`}>
-        <div className={`bg-card border rounded-xl overflow-hidden hover:border-foreground/20 transition-colors cursor-pointer group ${isSelected ? 'border-blue-600/40' : 'border-border'}`}>
+
+      <Link to={`/campaign/${campaign.id}`} className="block">
+        <div
+          className={`rounded-xl border overflow-hidden transition-all group ${
+            isSelected
+              ? 'border-blue-500 bg-blue-500/10 ring-2 ring-blue-500/50 shadow-sm'
+              : 'border-border bg-card hover:border-foreground/25 hover:bg-muted/30'
+          }`}
+        >
           <div className="flex h-full">
             <div className="w-28 flex-shrink-0 bg-muted relative">
               {campaign.thumbnail ? (
-                <img src={campaign.thumbnail} alt={campaign.name} className="w-full h-full object-cover" />
+                <img src={campaign.thumbnail} alt="" className="w-full h-full object-cover" />
               ) : (
                 <div className="w-full h-full flex items-center justify-center text-muted-foreground/30">
-                  <svg className="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                  <svg className="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={1.5}
+                      d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+                    />
                   </svg>
                 </div>
               )}
@@ -53,12 +71,17 @@ export function CampaignGridCard({ campaign, isSelected, onToggleSelection }: Ca
             <div className="flex-1 p-4 flex flex-col min-w-0">
               <div className="flex items-start justify-between gap-2 mb-2">
                 <div className="min-w-0">
-                  <h3 className="font-medium text-foreground truncate" title={campaign.name}>
+                  <h3
+                    className="font-medium text-foreground truncate group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors"
+                    title={campaign.name}
+                  >
                     {campaign.name}
                   </h3>
                   <p className="text-sm text-muted-foreground line-clamp-1 mt-0.5">{campaign.product}</p>
                 </div>
-                <span className={`text-xs px-2 py-0.5 rounded-full font-medium flex-shrink-0 ${statusStyles[campaign.status]}`}>
+                <span
+                  className={`text-xs px-2 py-0.5 rounded-full font-medium flex-shrink-0 ${statusStyles[campaign.status]}`}
+                >
                   {campaign.status}
                 </span>
               </div>

--- a/frontend/src/components/campaigns/DeleteCampaignModal.tsx
+++ b/frontend/src/components/campaigns/DeleteCampaignModal.tsx
@@ -1,53 +1,113 @@
-import { useState } from 'react';
+import { createPortal } from 'react-dom';
 import { AlertTriangleIcon, Loader2Icon, XIcon } from 'lucide-react';
 
 interface DeleteCampaignModalProps {
-  campaignName: string;
+  /** Names of campaigns that will be deleted (one or many). */
+  campaignNames: string[];
   onClose: () => void;
   onConfirm: () => void;
   isLoading?: boolean;
+  error?: string | null;
 }
 
-export function DeleteCampaignModal({ campaignName, onClose, onConfirm, isLoading = false }: DeleteCampaignModalProps) {
-  const [confirmation, setConfirmation] = useState('');
+const PER_CAMPAIGN_DELETED_ITEMS = [
+  'Campaign record and settings',
+  'Chat messages',
+  'Ad variants and generated ads',
+  'Campaign metrics',
+  'Consumer analytics events',
+] as const;
 
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-      <div className="absolute inset-0 bg-foreground/20 backdrop-blur-sm" onClick={() => !isLoading && onClose()} />
+export function DeleteCampaignModal({
+  campaignNames,
+  onClose,
+  onConfirm,
+  isLoading = false,
+  error = null,
+}: DeleteCampaignModalProps) {
+  const count = campaignNames.length;
+  const isPlural = count !== 1;
 
-      <div className="relative w-full max-w-md bg-card border border-border rounded-xl p-6">
+  const modal = (
+    <div className="fixed inset-0 z-[200] flex items-center justify-center p-4">
+      <div
+        className="absolute inset-0 bg-foreground/20 backdrop-blur-sm"
+        onClick={() => !isLoading && onClose()}
+        aria-hidden
+      />
+
+      <div
+        role="alertdialog"
+        aria-labelledby="delete-campaign-title"
+        aria-describedby="delete-campaign-description"
+        className="relative w-full max-w-md bg-card border border-border rounded-xl p-6 shadow-xl"
+      >
         <button
+          type="button"
           onClick={onClose}
           disabled={isLoading}
           className="absolute top-4 right-4 p-1.5 rounded-lg hover:bg-muted transition-colors text-muted-foreground"
+          aria-label="Close"
         >
           <XIcon className="w-4 h-4" />
         </button>
 
-        <div className="flex flex-col items-center text-center mb-6">
+        <div className="flex flex-col items-center text-center mb-4">
           <div className="w-11 h-11 bg-red-500/10 rounded-full flex items-center justify-center mb-4">
             <AlertTriangleIcon className="w-5 h-5 text-red-500" />
           </div>
-          <h2 className="text-lg font-semibold mb-1">Delete Campaign?</h2>
-          <p className="text-sm text-muted-foreground">
-            This action cannot be undone. This will permanently delete the campaign and all generated ads.
-          </p>
+          <h2 id="delete-campaign-title" className="text-lg font-semibold text-foreground">
+            {isPlural ? `Delete ${count} campaigns?` : `Delete "${campaignNames[0]}"?`}
+          </h2>
         </div>
 
-        <div className="space-y-1.5 mb-6">
-          <label className="block text-sm font-medium">
-            Type <span className="font-semibold">{campaignName}</span> to confirm
-          </label>
-          <input
-            placeholder={campaignName}
-            value={confirmation}
-            onChange={(e) => setConfirmation(e.target.value)}
-            className="w-full px-3 py-2 bg-background border border-border rounded-lg text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-foreground/20"
-          />
+        <div
+          id="delete-campaign-description"
+          className="mb-6 w-full rounded-lg border border-red-500/40 bg-red-500/10 px-4 py-3 text-left max-h-[min(50vh,20rem)] overflow-y-auto"
+        >
+          <p className="text-sm font-medium text-foreground">
+            This action cannot be undone.
+            {isPlural
+              ? ' The following campaigns will be permanently deleted:'
+              : ' The following will be permanently deleted for this campaign:'}
+          </p>
+          {isPlural ? (
+            <ul className="mt-3 text-sm font-medium text-foreground space-y-1 list-disc list-inside">
+              {campaignNames.map((name, index) => (
+                <li key={`${index}-${name}`} className="truncate" title={name}>
+                  {name}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <ul className="mt-3 text-sm text-foreground space-y-1 list-disc list-inside">
+              <li>The campaign</li>
+              {PER_CAMPAIGN_DELETED_ITEMS.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+          )}
+          {isPlural && (
+            <>
+              <p className="mt-4 text-sm text-foreground">For each campaign, this also removes:</p>
+              <ul className="mt-2 text-sm text-foreground space-y-1 list-disc list-inside">
+                {PER_CAMPAIGN_DELETED_ITEMS.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            </>
+          )}
         </div>
+
+        {error && (
+          <p className="mb-4 text-sm text-red-600 dark:text-red-400" role="alert">
+            {error}
+          </p>
+        )}
 
         <div className="flex justify-end gap-3">
           <button
+            type="button"
             onClick={onClose}
             disabled={isLoading}
             className="px-4 py-2 text-sm text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50"
@@ -55,15 +115,22 @@ export function DeleteCampaignModal({ campaignName, onClose, onConfirm, isLoadin
             Cancel
           </button>
           <button
+            type="button"
             onClick={onConfirm}
-            disabled={confirmation !== campaignName || isLoading}
+            disabled={isLoading}
             className="flex items-center gap-2 px-4 py-2 bg-red-500 text-white rounded-lg text-sm font-medium hover:bg-red-600 transition-colors disabled:opacity-40"
           >
             {isLoading && <Loader2Icon className="w-4 h-4 animate-spin" />}
-            {isLoading ? 'Deleting...' : 'Delete Campaign'}
+            {isLoading
+              ? 'Deleting...'
+              : isPlural
+                ? `Delete ${count} campaigns`
+                : 'Delete Campaign'}
           </button>
         </div>
       </div>
     </div>
   );
+
+  return createPortal(modal, document.body);
 }

--- a/frontend/src/hooks/useCampaigns.ts
+++ b/frontend/src/hooks/useCampaigns.ts
@@ -5,6 +5,7 @@ import {
   createCampaign,
   updateCampaign,
   deleteCampaign,
+  deleteCampaignsBulk,
 } from '../api/campaigns';
 import type { CreateCampaignPayload, UpdateCampaignPayload } from '../types';
 
@@ -57,6 +58,17 @@ export function useDeleteCampaign() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (campaignId: number) => deleteCampaign(campaignId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: CAMPAIGNS_KEY });
+    },
+  });
+}
+
+/** Delete multiple campaigns in one request. Invalidates the campaigns list on success. */
+export function useDeleteCampaignsBulk() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (campaignIds: number[]) => deleteCampaignsBulk(campaignIds),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: CAMPAIGNS_KEY });
     },

--- a/frontend/src/pages/CampaignDetailPage.tsx
+++ b/frontend/src/pages/CampaignDetailPage.tsx
@@ -253,6 +253,7 @@ export function CampaignDetailPage() {
   const [activeTab, setActiveTab] = useState<'variants' | 'analytics' | 'settings'>('variants');
   const [showEditModal, setShowEditModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   const tabs = [
     { key: 'variants' as const, label: 'Ad Variants' },
@@ -290,9 +291,22 @@ export function CampaignDetailPage() {
     });
   };
 
+  const closeDeleteModal = () => {
+    if (deleteMutation.isPending) return;
+    setShowDeleteModal(false);
+    setDeleteError(null);
+    deleteMutation.reset();
+  };
+
   const handleDelete = () => {
+    setDeleteError(null);
     deleteMutation.mutate(campaignId, {
       onSuccess: () => navigate('/campaigns'),
+      onError: (err) => {
+        setDeleteError(
+          err instanceof Error ? err.message : 'Failed to delete campaign.',
+        );
+      },
     });
   };
 
@@ -440,7 +454,11 @@ export function CampaignDetailPage() {
               <Button
                 variant="danger"
                 leftIcon={<TrashIcon className="w-4 h-4" />}
-                onClick={() => setShowDeleteModal(true)}
+                onClick={() => {
+                  setDeleteError(null);
+                  deleteMutation.reset();
+                  setShowDeleteModal(true);
+                }}
               >
                 Delete
               </Button>
@@ -582,11 +600,12 @@ export function CampaignDetailPage() {
           />
         )}
 
-        {showDeleteModal && (
+        {showDeleteModal && campaign && (
           <DeleteCampaignModal
-            campaignName={campaign.name}
+            campaignNames={[campaign.name]}
             isLoading={deleteMutation.isPending}
-            onClose={() => setShowDeleteModal(false)}
+            error={deleteError}
+            onClose={closeDeleteModal}
             onConfirm={handleDelete}
           />
         )}

--- a/frontend/src/pages/CampaignsPage.tsx
+++ b/frontend/src/pages/CampaignsPage.tsx
@@ -96,6 +96,15 @@ export function CampaignsPage() {
     [campaignsByDate, products],
   );
 
+  /** Names for any loaded campaign id (not limited to the current date filter). */
+  const campaignNameById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const c of rawCampaigns) {
+      map.set(String(c.id), c.name);
+    }
+    return map;
+  }, [rawCampaigns]);
+
   const [viewMode, setViewMode] = useState<'grid' | 'table'>('grid');
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedObjectives, setSelectedObjectives] = useState<string[]>([]);
@@ -164,9 +173,10 @@ export function CampaignsPage() {
   };
 
   const handleBulkDeleteClick = () => {
-    const targets = campaigns
-      .filter((c) => selectedCampaigns.includes(c.id))
-      .map((c) => ({ id: Number(c.id), name: c.name }));
+    const targets = selectedCampaigns.map((id) => ({
+      id: Number(id),
+      name: campaignNameById.get(id) ?? `Campaign #${id}`,
+    }));
     openDeleteModal(targets);
   };
 

--- a/frontend/src/pages/CampaignsPage.tsx
+++ b/frontend/src/pages/CampaignsPage.tsx
@@ -18,7 +18,13 @@ import { CreateCampaignModal } from '../components/campaigns/CreateCampaignModal
 import { DeleteCampaignModal } from '../components/campaigns/DeleteCampaignModal';
 
 import { useUser } from '../contexts/UserContext';
-import { useCampaigns, useDeleteCampaign, useUpdateCampaign } from '../hooks/useCampaigns';
+import { BULK_DELETE_MAX_CAMPAIGNS } from '../api/campaigns';
+import {
+  useCampaigns,
+  useDeleteCampaign,
+  useDeleteCampaignsBulk,
+  useUpdateCampaign,
+} from '../hooks/useCampaigns';
 import { useProducts } from '../hooks/useProducts';
 import {
   campaignToItem,
@@ -54,6 +60,7 @@ export function CampaignsPage() {
   const rawCampaigns = rawCampaignsData ?? EMPTY_CAMPAIGNS;
   const products = productsData ?? [];
   const deleteMutation = useDeleteCampaign();
+  const bulkDeleteMutation = useDeleteCampaignsBulk();
   const updateMutation = useUpdateCampaign();
 
   const [dateRangePreset, setDateRangePreset] = useState<DateRangePreset>('all');
@@ -96,7 +103,8 @@ export function CampaignsPage() {
 
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
-  const [campaignToDelete, setCampaignToDelete] = useState<{ id: number; name: string } | null>(null);
+  const [campaignsToDelete, setCampaignsToDelete] = useState<{ id: number; name: string }[]>([]);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   const toggleObjective = (objective: string) => {
     setSelectedObjectives((prev) =>
@@ -138,26 +146,71 @@ export function CampaignsPage() {
     setSelectedCampaigns([]);
   };
 
-  const handleBulkDelete = async () => {
-    await Promise.all(
-      selectedCampaigns.map((id) => deleteMutation.mutateAsync(Number(id))),
-    );
-    setSelectedCampaigns([]);
+  const isDeletingCampaigns =
+    deleteMutation.isPending || bulkDeleteMutation.isPending;
+
+  const closeDeleteModal = () => {
+    if (isDeletingCampaigns) return;
+    setShowDeleteModal(false);
+    setCampaignsToDelete([]);
+    setDeleteError(null);
   };
 
-  const handleDeleteClick = (campaignId: string, campaignName: string) => {
-    setCampaignToDelete({ id: Number(campaignId), name: campaignName });
+  const openDeleteModal = (targets: { id: number; name: string }[]) => {
+    if (targets.length === 0) return;
+    setDeleteError(null);
+    setCampaignsToDelete(targets);
     setShowDeleteModal(true);
   };
 
-  const handleConfirmDelete = () => {
-    if (!campaignToDelete) return;
-    deleteMutation.mutate(campaignToDelete.id, {
-      onSuccess: () => {
+  const handleBulkDeleteClick = () => {
+    const targets = campaigns
+      .filter((c) => selectedCampaigns.includes(c.id))
+      .map((c) => ({ id: Number(c.id), name: c.name }));
+    openDeleteModal(targets);
+  };
+
+  const handleDeleteClick = (campaignId: string, campaignName: string) => {
+    openDeleteModal([{ id: Number(campaignId), name: campaignName }]);
+  };
+
+  const handleConfirmDelete = async () => {
+    if (campaignsToDelete.length === 0) return;
+    setDeleteError(null);
+    const ids = campaignsToDelete.map((c) => c.id);
+    if (ids.length > BULK_DELETE_MAX_CAMPAIGNS) {
+      setDeleteError(
+        `You can delete at most ${BULK_DELETE_MAX_CAMPAIGNS} campaigns at a time. Deselect some campaigns and try again.`,
+      );
+      return;
+    }
+    try {
+      if (ids.length === 1) {
+        await deleteMutation.mutateAsync(ids[0]);
+        setSelectedCampaigns([]);
         setShowDeleteModal(false);
-        setCampaignToDelete(null);
-      },
-    });
+        setCampaignsToDelete([]);
+      } else {
+        const result = await bulkDeleteMutation.mutateAsync(ids);
+        const { deleted_ids, not_found_ids } = result;
+        if (deleted_ids.length === 0 && not_found_ids.length > 0) {
+          setDeleteError(
+            'None of the selected campaigns could be deleted — they may have already been removed.',
+          );
+          return;
+        }
+        setSelectedCampaigns([]);
+        setShowDeleteModal(false);
+        setCampaignsToDelete([]);
+        if (not_found_ids.length > 0) {
+          setDeleteError(
+            `${not_found_ids.length} campaign(s) were already removed and could not be deleted.`,
+          );
+        }
+      }
+    } catch (err) {
+      setDeleteError(err instanceof Error ? err.message : 'Failed to delete campaigns.');
+    }
   };
 
   const openCreateModal = () => {
@@ -204,6 +257,23 @@ export function CampaignsPage() {
           </div>
         </div>
 
+        {deleteError && (
+          <div
+            className="mb-4 rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-900 dark:text-amber-100 flex items-start justify-between gap-3"
+            role="alert"
+          >
+            <span>{deleteError}</span>
+            <button
+              type="button"
+              onClick={() => setDeleteError(null)}
+              className="text-amber-900/70 dark:text-amber-100/70 hover:text-amber-900 dark:hover:text-amber-100"
+              aria-label="Dismiss"
+            >
+              <XIcon className="w-4 h-4" />
+            </button>
+          </div>
+        )}
+
         {!userLoading && user && !canManageCampaigns && (
           <div
             className="mb-4 rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-900 dark:text-amber-100"
@@ -229,8 +299,14 @@ export function CampaignsPage() {
             </button>
             <button
               type="button"
-              onClick={handleBulkDelete}
-              className="px-3 py-1.5 text-sm border border-red-500/30 text-red-500 rounded-lg hover:bg-red-500/10 transition-colors"
+              onClick={handleBulkDeleteClick}
+              disabled={selectedCampaigns.length > BULK_DELETE_MAX_CAMPAIGNS}
+              title={
+                selectedCampaigns.length > BULK_DELETE_MAX_CAMPAIGNS
+                  ? `Select at most ${BULK_DELETE_MAX_CAMPAIGNS} campaigns to delete at once`
+                  : undefined
+              }
+              className="px-3 py-1.5 text-sm border border-red-500/30 text-red-500 rounded-lg hover:bg-red-500/10 transition-colors disabled:opacity-50 disabled:pointer-events-none"
             >
               Delete Selected
             </button>
@@ -409,14 +485,12 @@ export function CampaignsPage() {
           />
         )}
 
-        {showDeleteModal && campaignToDelete && (
+        {showDeleteModal && campaignsToDelete.length > 0 && (
           <DeleteCampaignModal
-            campaignName={campaignToDelete.name}
-            isLoading={deleteMutation.isPending}
-            onClose={() => {
-              setShowDeleteModal(false);
-              setCampaignToDelete(null);
-            }}
+            campaignNames={campaignsToDelete.map((c) => c.name)}
+            isLoading={isDeletingCampaigns}
+            error={deleteError}
+            onClose={closeDeleteModal}
             onConfirm={handleConfirmDelete}
           />
         )}


### PR DESCRIPTION
## Changes
- Cascade-delete campaign children (ad_variants, chat_messages, campaign_metrics, consumer_events) on DELETE /campaigns/{id}; return 409 when FKs still block.
- Add POST /campaigns/bulk-delete (up to 50 IDs, one transaction, deadlock retries) so list bulk delete avoids SQL Server deadlocks.
- Refresh campaigns UI: delete confirmation modal, grid checkbox selection, bulk/single delete routing, error handling, and docs/tests.

## Testing
- Unit tests
- End 2 end testing