### PR TITLE
Enforce JWT ownership on campaign delete

### DIFF
--- a/agent_resources/TESTING.md
+++ b/agent_resources/TESTING.md
@@ -25,7 +25,7 @@ We aim for a **short, fast base** of **unit tests**, a **middle layer** of **int
 ### Backend (`backend/tests/`)
 
 - **API integration:** `TestClient` against **`main.app`**, **`dependency_overrides`** for `get_db` and `get_current_client_id`, **in-memory SQLite** (`StaticPool`), temporary removal of **`dbo`** schema on models for SQLite (`test_consumers.py`, `test_product.py`, etc.).
-- **Campaign delete:** **`test_delete_campaign.py`** (single `DELETE`, cascade order, 404/409); **`test_bulk_delete_campaigns.py`** (bulk partial success, dedupe, limits).
+- **Campaign delete:** **`test_delete_campaign.py`** (single `DELETE`, cascade order, 404/409, **403** cross-tenant); **`test_bulk_delete_campaigns.py`** (bulk partial success, dedupe, limits, **403** when any id is foreign-owned).
 - **Route unit behavior:** e.g. **`test_ad_variants.py`** uses **`monkeypatch`** on env and CRUD functions to test SAS URL signing without Azure.
 - **Services:** **`test_persona_assignment_service.py`**, **`test_consumer_persona_processor.py`**, **`test_script_moderation_worker.py`** — mocks for LLM clients, **no network**.
 - **Workers / poller:** **`test_ad_job_worker.py`**, **`test_ad_job_poller.py`** — **`pytest.importorskip("azure.storage.blob")`** when imports pull Azure; **`patch`** / **`AsyncMock`** for `execute_ad_job`, `claim_ad_job`, etc.

--- a/agent_resources/references/backend-api.md
+++ b/agent_resources/references/backend-api.md
@@ -98,9 +98,9 @@ JWT required except **`GET /social-auth/callback`** (browser redirect from Meta)
 | POST | `/campaigns/bulk-delete` |
 | PATCH | `/campaigns/{campaign_id}/run` |
 
-**`DELETE /campaigns/{id}`:** Cascade-deletes `consumer_events` (via variants), `ad_variants`, `campaign_metrics`, and `chat_messages`, then the campaign (**204**). **404** if missing; **409** if a FK still blocks delete after cascade (`CampaignDeleteConflict`).
+**`DELETE /campaigns/{id}`:** Requires JWT (`Authorization: Bearer`). Caller must own `campaign.business_client_id` (**403** otherwise). Cascade-deletes `consumer_events` (via variants), `ad_variants`, `campaign_metrics`, and `chat_messages`, then the campaign (**204**). **401** without valid token; **404** if missing; **409** if a FK still blocks delete after cascade (`CampaignDeleteConflict`).
 
