### PR TITLE
refactor: introduce campaign_publications table for multi-platform support

### DIFF
--- a/backend/crud/campaign.py
+++ b/backend/crud/campaign.py
@@ -6,11 +6,12 @@ from typing import Optional
 
 from sqlalchemy import delete as sa_delete, select
 from sqlalchemy.exc import DBAPIError, IntegrityError
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, selectinload
 
 from models.ad_variant import AdVariant
 from models.campaign import Campaign
 from models.campaign_metric import CampaignMetric
+from models.campaign_publication import CampaignPublication
 from models.chat_message import ChatMessage
 from models.consumer_event import ConsumerEvent
 from schemas.campaign import CampaignCreate, CampaignUpdate
@@ -51,6 +52,11 @@ def _cascade_delete_campaign_ids(db: Session, campaign_ids: list[int]) -> None:
     db.execute(
         sa_delete(CampaignMetric).where(CampaignMetric.campaign_id.in_(campaign_ids))
     )
+    db.execute(
+        sa_delete(CampaignPublication).where(
+            CampaignPublication.campaign_id.in_(campaign_ids)
+        )
+    )
     db.execute(sa_delete(ChatMessage).where(ChatMessage.campaign_id.in_(campaign_ids)))
     db.execute(sa_delete(Campaign).where(Campaign.id.in_(campaign_ids)))
 
@@ -87,7 +93,11 @@ def get_campaigns(
     status: Optional[str] = None,
 ) -> list[Campaign]:
     """Return campaigns for a specific business client, with optional status filter."""
-    query = select(Campaign).where(Campaign.business_client_id == business_client_id)
+    query = (
+        select(Campaign)
+        .where(Campaign.business_client_id == business_client_id)
+        .options(selectinload(Campaign.publications))
+    )
     if status is not None:
         query = query.where(Campaign.status == status)
     query = query.order_by(Campaign.created_at.desc()).offset(skip).limit(limit)