-**`POST /campaigns/bulk-delete`:** Request body:
+**`POST /campaigns/bulk-delete`:** Requires JWT. If any **existing** id in the request belongs to another client, the whole request fails with **403** (no partial delete). Request body:
 
 ```json
 { "campaign_ids": [1, 2, 3] }
@@ -116,6 +116,8 @@ JWT required except **`GET /social-auth/callback`** (browser redirect from Meta)
 
 Deletes all **found** ids; ids with no row are listed in `not_found_ids` (no error if some missing).
 
+- **401** — missing or invalid Bearer token.
+- **403** — at least one requested id exists but belongs to another `business_client_id`.
 - **409** — FK still blocks after cascade.
 - **422** — empty list or more than 50 ids.
 

--- a/backend/routes/campaigns.py
+++ b/backend/routes/campaigns.py
@@ -5,11 +5,13 @@ from datetime import datetime, timezone
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 from cryptography.fernet import InvalidToken
 
 from database import get_db
 from dependencies import get_current_client_id
+from models.campaign import Campaign
 from schemas.campaign import (
     CampaignBulkDeleteRequest,
     CampaignBulkDeleteResponse,
@@ -35,6 +37,16 @@ from services.ad_platforms.meta.persona_grouping import group_approved_variants_
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
+
+
+def _raise_if_foreign_campaigns(campaigns: list[Campaign], client_id: int) -> None:
+    """Reject delete when any campaign belongs to another business client."""
+    for campaign in campaigns:
+        if campaign.business_client_id != client_id:
+            raise HTTPException(
+                status_code=403,
+                detail="Not authorized to delete this campaign",
+            )
 
 
 @router.get("/", response_model=list[CampaignResponse])
@@ -71,9 +83,18 @@ def create_new_campaign(data: CampaignCreate, db: Session = Depends(get_db)):
 
 @router.post("/bulk-delete", response_model=CampaignBulkDeleteResponse)
 def bulk_remove_campaigns(
-    body: CampaignBulkDeleteRequest, db: Session = Depends(get_db)
+    body: CampaignBulkDeleteRequest,
+    db: Session = Depends(get_db),
+    client_id: int = Depends(get_current_client_id),
 ):
     """Delete multiple campaigns and cascade-delete related rows in one transaction."""
+    unique_ids = list(dict.fromkeys(body.campaign_ids))
+    if unique_ids:
+        campaigns = list(
+            db.scalars(select(Campaign).where(Campaign.id.in_(unique_ids))).all()
+        )
+        _raise_if_foreign_campaigns(campaigns, client_id)
+
     try:
         deleted_ids, not_found_ids = delete_campaigns_bulk(db, body.campaign_ids)
     except CampaignDeleteConflict as exc:
@@ -96,8 +117,21 @@ def update_existing_campaign(
 
 
 @router.delete("/{campaign_id}", status_code=204)
-def remove_campaign(campaign_id: int, db: Session = Depends(get_db)):
+def remove_campaign(
+    campaign_id: int,
+    db: Session = Depends(get_db),
+    client_id: int = Depends(get_current_client_id),
+):
     """Delete a campaign by ID and cascade-delete related rows."""
+    campaign = get_campaign(db, campaign_id)
+    if campaign is None:
+        raise HTTPException(status_code=404, detail="Campaign not found")
+    if campaign.business_client_id != client_id:
+        raise HTTPException(
+            status_code=403,
+            detail="Not authorized to delete this campaign",
+        )
+
     try:
         deleted = delete_campaign(db, campaign_id)
     except CampaignDeleteConflict as exc:

--- a/backend/tests/test_bulk_delete_campaigns.py
+++ b/backend/tests/test_bulk_delete_campaigns.py
@@ -29,6 +29,7 @@ from models.consumer_event import ConsumerEvent
 _MODELS = (Campaign, AdVariant, ChatMessage, CampaignMetric, ConsumerEvent)
 _ORIGINAL_SCHEMAS = {m: m.__table__.schema for m in _MODELS}
 _CLIENT_ID = 42
+_OTHER_CLIENT_ID = 999
 
 
 @pytest.fixture()
@@ -63,10 +64,15 @@ def client(db_session):
     app.dependency_overrides.clear()
 
 
-def _seed_campaign(db_session, *, name: str = "Test Campaign") -> Campaign:
+def _seed_campaign(
+    db_session,
+    *,
+    name: str = "Test Campaign",
+    business_client_id: int = _CLIENT_ID,
+) -> Campaign:
     now = datetime.now(timezone.utc)
     campaign = Campaign(
-        business_client_id=_CLIENT_ID,
+        business_client_id=business_client_id,
         name=name,
         status="draft",
         created_at=now,
@@ -157,3 +163,28 @@ def test_bulk_delete_all_not_found(client, db_session):
     body = resp.json()
     assert body["deleted_ids"] == []
     assert set(body["not_found_ids"]) == {888, 999}
+
+
+def test_bulk_delete_returns_403_when_any_id_foreign(client, db_session):
+    own = _seed_campaign(db_session, name="Mine")
+    foreign = _seed_campaign(db_session, name="Theirs", business_client_id=_OTHER_CLIENT_ID)
+    _seed_variant(db_session, own.id)
+    _seed_variant(db_session, foreign.id)
+
+    resp = client.post(
+        "/campaigns/bulk-delete",
+        json={"campaign_ids": [own.id, foreign.id]},
+    )
+    assert resp.status_code == 403
+    assert db_session.get(Campaign, own.id) is not None
+    assert db_session.get(Campaign, foreign.id) is not None
+
+
+def test_bulk_delete_returns_403_for_foreign_only(client, db_session):
+    foreign = _seed_campaign(db_session, business_client_id=_OTHER_CLIENT_ID)
+    resp = client.post(
+        "/campaigns/bulk-delete",
+        json={"campaign_ids": [foreign.id]},
+    )
+    assert resp.status_code == 403
+    assert db_session.get(Campaign, foreign.id) is not None

--- a/backend/tests/test_delete_campaign.py
+++ b/backend/tests/test_delete_campaign.py
@@ -29,6 +29,7 @@ from models.consumer_event import ConsumerEvent
 _MODELS = (Campaign, AdVariant, ChatMessage, CampaignMetric, ConsumerEvent)
 _ORIGINAL_SCHEMAS = {m: m.__table__.schema for m in _MODELS}
 _CLIENT_ID = 42
+_OTHER_CLIENT_ID = 999
 
 
 @pytest.fixture()
@@ -198,6 +199,13 @@ def test_delete_campaign_cascades_consumer_events(client, db_session):
 def test_delete_campaign_not_found(client):
     resp = client.delete("/campaigns/999")
     assert resp.status_code == 404
+
+
+def test_delete_returns_403_for_other_clients_campaign(client, db_session):
+    campaign = _seed_campaign(db_session, business_client_id=_OTHER_CLIENT_ID)
+    resp = client.delete(f"/campaigns/{campaign.id}")
+    assert resp.status_code == 403
+    assert db_session.get(Campaign, campaign.id) is not None
 
 
 def test_delete_does_not_affect_other_campaigns(client, db_session):

--- a/exec-plans/README.md
+++ b/exec-plans/README.md
@@ -16,6 +16,7 @@ Add a Markdown file per task or epic slice, for example:
 - `2026-04-14-fix-campaign-list-auth.md`
 - `2026-05-20-campaign-cascade-delete.md` (campaign `DELETE` cascade — shipped)
 - `2026-05-20-campaign-bulk-delete-api.md` (bulk delete API — shipped)
+- `2026-05-20-campaign-delete-auth.md` (JWT + ownership on `DELETE` / `bulk-delete`)
 
 **Include** where helpful:
 


### PR DESCRIPTION
## Changes
- Require Authorization: Bearer on DELETE /campaigns/{id} and POST /campaigns/bulk-delete
- Verify campaign.business_client_id matches the JWT client before cascade delete
- Return 403 for cross-tenant access (same pattern as PATCH /campaigns/{id}/run)
- Bulk delete: fail entire request with 403 if any existing id belongs to another client
- Add integration tests for cross-tenant 403 on single and bulk delete

## Testing
- Unit tests
- made campaigns and deleted