@@ -95,8 +105,13 @@ def get_campaigns(
 
 
 def get_campaign(db: Session, campaign_id: int) -> Optional[Campaign]:
-    """Return a single campaign by ID, or None."""
-    return db.get(Campaign, campaign_id)
+    """Return a single campaign by ID with its publications eager-loaded, or None."""
+    stmt = (
+        select(Campaign)
+        .options(selectinload(Campaign.publications))
+        .where(Campaign.id == campaign_id)
+    )
+    return db.scalars(stmt).one_or_none()
 
 
 def create_campaign(db: Session, data: CampaignCreate) -> Campaign:

--- a/backend/crud/campaign_publication.py
+++ b/backend/crud/campaign_publication.py
@@ -1,0 +1,72 @@
+"""CRUD operations for campaign_publications."""
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from models.campaign_publication import CampaignPublication
+
+
+def get_publication(
+    db: Session, campaign_id: int, external_platform: str
+) -> Optional[CampaignPublication]:
+    """Return the publication for a given (campaign, platform), or None."""
+    stmt = select(CampaignPublication).where(
+        CampaignPublication.campaign_id == campaign_id,
+        CampaignPublication.external_platform == external_platform,
+    )
+    return db.scalars(stmt).one_or_none()
+
+
+def get_publications_for_campaign(
+    db: Session, campaign_id: int
+) -> list[CampaignPublication]:
+    """All publications attached to a campaign, oldest first."""
+    stmt = (
+        select(CampaignPublication)
+        .where(CampaignPublication.campaign_id == campaign_id)
+        .order_by(CampaignPublication.created_at)
+    )
+    return list(db.scalars(stmt).all())
+
+
+def upsert_publication(
+    db: Session,
+    *,
+    campaign_id: int,
+    external_platform: str,
+    external_campaign_id: str,
+    status: str,
+    error_message: Optional[str] = None,
+    published_at: Optional[datetime] = None,
+) -> CampaignPublication:
+    """Insert or update the (campaign x platform) publication row.
+
+    Uses the unique constraint (campaign_id, external_platform) to find an
+    existing row. Does not commit - caller commits as part of the broader
+    publish transaction so a publish failure leaves nothing partial behind.
+    """
+    existing = get_publication(db, campaign_id, external_platform)
+    now = datetime.now(timezone.utc)
+
+    if existing is None:
+        publication = CampaignPublication(
+            campaign_id=campaign_id,
+            external_platform=external_platform,
+            external_campaign_id=external_campaign_id,
+            status=status,
+            error_message=error_message,
+            published_at=published_at or (now if status == "active" else None),
+        )
+        db.add(publication)
+        return publication
+
+    existing.external_campaign_id = external_campaign_id
+    existing.status = status
+    existing.error_message = error_message
+    if status == "active" and existing.published_at is None:
+        existing.published_at = published_at or now
+    existing.updated_at = now
+    return existing

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -4,6 +4,7 @@ from .ad_job_batch import AdJobBatch
 from .business_client import BusinessClient
 from .campaign import Campaign
 from .campaign_metric import CampaignMetric
+from .campaign_publication import CampaignPublication
 from .chat_message import ChatMessage
 from .consumer_event import ConsumerEvent
 from .persona import Persona
@@ -18,6 +19,7 @@ __all__ = [
     "BusinessClient",
     "Campaign",
     "CampaignMetric",
+    "CampaignPublication",
     "ChatMessage",
     "ConsumerEvent",
     "Persona",

--- a/backend/models/campaign.py
+++ b/backend/models/campaign.py
@@ -2,12 +2,15 @@
 
 from datetime import datetime, date, timezone
 from decimal import Decimal
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 
 from sqlalchemy import Integer, String, DateTime, Date, Numeric
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from database import Base
+
+if TYPE_CHECKING:
+    from models.campaign_publication import CampaignPublication
 
 
 class Campaign(Base):
@@ -30,8 +33,13 @@ class Campaign(Base):
     updated_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
     product_ids: Mapped[Optional[str]] = mapped_column(String, nullable=True)
     meta_campaign_id: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
-    external_campaign_id: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
-    external_platform: Mapped[Optional[str]] = mapped_column(String(32), nullable=True)
+
+    publications: Mapped[list["CampaignPublication"]] = relationship(
+        "CampaignPublication",
+        back_populates="campaign",
+        cascade="all, delete-orphan",
+        order_by="CampaignPublication.created_at",
+    )
 
     def __repr__(self) -> str:
         return f"<Campaign(id={self.id}, name='{self.name}', status='{self.status}')>"

--- a/backend/models/campaign_publication.py
+++ b/backend/models/campaign_publication.py
@@ -1,0 +1,52 @@
+"""SQLAlchemy model for dbo.campaign_publications.
+
+Tracks each (campaign x ad platform) publication independently so a single
+Ad-gentic campaign can be live on multiple platforms (Meta, TikTok, etc.)
+without overwriting platform-specific IDs.
+"""
+
+from datetime import datetime, timezone
+from typing import Optional, TYPE_CHECKING
+
+from sqlalchemy import Integer, String, DateTime, ForeignKey, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from database import Base
+
+if TYPE_CHECKING:
+    from models.campaign import Campaign
+
+
+class CampaignPublication(Base):
+    __tablename__ = "campaign_publications"
+    __table_args__ = (
+        UniqueConstraint("campaign_id", "external_platform", name="uq_camp_pub"),
+        {"schema": "dbo"},
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    campaign_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("dbo.campaigns.id"), nullable=False
+    )
+    external_platform: Mapped[str] = mapped_column(String(32), nullable=False)
+    external_campaign_id: Mapped[str] = mapped_column(String(100), nullable=False)
+    status: Mapped[str] = mapped_column(String(32), nullable=False, default="active")
+    published_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    error_message: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime,
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    campaign: Mapped["Campaign"] = relationship("Campaign", back_populates="publications")
+
+    def __repr__(self) -> str:
+        return (
+            f"<CampaignPublication(campaign_id={self.campaign_id}, "
+            f"platform='{self.external_platform}', status='{self.status}')>"
+        )

--- a/backend/routes/campaigns.py
+++ b/backend/routes/campaigns.py
@@ -28,6 +28,7 @@ from crud.campaign import (
     delete_campaign,
     delete_campaigns_bulk,
 )
+from crud.campaign_publication import get_publication, upsert_publication
 from services.ad_platforms.meta.campaign_publisher import publish_campaign, MetaPublishError
 from services.ad_platforms.meta.connection_loader import (
     load_publish_connection,
@@ -182,6 +183,11 @@ def run_campaign(
             detail="No approved ad variants to publish. Approve at least one variant first.",
         )
 
+    # Look up any prior Meta publication so we can resume from a partial failure
+    # instead of creating a duplicate campaign on Meta.
+    existing_pub = get_publication(db, campaign_id, "meta")
+    existing_meta_id = existing_pub.external_campaign_id if existing_pub else campaign.meta_campaign_id
+
     try:
         meta_campaign_id = publish_campaign(
             campaign_name=campaign.name,
@@ -194,7 +200,7 @@ def run_campaign(
             ad_account_id=connection.ad_account_id,
             instagram_account_id=connection.instagram_account_id,
             facebook_page_id=connection.facebook_page_id,
-            existing_meta_campaign_id=campaign.meta_campaign_id,
+            existing_meta_campaign_id=existing_meta_id,
         )
     except InvalidToken:
         # Token decryption failed (e.g., rotated FERNET_SECRET_KEY or corrupted token).
@@ -208,12 +214,16 @@ def run_campaign(
         )
     except MetaPublishError as exc:
         # Persist partial state so a retry can resume without creating duplicates.
-        # Also persist when publish_campaign rotated the Meta campaign id (e.g., stale stored id),
-        # so retries don't keep recreating campaigns.
-        if exc.meta_campaign_id and exc.meta_campaign_id != campaign.meta_campaign_id:
-            campaign.meta_campaign_id = exc.meta_campaign_id
-            campaign.external_campaign_id = exc.meta_campaign_id
-            campaign.external_platform = "meta"
+        if exc.meta_campaign_id:
+            upsert_publication(
+                db,
+                campaign_id=campaign_id,
+                external_platform="meta",
+                external_campaign_id=exc.meta_campaign_id,
+                status="failed",
+                error_message=str(exc)[:500],
+            )
+            campaign.meta_campaign_id = exc.meta_campaign_id  # legacy column kept in sync
             campaign.updated_at = datetime.now(timezone.utc)
             db.commit()
         logger.exception(
@@ -233,11 +243,15 @@ def run_campaign(
             ),
         )
 
-    campaign.meta_campaign_id = meta_campaign_id
-    campaign.external_campaign_id = meta_campaign_id
-    campaign.external_platform = "meta"
+    upsert_publication(
+        db,
+        campaign_id=campaign_id,
+        external_platform="meta",
+        external_campaign_id=meta_campaign_id,
+        status="active",
+    )
+    campaign.meta_campaign_id = meta_campaign_id  # legacy column kept in sync
     campaign.status = "active"
     campaign.updated_at = datetime.now(timezone.utc)
     db.commit()
-    db.refresh(campaign)
-    return campaign
+    return get_campaign(db, campaign_id)

--- a/backend/schemas/campaign.py
+++ b/backend/schemas/campaign.py
@@ -6,6 +6,8 @@ from decimal import Decimal
 from typing import Literal, Optional
 from pydantic import BaseModel, Field, field_validator, model_validator
 
+from schemas.campaign_publication import CampaignPublicationResponse
+
 # Valid campaign statuses
 CampaignStatus = Literal["draft", "active", "paused", "completed"]
 
@@ -118,7 +120,6 @@ class CampaignResponse(BaseModel):
     brief: Optional[str] = None
     platforms: Optional[str] = None
     meta_campaign_id: Optional[str] = None
-    external_campaign_id: Optional[str] = None
-    external_platform: Optional[str] = None
+    publications: list[CampaignPublicationResponse] = []
 
     model_config = {"from_attributes": True}

--- a/backend/schemas/campaign_publication.py
+++ b/backend/schemas/campaign_publication.py
@@ -1,0 +1,23 @@
+"""Pydantic schemas for campaign_publications."""
+
+from datetime import datetime
+from typing import Literal, Optional
+
+from pydantic import BaseModel
+
+
+PublicationStatus = Literal["active", "paused", "failed"]
+
+
+class CampaignPublicationResponse(BaseModel):
+    id: int
+    campaign_id: int
+    external_platform: str
+    external_campaign_id: str
+    status: PublicationStatus
+    published_at: Optional[datetime] = None
+    error_message: Optional[str] = None
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}

--- a/backend/services/ad_platforms/meta/insights.py
+++ b/backend/services/ad_platforms/meta/insights.py
@@ -68,7 +68,11 @@ def fetch_and_cache_metrics(
         day = date.fromisoformat(day_row["date_start"])
         conversions = _extract_conversions(day_row.get("actions", []))
 
-        existing = db.query(CampaignMetric).filter_by(campaign_id=campaign_id, date=day).first()
+        existing = (
+            db.query(CampaignMetric)
+            .filter_by(campaign_id=campaign_id, external_platform="meta", date=day)
+            .first()
+        )
         if existing:
             # Overwrite with latest values — Meta may have updated this day's numbers
             _apply(existing, day_row, conversions, meta_campaign_id, now)

--- a/backend/tests/test_bulk_delete_campaigns.py
+++ b/backend/tests/test_bulk_delete_campaigns.py
@@ -23,10 +23,11 @@ from main import app
 from models.ad_variant import AdVariant
 from models.campaign import Campaign
 from models.campaign_metric import CampaignMetric
+from models.campaign_publication import CampaignPublication
 from models.chat_message import ChatMessage
 from models.consumer_event import ConsumerEvent
 
-_MODELS = (Campaign, AdVariant, ChatMessage, CampaignMetric, ConsumerEvent)
+_MODELS = (Campaign, AdVariant, ChatMessage, CampaignMetric, CampaignPublication, ConsumerEvent)
 _ORIGINAL_SCHEMAS = {m: m.__table__.schema for m in _MODELS}
 _CLIENT_ID = 42
 _OTHER_CLIENT_ID = 999

--- a/backend/tests/test_delete_campaign.py
+++ b/backend/tests/test_delete_campaign.py
@@ -23,10 +23,11 @@ from main import app
 from models.ad_variant import AdVariant
 from models.campaign import Campaign
 from models.campaign_metric import CampaignMetric
+from models.campaign_publication import CampaignPublication
 from models.chat_message import ChatMessage
 from models.consumer_event import ConsumerEvent
 
-_MODELS = (Campaign, AdVariant, ChatMessage, CampaignMetric, ConsumerEvent)
+_MODELS = (Campaign, AdVariant, ChatMessage, CampaignMetric, CampaignPublication, ConsumerEvent)
 _ORIGINAL_SCHEMAS = {m: m.__table__.schema for m in _MODELS}
 _CLIENT_ID = 42
 _OTHER_CLIENT_ID = 999

--- a/backend/tests/test_run_campaign.py
+++ b/backend/tests/test_run_campaign.py
@@ -21,6 +21,7 @@ from database import Base, get_db
 from dependencies import get_current_client_id
 from main import app
 from models.campaign import Campaign
+from models.campaign_publication import CampaignPublication
 from services.ad_platforms.meta.campaign_publisher import MetaPublishError
 from services.ad_platforms.meta.connection_loader import (
     ConnectionValidationError,
@@ -29,7 +30,8 @@ from services.ad_platforms.meta.connection_loader import (
 
 _CLIENT_ID = 1
 _OTHER_CLIENT_ID = 999
-_original_schema = Campaign.__table__.schema
+_MODELS = (Campaign, CampaignPublication)
+_ORIGINAL_SCHEMAS = {m: m.__table__.schema for m in _MODELS}
 
 _VALID_CONNECTION = ValidatedMetaConnection(
     encrypted_token="enc-token",
@@ -41,21 +43,23 @@ _VALID_CONNECTION = ValidatedMetaConnection(
 
 @pytest.fixture()
 def db_session():
-    Campaign.__table__.schema = None
+    for model in _MODELS:
+        model.__table__.schema = None
     engine = create_engine(
         "sqlite:///:memory:",
         connect_args={"check_same_thread": False},
         poolclass=StaticPool,
     )
-    Base.metadata.create_all(bind=engine, tables=[Campaign.__table__])
+    Base.metadata.create_all(bind=engine, tables=[m.__table__ for m in _MODELS])
     SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
     session = SessionLocal()
     try:
         yield session
     finally:
         session.close()
-        Base.metadata.drop_all(bind=engine, tables=[Campaign.__table__])
-        Campaign.__table__.schema = _original_schema
+        Base.metadata.drop_all(bind=engine, tables=[m.__table__ for m in _MODELS])
+        for model in _MODELS:
+            model.__table__.schema = _ORIGINAL_SCHEMAS[model]
 
 
 @pytest.fixture()
@@ -283,14 +287,13 @@ def test_run_resumes_from_existing_meta_campaign_id(client, db_session, monkeypa
 
 
 # ---------------------------------------------------------------------------
-# Generic external_campaign_id / external_platform dual-write — PR 1 migration
+# Publications table — multi-platform schema
 # ---------------------------------------------------------------------------
-# These columns coexist with meta_campaign_id during the transition to a
-# multi-platform schema. Once TikTok lands and the legacy column is dropped,
-# only the assertions on meta_campaign_id need to go — the rest stay.
+# /run writes to dbo.campaign_publications instead of inline columns on
+# dbo.campaigns. meta_campaign_id is still kept in sync as a legacy column.
 
 
-def test_run_dual_writes_external_columns_on_success(client, db_session, monkeypatch):
+def test_run_creates_publication_row_on_success(client, db_session, monkeypatch):
     campaign = _seed_campaign(db_session)
     _patch_helpers(monkeypatch, publish_result="meta_new_888")
 
@@ -298,16 +301,21 @@ def test_run_dual_writes_external_columns_on_success(client, db_session, monkeyp
     assert resp.status_code == 200
     body = resp.json()
     assert body["meta_campaign_id"] == "meta_new_888"
-    assert body["external_campaign_id"] == "meta_new_888"
-    assert body["external_platform"] == "meta"
+    assert len(body["publications"]) == 1
+    pub = body["publications"][0]
+    assert pub["external_platform"] == "meta"
+    assert pub["external_campaign_id"] == "meta_new_888"
+    assert pub["status"] == "active"
+    assert pub["published_at"] is not None
 
-    db_session.refresh(campaign)
-    assert campaign.meta_campaign_id == "meta_new_888"
-    assert campaign.external_campaign_id == "meta_new_888"
-    assert campaign.external_platform == "meta"
+    pubs = db_session.query(CampaignPublication).filter_by(campaign_id=campaign.id).all()
+    assert len(pubs) == 1
+    assert pubs[0].external_platform == "meta"
+    assert pubs[0].external_campaign_id == "meta_new_888"
+    assert pubs[0].status == "active"
 
 
-def test_run_dual_writes_external_columns_on_partial_failure(client, db_session, monkeypatch):
+def test_run_records_failed_publication_on_partial_failure(client, db_session, monkeypatch):
     campaign = _seed_campaign(db_session)
     _patch_helpers(
         monkeypatch,
@@ -319,7 +327,51 @@ def test_run_dual_writes_external_columns_on_partial_failure(client, db_session,
     resp = client.patch(f"/campaigns/{campaign.id}/run")
     assert resp.status_code == 502
 
+    pubs = db_session.query(CampaignPublication).filter_by(campaign_id=campaign.id).all()
+    assert len(pubs) == 1
+    assert pubs[0].external_platform == "meta"
+    assert pubs[0].external_campaign_id == "meta_partial_777"
+    assert pubs[0].status == "failed"
+    assert pubs[0].error_message is not None
+    assert "Ad set creation failed" in pubs[0].error_message
+
     db_session.refresh(campaign)
     assert campaign.meta_campaign_id == "meta_partial_777"
-    assert campaign.external_campaign_id == "meta_partial_777"
-    assert campaign.external_platform == "meta"
+    assert campaign.status == "draft"
+
+
+def test_run_resumes_from_existing_publication(client, db_session, monkeypatch):
+    """When a prior publication row exists, its external_campaign_id is used to resume."""
+    campaign = _seed_campaign(db_session)
+    db_session.add(
+        CampaignPublication(
+            campaign_id=campaign.id,
+            external_platform="meta",
+            external_campaign_id="meta_resume_from_pub",
+            status="failed",
+            error_message="prior partial failure",
+        )
+    )
+    db_session.commit()
+
+    captured = {}
+
+    def _publish(**kwargs):
+        captured.update(kwargs)
+        return "meta_resume_from_pub"
+
+    monkeypatch.setattr("routes.campaigns.load_publish_connection", lambda _d, _c: _VALID_CONNECTION)
+    monkeypatch.setattr(
+        "routes.campaigns.group_approved_variants_by_persona",
+        lambda _d, _cid: [{"persona_name": "X", "persona_traits": {}, "variants": [{"id": 1, "media_url": "x", "script": ""}]}],
+    )
+    monkeypatch.setattr("routes.campaigns.publish_campaign", _publish)
+
+    resp = client.patch(f"/campaigns/{campaign.id}/run")
+    assert resp.status_code == 200
+    assert captured["existing_meta_campaign_id"] == "meta_resume_from_pub"
+
+    # The same publication row is upserted to 'active' (no duplicate).
+    pubs = db_session.query(CampaignPublication).filter_by(campaign_id=campaign.id).all()
+    assert len(pubs) == 1
+    assert pubs[0].status == "active"


### PR DESCRIPTION

- Move Meta external_campaign_id off campaigns into campaign_publications
  (one row per campaign × platform, unique constraint on the pair).
- Campaign.meta_campaign_id kept as a legacy denormalized column.
- /run upserts a publication row on success or partial failure so retries
  can resume by reading the prior external_campaign_id from publications.
- CampaignResponse now returns publications eagerly loaded.
- meta/insights.py existing-row lookup filters by external_platform so a
  campaign published to multiple platforms doesn't cross-contaminate
  daily metrics.