### PR TITLE
Save Ad Studio generation preferences per campaign

### DIFF
--- a/agent_resources/SCHEMA.md
+++ b/agent_resources/SCHEMA.md
@@ -123,6 +123,7 @@ Unique constraint: **`(campaign_id, external_platform)`** (`uq_camp_pub`).
 | updated_at | datetime2 | no |  |  |
 | product_ids | nvarchar(MAX) | yes |  |  |
 | brief | nvarchar(MAX) | yes |  |  |
+| draft_generation_preferences | nvarchar(MAX) | yes |  |  |
 | meta_campaign_id | nvarchar(200) | yes |  |  |
 | platforms | nvarchar(MAX) | yes |  |  |
 

--- a/agent_resources/design-docs/2026-05-24-draft-generation-preferences.md
+++ b/agent_resources/design-docs/2026-05-24-draft-generation-preferences.md
@@ -1,0 +1,49 @@
+# Draft generation preferences (server-backed)
+
+**Status:** Implemented  
+**Exec plan:** [`exec-plans/2026-05-24-persist-campaign-generation-preferences.md`](../../exec-plans/2026-05-24-persist-campaign-generation-preferences.md)
+
+## Context
+
+Ad Studio filter panel choices (tone, platforms, variants per group, etc.) were in-memory only on Generate Ads. Users lost edits on refresh and could not sync prefs across devices.
+
+## Goals
+
+- Persist **draft** panel state per campaign on the server.
+- Hydrate panel when switching campaigns or opening on another device.
+- Keep **approved version** snapshots in `campaign.brief[version].generation_preferences` unchanged at plan approve.
+
+## Non-goals
+
+- Auto-regenerate variants when prefs change in results phase.
+- Optimistic concurrency / merge UI (v1: last-write-wins).
+- JWT hardening for unauthenticated `PUT /campaigns/{id}` (follow-up).
+
+## Design
+
+| Layer | Choice |
+|-------|--------|
+| Storage | `campaigns.draft_generation_preferences` (nullable JSON text) |
+| Write (editing) | `PATCH /campaigns/{id}/draft-generation-preferences` — JWT + ownership |
+| Write (approve) | `PUT /campaigns/{id}` with `brief` + `draft_generation_preferences` |
+| Frontend | `usePersistedCampaignPreferences` — hydrate on campaign switch; 500 ms debounced autosave |
+
+**Hydration order:** server draft → latest approved `generation_preferences` in `brief` → UI defaults.
+
+**Autosave guards:** skip one debounce cycle after campaign switch (avoids writing previous campaign’s prefs to the new id); only save when `hydratedCampaignIdRef` matches active campaign; ignore stale PATCH responses via save generation counter.
+
+## Rollout
+
+1. Backend migration (`main.py` startup helper on SQL Server).
+2. Frontend reads/writes new column; old clients ignore the field.
+
+## Testing
+
+- Backend: `backend/tests/test_campaign_draft_preferences.py`
+- Frontend: `frontend/src/types/generationPreferences.test.ts`
+
+## Implementation notes
+
+- Apply button removed in favor of debounced autosave.
+- `PreferencesSaveIndicator` shows Saving / Saved / error in filter panel and results toolbar.
+- Known follow-up: authenticate `PUT /campaigns/{id}`.

--- a/agent_resources/references/backend-api.md
+++ b/agent_resources/references/backend-api.md
@@ -106,6 +106,11 @@ Requires auth; enforces campaign/product ownership and daily credit balance. Ret
 | DELETE | `/campaigns/{campaign_id}` |
 | POST | `/campaigns/bulk-delete` |
 | PATCH | `/campaigns/{campaign_id}/run` |
+| PATCH | `/campaigns/{campaign_id}/draft-generation-preferences` |
+
+**`PATCH /campaigns/{id}/draft-generation-preferences`:** Requires JWT; caller must own the campaign. Body = `GenerationPreferences` JSON (same shape as version snapshots in `brief`). Persists in-progress Ad Studio panel state to `campaigns.draft_generation_preferences` for cross-device sync. **200** returns `CampaignResponse` with parsed `draft_generation_preferences`. **401** / **403** / **404** / **422** as usual.
+
+**`PUT /campaigns/{id}`** may also include `draft_generation_preferences` (object or JSON string) alongside other fields — used on plan approve together with `brief`.
 
 **`DELETE /campaigns/{id}`:** Requires JWT (`Authorization: Bearer`). Caller must own `campaign.business_client_id` (**403** otherwise). Cascade-deletes `consumer_events` (via variants), `ad_variants`, `campaign_metrics`, `campaign_publications`, and `chat_messages`, then the campaign (**204**). **401** without valid token; **404** if missing; **409** if a FK still blocks delete after cascade (`CampaignDeleteConflict`).
 

--- a/agent_resources/references/generation-preferences.md
+++ b/agent_resources/references/generation-preferences.md
@@ -4,7 +4,15 @@ Structured snapshot of the **Ad Studio** filter panel at **plan approval**, pers
 
 ## Storage
 
-- Key: version number as string (`"1"`, `"2"`, …).
+### Draft (in-progress panel)
+
+- Column: `campaigns.draft_generation_preferences` (nullable JSON text).
+- Written via **debounced autosave** (500 ms) when the user edits the preferences panel (`PATCH /campaigns/{id}/draft-generation-preferences`) and on plan approve via **`PUT /campaigns/{id}`** (same snapshot as the approved version).
+- Hydration order on Generate Ads: server draft → else latest approved version’s `generation_preferences` in `brief` → else UI defaults.
+
+### Approved version (frozen at plan approve)
+
+- Key: version number as string (`"1"`, `"2"`, …) inside `campaign.brief` JSON.
 - Value (new): object with:
   - `plan_message` (string) — full assistant plan message (Markdown + JSON block).
   - `generation_preferences` (object, optional) — fields below.

--- a/agent_resources/references/persistence.md
+++ b/agent_resources/references/persistence.md
@@ -7,7 +7,7 @@ ORM models live in **`backend/models/`**. Tables use schema **`dbo`** (SQL Serve
 | Module | Table (`dbo`) | Primary identifiers | Notes |
 |--------|---------------|---------------------|--------|
 | `business_client.py` | `business_clients` | `id` int | Email unique; `stripe_customer_id` placeholder default; `credits_balance` + `credits_daily_reset_on` (daily allowance) |
-| `campaign.py` | `campaigns` | `id` int | `business_client_id`; `brief` may store versioned JSON text; optional `meta_campaign_id` (legacy; kept in sync with Meta publish) |
+| `campaign.py` | `campaigns` | `id` int | `business_client_id`; `brief` versioned JSON; `draft_generation_preferences` JSON (Ad Studio panel draft); optional `meta_campaign_id` (legacy; kept in sync with Meta publish) |
 | `campaign_publication.py` | `campaign_publications` | `id` int | One row per `(campaign_id, external_platform)`; stores platform campaign id, status, partial-failure `error_message` |
 | `product.py` | `products` | `id` int | `business_client_id`; `image_name` / blob for generation |
 | `consumer.py` | `consumers` | `id` int | `business_client_id`; FK to `personas`; unique `(business_client_id, email)`; `traits` JSON text; **`consumer_traits_description`** narrative for script LLM (refreshed on consumer create/CSV and `seed_consumer_traits.py` — not automatic for other traits writes) |

--- a/backend/crud/campaign.py
+++ b/backend/crud/campaign.py
@@ -15,6 +15,8 @@ from models.campaign_publication import CampaignPublication
 from models.chat_message import ChatMessage
 from models.consumer_event import ConsumerEvent
 from schemas.campaign import CampaignCreate, CampaignUpdate
+from schemas.generation_preferences import GenerationPreferences
+from utils.draft_generation_preferences import generation_preferences_to_json
 
 _MAX_DEADLOCK_RETRIES = 3
 
@@ -132,6 +134,22 @@ def update_campaign(
         return None
     for field, value in data.model_dump(exclude_unset=True).items():
         setattr(campaign, field, value)
+    campaign.updated_at = datetime.now(timezone.utc)
+    db.commit()
+    db.refresh(campaign)
+    return campaign
+
+
+def update_campaign_draft_preferences(
+    db: Session,
+    campaign_id: int,
+    prefs: GenerationPreferences,
+) -> Optional[Campaign]:
+    """Update only ``draft_generation_preferences`` for a campaign."""
+    campaign = db.get(Campaign, campaign_id)
+    if campaign is None:
+        return None
+    campaign.draft_generation_preferences = generation_preferences_to_json(prefs)
     campaign.updated_at = datetime.now(timezone.utc)
     db.commit()
     db.refresh(campaign)

--- a/backend/main.py
+++ b/backend/main.py
@@ -134,11 +134,34 @@ def _ensure_business_client_columns_exist() -> None:
     logger.info("Ensured business_clients schema columns exist (auth + credits).")
 
 
+def _ensure_campaign_columns_exist() -> None:
+    """Best-effort startup migration for dbo.campaigns columns."""
+    engine = get_engine()
+    if engine.dialect.name != "mssql":
+        return
+
+    statements = [
+        """
+        IF COL_LENGTH('dbo.campaigns', 'draft_generation_preferences') IS NULL
+        BEGIN
+            ALTER TABLE dbo.campaigns
+            ADD draft_generation_preferences NVARCHAR(MAX) NULL;
+        END
+        """,
+    ]
+
+    with engine.begin() as conn:
+        for stmt in statements:
+            conn.execute(text(stmt))
+    logger.info("Ensured campaigns schema columns exist (draft_generation_preferences).")
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Start the ad_job poller task when the app starts; cancel it on shutdown."""
     import asyncio
     _ensure_business_client_columns_exist()
+    _ensure_campaign_columns_exist()
     poller_task = asyncio.create_task(run_poller())
     yield
     poller_task.cancel()

--- a/backend/models/campaign.py
+++ b/backend/models/campaign.py
@@ -28,6 +28,7 @@ class Campaign(Base):
     target_audience: Mapped[Optional[str]] = mapped_column(String, nullable=True)
     product_context: Mapped[Optional[str]] = mapped_column(String, nullable=True)
     brief: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    draft_generation_preferences: Mapped[Optional[str]] = mapped_column(String, nullable=True)
     platforms: Mapped[Optional[str]] = mapped_column(String, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=lambda: datetime.now(timezone.utc))
     updated_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))

--- a/backend/routes/campaigns.py
+++ b/backend/routes/campaigns.py
@@ -19,12 +19,14 @@ from schemas.campaign import (
     CampaignUpdate,
     CampaignResponse,
 )
+from schemas.generation_preferences import GenerationPreferences
 from crud.campaign import (
     CampaignDeleteConflict,
     get_campaigns,
     get_campaign,
     create_campaign,
     update_campaign,
+    update_campaign_draft_preferences,
     delete_campaign,
     delete_campaigns_bulk,
 )
@@ -48,6 +50,19 @@ def _raise_if_foreign_campaigns(campaigns: list[Campaign], client_id: int) -> No
                 status_code=403,
                 detail="Not authorized to delete this campaign",
             )
+
+
+def _require_owned_campaign(db: Session, campaign_id: int, client_id: int) -> Campaign:
+    """Return campaign when owned by client; otherwise 404 or 403."""
+    campaign = get_campaign(db, campaign_id)
+    if campaign is None:
+        raise HTTPException(status_code=404, detail="Campaign not found")
+    if campaign.business_client_id != client_id:
+        raise HTTPException(
+            status_code=403,
+            detail="Not authorized to update this campaign",
+        )
+    return campaign
 
 
 @router.get("/", response_model=list[CampaignResponse])
@@ -112,6 +127,21 @@ def update_existing_campaign(
 ):
     """Update an existing campaign."""
     campaign = update_campaign(db, campaign_id, data)
+    if campaign is None:
+        raise HTTPException(status_code=404, detail="Campaign not found")
+    return campaign
+
+
+@router.patch("/{campaign_id}/draft-generation-preferences", response_model=CampaignResponse)
+def patch_draft_generation_preferences(
+    campaign_id: int,
+    body: GenerationPreferences,
+    db: Session = Depends(get_db),
+    client_id: int = Depends(get_current_client_id),
+):
+    """Persist in-progress Ad Studio panel preferences for cross-device sync."""
+    _require_owned_campaign(db, campaign_id, client_id)
+    campaign = update_campaign_draft_preferences(db, campaign_id, body)
     if campaign is None:
         raise HTTPException(status_code=404, detail="Campaign not found")
     return campaign

--- a/backend/schemas/campaign.py
+++ b/backend/schemas/campaign.py
@@ -3,10 +3,15 @@
 import json
 from datetime import datetime, date
 from decimal import Decimal
-from typing import Literal, Optional
+from typing import Any, Literal, Optional
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from schemas.campaign_publication import CampaignPublicationResponse
+from schemas.generation_preferences import GenerationPreferences, parse_generation_preferences
+from utils.draft_generation_preferences import (
+    coerce_draft_generation_preferences_input,
+    parse_draft_generation_preferences_column,
+)
 
 # Valid campaign statuses
 CampaignStatus = Literal["draft", "active", "paused", "completed"]
@@ -80,11 +85,19 @@ class CampaignUpdate(_DateRangeValidator):
     product_ids: Optional[str] = None
     brief: Optional[str] = None
     platforms: Optional[str] = None
+    draft_generation_preferences: Optional[str] = None
 
     @field_validator("product_context", "product_ids", "brief", "platforms", mode="before")
     @classmethod
     def coerce_to_json(cls, v: Optional[str]) -> Optional[str]:
         return _ensure_json(v)
+
+    @field_validator("draft_generation_preferences", mode="before")
+    @classmethod
+    def coerce_draft_prefs(cls, v: Any) -> Optional[str]:
+        if v is None:
+            return None
+        return coerce_draft_generation_preferences_input(v)
 
 
 class CampaignBulkDeleteRequest(BaseModel):
@@ -119,7 +132,21 @@ class CampaignResponse(BaseModel):
     product_ids: Optional[str] = None
     brief: Optional[str] = None
     platforms: Optional[str] = None
+    draft_generation_preferences: Optional[GenerationPreferences] = None
     meta_campaign_id: Optional[str] = None
     publications: list[CampaignPublicationResponse] = []
+
+    @field_validator("draft_generation_preferences", mode="before")
+    @classmethod
+    def parse_draft_prefs_response(cls, v: Any) -> Optional[GenerationPreferences]:
+        if v is None or v == "":
+            return None
+        if isinstance(v, GenerationPreferences):
+            return v
+        if isinstance(v, str):
+            return parse_draft_generation_preferences_column(v)
+        if isinstance(v, dict):
+            return parse_generation_preferences(v)
+        return None
 
     model_config = {"from_attributes": True}

--- a/backend/schemas/generation_preferences.py
+++ b/backend/schemas/generation_preferences.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Optional
 
-from pydantic import BaseModel, ConfigDict, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 
 class GenerationPreferences(BaseModel):
@@ -13,7 +13,7 @@ class GenerationPreferences(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     personalization_range: Optional[str] = None
-    variants_per_group: Optional[int] = None
+    variants_per_group: Optional[int] = Field(default=None, ge=1, le=10)
     ad_formats: Optional[list[str]] = None
     tone: Optional[str] = None
     budget_tier: Optional[str] = None

--- a/backend/tests/test_campaign_draft_preferences.py
+++ b/backend/tests/test_campaign_draft_preferences.py
@@ -1,0 +1,197 @@
+"""Tests for PATCH /campaigns/{id}/draft-generation-preferences."""
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+_backend_dir = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_backend_dir))
+
+os.environ.setdefault("ALLOWED_ORIGINS", "http://localhost")
+os.environ.setdefault("JWT_SECRET", "test-secret")
+
+from database import Base, get_db
+from dependencies import get_current_client_id
+from main import app
+from models.campaign import Campaign
+from models.campaign_publication import CampaignPublication
+
+_ORIGINAL_SCHEMAS = {
+    Campaign: Campaign.__table__.schema,
+    CampaignPublication: CampaignPublication.__table__.schema,
+}
+_CLIENT_ID = 42
+_OTHER_CLIENT_ID = 999
+
+_VALID_PREFS = {
+    "personalization_range": "group",
+    "variants_per_group": 4,
+    "ad_formats": ["images", "videos"],
+    "tone": "bold",
+    "budget_tier": "mid",
+    "cta_style": "direct",
+    "language": "English (US)",
+    "platforms": ["Facebook Feed", "Instagram Story"],
+    "color_mode": "brand",
+}
+
+
+_TEST_MODELS = (Campaign, CampaignPublication)
+
+
+@pytest.fixture()
+def db_session():
+    for model in _TEST_MODELS:
+        model.__table__.schema = None
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine, tables=[m.__table__ for m in _TEST_MODELS])
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine, tables=[m.__table__ for m in _TEST_MODELS])
+        for model in _TEST_MODELS:
+            model.__table__.schema = _ORIGINAL_SCHEMAS[model]
+
+
+@pytest.fixture()
+def client(db_session):
+    def _override_get_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[get_current_client_id] = lambda: _CLIENT_ID
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture()
+def client_no_auth(db_session):
+    def _override_get_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides.pop(get_current_client_id, None)
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def _seed_campaign(
+    db_session,
+    *,
+    name: str = "Prefs Campaign",
+    business_client_id: int = _CLIENT_ID,
+) -> Campaign:
+    now = datetime.now(timezone.utc)
+    campaign = Campaign(
+        business_client_id=business_client_id,
+        name=name,
+        status="draft",
+        created_at=now,
+        updated_at=now,
+    )
+    db_session.add(campaign)
+    db_session.commit()
+    db_session.refresh(campaign)
+    return campaign
+
+
+def test_patch_draft_preferences_success(client, db_session):
+    campaign = _seed_campaign(db_session)
+
+    res = client.patch(
+        f"/campaigns/{campaign.id}/draft-generation-preferences",
+        json=_VALID_PREFS,
+    )
+
+    assert res.status_code == 200
+    body = res.json()
+    assert body["draft_generation_preferences"]["tone"] == "bold"
+    assert body["draft_generation_preferences"]["variants_per_group"] == 4
+
+    db_session.refresh(campaign)
+    stored = json.loads(campaign.draft_generation_preferences)
+    assert stored["tone"] == "bold"
+
+
+def test_get_campaign_returns_parsed_draft(client, db_session):
+    campaign = _seed_campaign(db_session)
+    client.patch(
+        f"/campaigns/{campaign.id}/draft-generation-preferences",
+        json=_VALID_PREFS,
+    )
+
+    res = client.get(f"/campaigns/{campaign.id}")
+    assert res.status_code == 200
+    assert res.json()["draft_generation_preferences"]["cta_style"] == "direct"
+
+
+def test_patch_draft_preferences_forbidden_other_client(client, db_session):
+    campaign = _seed_campaign(db_session, business_client_id=_OTHER_CLIENT_ID)
+
+    res = client.patch(
+        f"/campaigns/{campaign.id}/draft-generation-preferences",
+        json=_VALID_PREFS,
+    )
+
+    assert res.status_code == 403
+
+
+def test_patch_draft_preferences_not_found(client):
+    res = client.patch(
+        "/campaigns/99999/draft-generation-preferences",
+        json=_VALID_PREFS,
+    )
+    assert res.status_code == 404
+
+
+def test_patch_draft_preferences_unauthorized(client_no_auth, db_session):
+    campaign = _seed_campaign(db_session)
+
+    res = client_no_auth.patch(
+        f"/campaigns/{campaign.id}/draft-generation-preferences",
+        json=_VALID_PREFS,
+    )
+
+    assert res.status_code in (401, 403)
+
+
+def test_patch_draft_preferences_invalid_variants(client, db_session):
+    campaign = _seed_campaign(db_session)
+    bad = {**_VALID_PREFS, "variants_per_group": 99}
+
+    res = client.patch(
+        f"/campaigns/{campaign.id}/draft-generation-preferences",
+        json=bad,
+    )
+
+    assert res.status_code == 422
+
+
+def test_put_campaign_with_draft_preferences(client, db_session):
+    campaign = _seed_campaign(db_session)
+
+    res = client.put(
+        f"/campaigns/{campaign.id}",
+        json={"draft_generation_preferences": _VALID_PREFS},
+    )
+
+    assert res.status_code == 200
+    assert res.json()["draft_generation_preferences"]["tone"] == "bold"
+
+    db_session.refresh(campaign)
+    assert campaign.draft_generation_preferences is not None

--- a/backend/utils/draft_generation_preferences.py
+++ b/backend/utils/draft_generation_preferences.py
@@ -1,0 +1,49 @@
+"""Serialize / parse ``campaigns.draft_generation_preferences`` JSON column."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Optional
+
+from schemas.generation_preferences import GenerationPreferences, parse_generation_preferences
+
+
+def generation_preferences_to_json(prefs: GenerationPreferences) -> str:
+    """Persistable JSON string for the campaigns column."""
+    return prefs.model_dump_json(exclude_none=True)
+
+
+def parse_draft_generation_preferences_column(
+    raw: Optional[str],
+) -> Optional[GenerationPreferences]:
+    """Parse DB column text to ``GenerationPreferences``, or ``None`` if absent/invalid."""
+    if raw is None or not str(raw).strip():
+        return None
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    return parse_generation_preferences(data)
+
+
+def coerce_draft_generation_preferences_input(value: Any) -> Optional[str]:
+    """Accept dict / model / JSON string from API requests; return column JSON text."""
+    if value is None:
+        return None
+    if isinstance(value, GenerationPreferences):
+        return generation_preferences_to_json(value)
+    if isinstance(value, dict):
+        prefs = GenerationPreferences.model_validate(value)
+        return generation_preferences_to_json(prefs)
+    if isinstance(value, str):
+        if not value.strip():
+            return None
+        try:
+            parsed = json.loads(value)
+        except (json.JSONDecodeError, TypeError) as exc:
+            raise ValueError("draft_generation_preferences must be valid JSON") from exc
+        prefs = parse_generation_preferences(parsed)
+        if prefs is None:
+            raise ValueError("draft_generation_preferences must be a non-empty preferences object")
+        return generation_preferences_to_json(prefs)
+    raise ValueError("draft_generation_preferences has an unsupported type")

--- a/frontend/src/api/campaigns.ts
+++ b/frontend/src/api/campaigns.ts
@@ -5,8 +5,9 @@ export const BULK_DELETE_MAX_CAMPAIGNS = 50;
 import type {
   Campaign,
   CreateCampaignPayload,
-  UpdateCampaignPayload
+  UpdateCampaignPayload,
 } from '../types';
+import type { GenerationPreferences } from '../types/generationPreferences';
 
 // ---------- API calls ----------
 
@@ -74,6 +75,24 @@ export async function updateCampaign(
   if (!res.ok) {
     const body = await res.json().catch(() => ({}));
     throw new Error(body.detail || 'Failed to update campaign.');
+  }
+
+  return (await res.json()) as Campaign;
+}
+
+export async function patchCampaignDraftPreferences(
+  campaignId: number,
+  prefs: GenerationPreferences,
+): Promise<Campaign> {
+  const res = await fetch(apiUrl(`/campaigns/${campaignId}/draft-generation-preferences`), {
+    method: 'PATCH',
+    headers: authHeaders(),
+    body: JSON.stringify(prefs),
+  });
+
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.detail || 'Failed to save generation preferences.');
   }
 
   return (await res.json()) as Campaign;

--- a/frontend/src/components/generate/ChatPanel.tsx
+++ b/frontend/src/components/generate/ChatPanel.tsx
@@ -6,6 +6,7 @@ import { ChatInput } from './ChatInput';
 import type { Campaign, ChatMessage } from '../../types';
 import type { Phase, Version } from './types';
 import type { FilterState, FilterAction } from '../../hooks/useFilterState';
+import type { PreferencesSaveStatus } from '../../hooks/usePersistedCampaignPreferences';
 
 interface ChatPanelProps {
   phase: Phase;
@@ -22,6 +23,7 @@ interface ChatPanelProps {
   // Filter
   filterState: FilterState;
   filterDispatch: React.Dispatch<FilterAction>;
+  preferencesSaveStatus?: PreferencesSaveStatus;
   // Chat
   messages: ChatMessage[];
   userName: string;
@@ -54,6 +56,7 @@ export function ChatPanel({
   onVersionSelect,
   filterState,
   filterDispatch,
+  preferencesSaveStatus = 'idle',
   messages,
   userName,
   input,
@@ -100,6 +103,7 @@ export function ChatPanel({
           onClose={() => setShowFilterPanel(false)}
           phase={phase}
           onEditClick={() => setShowFilterPanel(true)}
+          preferencesSaveStatus={preferencesSaveStatus}
         />
       )}
 

--- a/frontend/src/components/generate/FilterPanel.tsx
+++ b/frontend/src/components/generate/FilterPanel.tsx
@@ -1,7 +1,9 @@
 import { SlidersHorizontalIcon, XIcon } from 'lucide-react';
 import { FilterControls } from './FilterControls';
+import { PreferencesSaveIndicator } from './PreferencesSaveIndicator';
 import type { FilterState, FilterAction } from '../../hooks/useFilterState';
 import { countActiveFilters, DEFAULT_FILTERS } from '../../hooks/useFilterState';
+import type { PreferencesSaveStatus } from '../../hooks/usePersistedCampaignPreferences';
 import type { Phase } from './types';
 
 interface FilterPanelProps {
@@ -11,6 +13,7 @@ interface FilterPanelProps {
   onClose: () => void;
   phase: Phase;
   onEditClick: () => void;
+  preferencesSaveStatus?: PreferencesSaveStatus;
 }
 
 export function FilterPanel({
@@ -20,6 +23,7 @@ export function FilterPanel({
   onClose,
   phase,
   onEditClick,
+  preferencesSaveStatus = 'idle',
 }: FilterPanelProps) {
   const activeFilterCount = countActiveFilters(filterState);
 
@@ -44,17 +48,12 @@ export function FilterPanel({
               )}
             </div>
             <div className="flex items-center gap-2">
+              <PreferencesSaveIndicator status={preferencesSaveStatus} />
               <button
                 onClick={() => filterDispatch({ type: 'RESET' })}
                 className="text-xs text-muted-foreground hover:text-foreground font-medium transition-colors"
               >
                 Reset
-              </button>
-              <button
-                onClick={onClose}
-                className="px-3 py-1.5 bg-blue-600 text-white text-xs font-medium rounded-lg hover:bg-blue-700 transition-colors"
-              >
-                Apply
               </button>
               <button
                 onClick={onClose}
@@ -67,10 +66,9 @@ export function FilterPanel({
           </div>
           <div className="px-4 py-3 max-h-[50vh] overflow-y-auto">
             <p className="text-xs text-muted-foreground mb-3 leading-relaxed">
-              Tone, language, platforms, CTA, budget, and color choices are saved when you approve a plan and are applied
-              directly to script generation. &quot;Per group&quot; sets how many preview variants to generate per plan
-              persona (distinct consumers when available). Preview uses the chat plan&apos;s persona groups; format toggles
-              still guide planning.
+              Preferences save automatically for this campaign. Tone, language, platforms, CTA,
+              budget, and color are also applied to script generation when you approve a plan. &quot;Per group&quot;
+              sets how many preview variants to generate per plan persona.
             </p>
             <FilterControls filterState={filterState} filterDispatch={filterDispatch} compact={false} />
           </div>

--- a/frontend/src/components/generate/PreferencesSaveIndicator.tsx
+++ b/frontend/src/components/generate/PreferencesSaveIndicator.tsx
@@ -1,0 +1,33 @@
+import type { PreferencesSaveStatus } from '../../hooks/usePersistedCampaignPreferences';
+
+interface PreferencesSaveIndicatorProps {
+  status: PreferencesSaveStatus;
+  className?: string;
+}
+
+export function PreferencesSaveIndicator({ status, className = '' }: PreferencesSaveIndicatorProps) {
+  if (status === 'idle') return null;
+
+  const label =
+    status === 'saving'
+      ? 'Saving…'
+      : status === 'saved'
+        ? 'Saved'
+        : "Couldn't save";
+
+  const toneClass =
+    status === 'error'
+      ? 'text-red-500'
+      : status === 'saved'
+        ? 'text-emerald-600 dark:text-emerald-400'
+        : 'text-muted-foreground';
+
+  return (
+    <span
+      className={`text-[10px] font-medium tabular-nums ${toneClass} ${className}`}
+      aria-live="polite"
+    >
+      {label}
+    </span>
+  );
+}

--- a/frontend/src/components/generate/ResultsPanel.tsx
+++ b/frontend/src/components/generate/ResultsPanel.tsx
@@ -16,12 +16,15 @@ import type { Phase } from './types';
 import type { AdVariant } from '../../types';
 import type { FilterState, FilterAction } from '../../hooks/useFilterState';
 import { countActiveFilters } from '../../hooks/useFilterState';
+import type { PreferencesSaveStatus } from '../../hooks/usePersistedCampaignPreferences';
+import { PreferencesSaveIndicator } from './PreferencesSaveIndicator';
 import { useGroupedVariants } from '../../hooks/useGroupedVariants';
 
 interface ResultsPanelProps {
   phase: Phase;
   filterState: FilterState;
   filterDispatch: React.Dispatch<FilterAction>;
+  preferencesSaveStatus?: PreferencesSaveStatus;
   adVariants: AdVariant[];
   progressIdx: number;
   // Selection
@@ -32,14 +35,13 @@ interface ResultsPanelProps {
   onReviseSelected: () => void;
   onDeleteSelected: () => void;
   onApproveSelected: () => void;
-  // Filters
-  onApplyFilters?: () => void;
 }
 
 export function ResultsPanel({
   phase,
   filterState,
   filterDispatch,
+  preferencesSaveStatus = 'idle',
   adVariants,
   progressIdx,
   selectedVariants,
@@ -48,7 +50,6 @@ export function ResultsPanel({
   onReviseSelected,
   onDeleteSelected,
   onApproveSelected,
-  onApplyFilters,
 }: ResultsPanelProps) {
   const rightPanelRef = useRef<HTMLDivElement>(null);
   const [variantCols, setVariantCols] = useState(2);
@@ -105,17 +106,12 @@ export function ResultsPanel({
               </button>
               {showFilters && (
                 <div className="flex items-center gap-2">
+                  <PreferencesSaveIndicator status={preferencesSaveStatus} />
                   <button
                     onClick={() => filterDispatch({ type: 'RESET' })}
                     className="text-xs text-muted-foreground hover:text-foreground font-medium transition-colors"
                   >
                     Reset
-                  </button>
-                  <button
-                    onClick={onApplyFilters}
-                    className="px-3 py-1.5 bg-blue-600 text-white text-xs font-medium rounded-lg hover:bg-blue-700 transition-colors"
-                  >
-                    Apply
                   </button>
                 </div>
               )}

--- a/frontend/src/hooks/useFilterState.ts
+++ b/frontend/src/hooks/useFilterState.ts
@@ -48,6 +48,7 @@ export type FilterAction =
   | { type: 'SET_COLOR_MODE'; payload: ColorMode }
   | { type: 'SET_CUSTOM_COLOR'; payload: string }
   | { type: 'TOGGLE_PLATFORM'; payload: string }
+  | { type: 'LOAD'; payload: FilterState }
   | { type: 'RESET' };
 
 // ─── Reducer ─────────────────────────────────────────────────────
@@ -97,6 +98,13 @@ function filterReducer(state: FilterState, action: FilterAction): FilterState {
       }
       return { ...state, selectedPlatforms: next };
     }
+
+    case 'LOAD':
+      return {
+        ...action.payload,
+        adFormats: new Set(action.payload.adFormats),
+        selectedPlatforms: new Set(action.payload.selectedPlatforms),
+      };
 
     case 'RESET':
       return {

--- a/frontend/src/hooks/usePersistedCampaignPreferences.ts
+++ b/frontend/src/hooks/usePersistedCampaignPreferences.ts
@@ -64,19 +64,36 @@ export function usePersistedCampaignPreferences(
       }
 
       try {
-        await patchCampaignDraftPreferences(
+        const updatedCampaign = await patchCampaignDraftPreferences(
           campaignId,
           buildGenerationPreferencesSnapshot(state),
         );
 
         if (generation !== saveGenerationRef.current) return;
 
+        // Always sync cache for the saved campaign (including flush saves after switch).
+        queryClient.setQueriesData<Campaign[]>(
+          { queryKey: CAMPAIGNS_KEY },
+          (old) => {
+            if (!Array.isArray(old)) return old;
+            return old.map((c) =>
+              c.id === campaignId
+                ? {
+                    ...c,
+                    draft_generation_preferences: updatedCampaign.draft_generation_preferences,
+                  }
+                : c,
+            );
+          },
+        );
+        queryClient.setQueryData([...CAMPAIGNS_KEY, campaignId], updatedCampaign);
+        void queryClient.invalidateQueries({ queryKey: CAMPAIGNS_KEY });
+
         if (activeCampaignIdRef.current === campaignId) {
           setLastSavedSnapshot(snapshotJson);
           setSaveStatus('saved');
           if (savedFadeTimerRef.current) clearTimeout(savedFadeTimerRef.current);
           savedFadeTimerRef.current = setTimeout(() => setSaveStatus('idle'), SAVED_INDICATOR_MS);
-          queryClient.invalidateQueries({ queryKey: CAMPAIGNS_KEY });
         }
       } catch {
         if (generation !== saveGenerationRef.current) return;

--- a/frontend/src/hooks/usePersistedCampaignPreferences.ts
+++ b/frontend/src/hooks/usePersistedCampaignPreferences.ts
@@ -52,7 +52,6 @@ function syncCampaignDraftToCache(
     },
   );
   queryClient.setQueryData([...CAMPAIGNS_KEY, campaignId], updatedCampaign);
-  void queryClient.invalidateQueries({ queryKey: CAMPAIGNS_KEY });
 }
 
 /** Hydrate filter state from server; debounced autosave when preferences change. */

--- a/frontend/src/hooks/usePersistedCampaignPreferences.ts
+++ b/frontend/src/hooks/usePersistedCampaignPreferences.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { useQueryClient } from '@tanstack/react-query';
+import { useQueryClient, type QueryClient } from '@tanstack/react-query';
 import { patchCampaignDraftPreferences } from '../api/campaigns';
 import { CAMPAIGNS_KEY } from './useCampaigns';
 import type { Campaign } from '../types';
@@ -32,6 +32,29 @@ function resolveHydrationFilterState(campaign: Campaign | undefined): FilterStat
   return cloneDefaultFilterState();
 }
 
+function syncCampaignDraftToCache(
+  queryClient: QueryClient,
+  campaignId: number,
+  updatedCampaign: Campaign,
+) {
+  queryClient.setQueriesData<Campaign[]>(
+    { queryKey: CAMPAIGNS_KEY },
+    (old) => {
+      if (!Array.isArray(old)) return old;
+      return old.map((c) =>
+        c.id === campaignId
+          ? {
+              ...c,
+              draft_generation_preferences: updatedCampaign.draft_generation_preferences,
+            }
+          : c,
+      );
+    },
+  );
+  queryClient.setQueryData([...CAMPAIGNS_KEY, campaignId], updatedCampaign);
+  void queryClient.invalidateQueries({ queryKey: CAMPAIGNS_KEY });
+}
+
 /** Hydrate filter state from server; debounced autosave when preferences change. */
 export function usePersistedCampaignPreferences(
   activeCampaignId: number | undefined,
@@ -45,7 +68,7 @@ export function usePersistedCampaignPreferences(
   const hydratedCampaignIdRef = useRef<number | undefined>(undefined);
   const prevCampaignIdRef = useRef<number | undefined>(undefined);
   const activeCampaignIdRef = useRef(activeCampaignId);
-  const saveGenerationRef = useRef(0);
+  const saveGenerationByCampaignRef = useRef(new Map<number, number>());
   const skipAutosaveOnceRef = useRef(false);
   const pendingAutosaveRef = useRef<{ campaignId: number; state: FilterState } | null>(null);
   const [saveStatus, setSaveStatus] = useState<PreferencesSaveStatus>('idle');
@@ -56,7 +79,9 @@ export function usePersistedCampaignPreferences(
 
   const persistPreferences = useCallback(
     async (campaignId: number, state: FilterState) => {
-      const generation = ++saveGenerationRef.current;
+      const generation =
+        (saveGenerationByCampaignRef.current.get(campaignId) ?? 0) + 1;
+      saveGenerationByCampaignRef.current.set(campaignId, generation);
       const snapshotJson = preferencesSnapshotJson(state);
 
       if (activeCampaignIdRef.current === campaignId) {
@@ -69,25 +94,10 @@ export function usePersistedCampaignPreferences(
           buildGenerationPreferencesSnapshot(state),
         );
 
-        if (generation !== saveGenerationRef.current) return;
+        // Only apply if no newer save superseded this one for the same campaign.
+        if (saveGenerationByCampaignRef.current.get(campaignId) !== generation) return;
 
-        // Always sync cache for the saved campaign (including flush saves after switch).
-        queryClient.setQueriesData<Campaign[]>(
-          { queryKey: CAMPAIGNS_KEY },
-          (old) => {
-            if (!Array.isArray(old)) return old;
-            return old.map((c) =>
-              c.id === campaignId
-                ? {
-                    ...c,
-                    draft_generation_preferences: updatedCampaign.draft_generation_preferences,
-                  }
-                : c,
-            );
-          },
-        );
-        queryClient.setQueryData([...CAMPAIGNS_KEY, campaignId], updatedCampaign);
-        void queryClient.invalidateQueries({ queryKey: CAMPAIGNS_KEY });
+        syncCampaignDraftToCache(queryClient, campaignId, updatedCampaign);
 
         if (activeCampaignIdRef.current === campaignId) {
           setLastSavedSnapshot(snapshotJson);
@@ -96,7 +106,7 @@ export function usePersistedCampaignPreferences(
           savedFadeTimerRef.current = setTimeout(() => setSaveStatus('idle'), SAVED_INDICATOR_MS);
         }
       } catch {
-        if (generation !== saveGenerationRef.current) return;
+        if (saveGenerationByCampaignRef.current.get(campaignId) !== generation) return;
         if (activeCampaignIdRef.current === campaignId) {
           setSaveStatus('error');
         }

--- a/frontend/src/hooks/usePersistedCampaignPreferences.ts
+++ b/frontend/src/hooks/usePersistedCampaignPreferences.ts
@@ -1,0 +1,181 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { patchCampaignDraftPreferences } from '../api/campaigns';
+import { CAMPAIGNS_KEY } from './useCampaigns';
+import type { Campaign } from '../types';
+import type { FilterAction, FilterState } from './useFilterState';
+import { cloneDefaultFilterState } from '../types/generationPreferences';
+import {
+  buildGenerationPreferencesSnapshot,
+  parseGenerationPreferencesToFilterState,
+  preferencesSnapshotJson,
+  resolveLatestApprovedGenerationPreferences,
+} from '../types/generationPreferences';
+
+export type PreferencesSaveStatus = 'idle' | 'saving' | 'saved' | 'error';
+
+const SAVED_INDICATOR_MS = 2000;
+const AUTOSAVE_DEBOUNCE_MS = 500;
+
+function resolveHydrationFilterState(campaign: Campaign | undefined): FilterState {
+  if (!campaign) return cloneDefaultFilterState();
+
+  if (campaign.draft_generation_preferences) {
+    return parseGenerationPreferencesToFilterState(campaign.draft_generation_preferences);
+  }
+
+  const approvedPrefs = resolveLatestApprovedGenerationPreferences(campaign.brief);
+  if (approvedPrefs) {
+    return parseGenerationPreferencesToFilterState(approvedPrefs);
+  }
+
+  return cloneDefaultFilterState();
+}
+
+/** Hydrate filter state from server; debounced autosave when preferences change. */
+export function usePersistedCampaignPreferences(
+  activeCampaignId: number | undefined,
+  activeCampaign: Campaign | undefined,
+  filterState: FilterState,
+  filterDispatch: React.Dispatch<FilterAction>,
+) {
+  const queryClient = useQueryClient();
+  const savedFadeTimerRef = useRef<ReturnType<typeof setTimeout>>();
+  const autosaveTimerRef = useRef<ReturnType<typeof setTimeout>>();
+  const hydratedCampaignIdRef = useRef<number | undefined>(undefined);
+  const prevCampaignIdRef = useRef<number | undefined>(undefined);
+  const activeCampaignIdRef = useRef(activeCampaignId);
+  const saveGenerationRef = useRef(0);
+  const skipAutosaveOnceRef = useRef(false);
+  const pendingAutosaveRef = useRef<{ campaignId: number; state: FilterState } | null>(null);
+  const [saveStatus, setSaveStatus] = useState<PreferencesSaveStatus>('idle');
+  const [preferencesReady, setPreferencesReady] = useState(false);
+  const [lastSavedSnapshot, setLastSavedSnapshot] = useState<string | null>(null);
+
+  activeCampaignIdRef.current = activeCampaignId;
+
+  const persistPreferences = useCallback(
+    async (campaignId: number, state: FilterState) => {
+      const generation = ++saveGenerationRef.current;
+      const snapshotJson = preferencesSnapshotJson(state);
+
+      if (activeCampaignIdRef.current === campaignId) {
+        setSaveStatus('saving');
+      }
+
+      try {
+        await patchCampaignDraftPreferences(
+          campaignId,
+          buildGenerationPreferencesSnapshot(state),
+        );
+
+        if (generation !== saveGenerationRef.current) return;
+
+        if (activeCampaignIdRef.current === campaignId) {
+          setLastSavedSnapshot(snapshotJson);
+          setSaveStatus('saved');
+          if (savedFadeTimerRef.current) clearTimeout(savedFadeTimerRef.current);
+          savedFadeTimerRef.current = setTimeout(() => setSaveStatus('idle'), SAVED_INDICATOR_MS);
+          queryClient.invalidateQueries({ queryKey: CAMPAIGNS_KEY });
+        }
+      } catch {
+        if (generation !== saveGenerationRef.current) return;
+        if (activeCampaignIdRef.current === campaignId) {
+          setSaveStatus('error');
+        }
+      }
+    },
+    [queryClient],
+  );
+
+  // Hydrate when switching campaigns (wait until campaign row is available).
+  useEffect(() => {
+    if (prevCampaignIdRef.current !== activeCampaignId) {
+      hydratedCampaignIdRef.current = undefined;
+      prevCampaignIdRef.current = activeCampaignId;
+      skipAutosaveOnceRef.current = true;
+      setPreferencesReady(false);
+      setLastSavedSnapshot(null);
+    }
+
+    if (!activeCampaignId) {
+      hydratedCampaignIdRef.current = undefined;
+      setLastSavedSnapshot(null);
+      setPreferencesReady(false);
+      setSaveStatus('idle');
+      return;
+    }
+
+    if (!activeCampaign || activeCampaign.id !== activeCampaignId) return;
+    if (hydratedCampaignIdRef.current === activeCampaignId) return;
+
+    hydratedCampaignIdRef.current = activeCampaignId;
+
+    const nextState = resolveHydrationFilterState(activeCampaign);
+    filterDispatch({ type: 'LOAD', payload: nextState });
+    const snapshotJson = preferencesSnapshotJson(nextState);
+    setLastSavedSnapshot(snapshotJson);
+    setPreferencesReady(true);
+    setSaveStatus('idle');
+  }, [activeCampaignId, activeCampaign, filterDispatch]);
+
+  // Debounced autosave when filter state diverges from last saved snapshot.
+  useEffect(() => {
+    if (!activeCampaignId || !preferencesReady) {
+      pendingAutosaveRef.current = null;
+      return;
+    }
+
+    if (hydratedCampaignIdRef.current !== activeCampaignId) {
+      pendingAutosaveRef.current = null;
+      return;
+    }
+
+    if (skipAutosaveOnceRef.current) {
+      skipAutosaveOnceRef.current = false;
+      pendingAutosaveRef.current = null;
+      return;
+    }
+
+    const snapshotJson = preferencesSnapshotJson(filterState);
+    if (snapshotJson === lastSavedSnapshot) {
+      pendingAutosaveRef.current = null;
+      return;
+    }
+
+    const campaignIdToSave = activeCampaignId;
+    const stateToSave = filterState;
+    pendingAutosaveRef.current = { campaignId: campaignIdToSave, state: stateToSave };
+
+    if (autosaveTimerRef.current) clearTimeout(autosaveTimerRef.current);
+    autosaveTimerRef.current = setTimeout(() => {
+      pendingAutosaveRef.current = null;
+      if (hydratedCampaignIdRef.current !== campaignIdToSave) return;
+      void persistPreferences(campaignIdToSave, stateToSave);
+    }, AUTOSAVE_DEBOUNCE_MS);
+
+    return () => {
+      if (autosaveTimerRef.current) clearTimeout(autosaveTimerRef.current);
+    };
+  }, [activeCampaignId, filterState, preferencesReady, lastSavedSnapshot, persistPreferences]);
+
+  // Flush pending autosave when switching campaigns or unmounting.
+  useEffect(() => {
+    return () => {
+      const pending = pendingAutosaveRef.current;
+      if (pending) {
+        pendingAutosaveRef.current = null;
+        void persistPreferences(pending.campaignId, pending.state);
+      }
+    };
+  }, [activeCampaignId, persistPreferences]);
+
+  useEffect(() => {
+    return () => {
+      if (savedFadeTimerRef.current) clearTimeout(savedFadeTimerRef.current);
+      if (autosaveTimerRef.current) clearTimeout(autosaveTimerRef.current);
+    };
+  }, []);
+
+  return { saveStatus };
+}

--- a/frontend/src/pages/GenerateAdsPage.tsx
+++ b/frontend/src/pages/GenerateAdsPage.tsx
@@ -8,6 +8,7 @@ import type { Phase, Version } from '../components/generate';
 import type { Campaign, ChatMessage, AdVariant } from '../types';
 import { useFilterState } from '../hooks/useFilterState';
 import { buildGenerationPreferencesSnapshot } from '../types/generationPreferences';
+import { usePersistedCampaignPreferences } from '../hooks/usePersistedCampaignPreferences';
 import { useResizablePanel } from '../hooks/useResizablePanel';
 import { useCampaigns } from '../hooks/useCampaigns';
 import { useChatMessages, useSendChatMessage, useChatCompletion } from '../hooks/useChatMessages';
@@ -149,6 +150,13 @@ export function GenerateAdsPage() {
 
   // Show welcome message when no persisted messages exist
   const activeCampaign = campaigns.find((c) => c.id === activeCampaignId);
+  const { saveStatus: preferencesSaveStatus } = usePersistedCampaignPreferences(
+    activeCampaignId,
+    activeCampaign,
+    filterState,
+    filterDispatch,
+  );
+
   const messages: ChatMessage[] = useMemo(
     () => (serverMessages.length === 0
       ? [buildWelcomeBack(activeCampaign, versions)]
@@ -301,10 +309,11 @@ export function GenerateAdsPage() {
 
     const newVersion = versionCounter;
     const briefContent = planMessage.content;
+    const prefsSnapshot = buildGenerationPreferencesSnapshot(filterState);
     const existingBrief = activeCampaign.brief ? JSON.parse(activeCampaign.brief) : {};
     existingBrief[String(newVersion)] = {
       plan_message: briefContent,
-      generation_preferences: buildGenerationPreferencesSnapshot(filterState),
+      generation_preferences: prefsSnapshot,
     };
 
     sendAssistantMessage(
@@ -318,7 +327,10 @@ export function GenerateAdsPage() {
     updateCampaign.mutate(
       {
         campaignId: activeCampaignId,
-        data: { brief: JSON.stringify(existingBrief) },
+        data: {
+          brief: JSON.stringify(existingBrief),
+          draft_generation_preferences: prefsSnapshot,
+        },
       },
       {
         onSuccess: () => {
@@ -522,6 +534,7 @@ export function GenerateAdsPage() {
           onVersionSelect={handleVersionSelect}
           filterState={filterState}
           filterDispatch={filterDispatch}
+          preferencesSaveStatus={preferencesSaveStatus}
           messages={messages}
           userName={profile.userName}
           input={input}
@@ -564,6 +577,7 @@ export function GenerateAdsPage() {
             phase={resultsPanelPhase}
             filterState={filterState}
             filterDispatch={filterDispatch}
+            preferencesSaveStatus={preferencesSaveStatus}
             adVariants={activeVersionVariants}
             progressIdx={progressIdx}
             selectedVariants={selectedVariants}
@@ -572,10 +586,6 @@ export function GenerateAdsPage() {
             onApproveSelected={handleApproveSelected}
             onReviseSelected={handleReviseSelected}
             onDeleteSelected={handleDeleteSelected}
-            onApplyFilters={() => {
-              sendAssistantMessage('Preferences updated! Regenerating variants with your new settings...');
-              setPhase('generating');
-            }}
           />
         )}
       </div>}

--- a/frontend/src/types/campaign.ts
+++ b/frontend/src/types/campaign.ts
@@ -1,3 +1,5 @@
+import type { GenerationPreferences } from './generationPreferences';
+
 export type CampaignStatus = 'draft' | 'active' | 'paused' | 'completed';
 
 /** Icons supported by the campaign detail hero KPI strip (mapped to visuals in the UI). */
@@ -57,6 +59,7 @@ export interface Campaign {
     product_ids: string | null;
     brief: string | null;
     platforms: string | null;
+    draft_generation_preferences?: GenerationPreferences | null;
     /** When set with a valid shape, the hero strip and analytics tab use live data. */
     analytics_summary?: CampaignAnalyticsSummary | null;
     /** Set after the campaign is published to Meta via the Marketing API. */
@@ -91,4 +94,5 @@ export interface UpdateCampaignPayload {
     product_ids?: string | null;
     brief?: string | null;
     platforms?: string | null;
+    draft_generation_preferences?: GenerationPreferences | null;
 }

--- a/frontend/src/types/generationPreferences.test.ts
+++ b/frontend/src/types/generationPreferences.test.ts
@@ -43,6 +43,27 @@ describe('generationPreferences', () => {
     expect(state.selectedPlatforms.has('Facebook Feed')).toBe(false);
   });
 
+  it('preserves empty platform list from persisted JSON', () => {
+    const prefs = {
+      personalization_range: 'group',
+      variants_per_group: 4,
+      ad_formats: ['images', 'videos'],
+      tone: 'bold',
+      budget_tier: 'mid',
+      cta_style: 'direct',
+      language: 'English (US)',
+      platforms: [] as string[],
+      color_mode: 'brand',
+    };
+    const state = parseGenerationPreferencesToFilterState(prefs);
+    expect(state.selectedPlatforms.size).toBe(0);
+
+    const roundTripped = parseGenerationPreferencesToFilterState(
+      buildGenerationPreferencesSnapshot(state),
+    );
+    expect(roundTripped.selectedPlatforms.size).toBe(0);
+  });
+
   it('preferencesSnapshotJson is stable for unchanged state', () => {
     const state = {
       ...DEFAULT_FILTERS,

--- a/frontend/src/types/generationPreferences.test.ts
+++ b/frontend/src/types/generationPreferences.test.ts
@@ -64,6 +64,23 @@ describe('generationPreferences', () => {
     expect(roundTripped.selectedPlatforms.size).toBe(0);
   });
 
+  it('canonicalizes set-backed arrays for snapshot comparison', () => {
+    const defaults = {
+      ...DEFAULT_FILTERS,
+      selectedPlatforms: new Set(DEFAULT_FILTERS.selectedPlatforms),
+    };
+    const insertionOrderA = {
+      ...defaults,
+      adFormats: new Set(['images', 'videos'] as const),
+    };
+    const insertionOrderB = {
+      ...defaults,
+      adFormats: new Set(['videos', 'images'] as const),
+    };
+
+    expect(preferencesSnapshotJson(insertionOrderA)).toBe(preferencesSnapshotJson(insertionOrderB));
+  });
+
   it('preferencesSnapshotJson is stable for unchanged state', () => {
     const state = {
       ...DEFAULT_FILTERS,

--- a/frontend/src/types/generationPreferences.test.ts
+++ b/frontend/src/types/generationPreferences.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_FILTERS } from '../hooks/useFilterState';
+import {
+  buildGenerationPreferencesSnapshot,
+  parseGenerationPreferencesToFilterState,
+  preferencesSnapshotJson,
+} from './generationPreferences';
+
+describe('generationPreferences', () => {
+  it('round-trips filter state', () => {
+    const state = {
+      ...DEFAULT_FILTERS,
+      tone: 'playful' as const,
+      variantsPerGroup: 2,
+      adFormats: new Set(['images'] as const),
+      selectedPlatforms: new Set(['TikTok Feed', 'LinkedIn Banner']),
+    };
+    const restored = parseGenerationPreferencesToFilterState(
+      buildGenerationPreferencesSnapshot(state),
+    );
+    expect(restored.tone).toBe('playful');
+    expect(restored.variantsPerGroup).toBe(2);
+    expect(restored.adFormats.has('images')).toBe(true);
+    expect(restored.selectedPlatforms.has('TikTok Feed')).toBe(true);
+    expect(restored.selectedPlatforms.has('LinkedIn Banner')).toBe(true);
+  });
+
+  it('preserves non-default platforms from persisted JSON', () => {
+    const prefs = {
+      personalization_range: 'group',
+      variants_per_group: 4,
+      ad_formats: ['images', 'videos'],
+      tone: 'bold',
+      budget_tier: 'mid',
+      cta_style: 'direct',
+      language: 'English (US)',
+      platforms: ['YouTube Pre-roll', 'TikTok Feed'],
+      color_mode: 'brand',
+    };
+    const state = parseGenerationPreferencesToFilterState(prefs);
+    expect(state.selectedPlatforms.has('YouTube Pre-roll')).toBe(true);
+    expect(state.selectedPlatforms.has('TikTok Feed')).toBe(true);
+    expect(state.selectedPlatforms.has('Facebook Feed')).toBe(false);
+  });
+
+  it('preferencesSnapshotJson is stable for unchanged state', () => {
+    const state = {
+      ...DEFAULT_FILTERS,
+      adFormats: new Set(DEFAULT_FILTERS.adFormats),
+      selectedPlatforms: new Set(DEFAULT_FILTERS.selectedPlatforms),
+    };
+    expect(preferencesSnapshotJson(state)).toBe(preferencesSnapshotJson(state));
+  });
+});

--- a/frontend/src/types/generationPreferences.ts
+++ b/frontend/src/types/generationPreferences.ts
@@ -45,17 +45,22 @@ function parsePlatforms(value: unknown): Set<string> {
   return new Set(labels);
 }
 
+/** Stable JSON order for set-backed fields (insertion order varies after toggles). */
+function sortedSetValues(values: Set<string>): string[] {
+  return [...values].sort((a, b) => a.localeCompare(b));
+}
+
 /** Snapshot current filter panel for persistence at plan approval or draft save. */
 export function buildGenerationPreferencesSnapshot(state: FilterState): GenerationPreferences {
   return {
     personalization_range: state.personalizationRange,
     variants_per_group: state.variantsPerGroup,
-    ad_formats: Array.from(state.adFormats),
+    ad_formats: sortedSetValues(state.adFormats),
     tone: state.tone,
     budget_tier: state.budgetTier,
     cta_style: state.ctaStyle,
     language: state.language,
-    platforms: Array.from(state.selectedPlatforms),
+    platforms: sortedSetValues(state.selectedPlatforms),
     color_mode: state.colorMode,
     ...(state.colorMode === 'custom' ? { custom_color: state.customColor } : {}),
   };

--- a/frontend/src/types/generationPreferences.ts
+++ b/frontend/src/types/generationPreferences.ts
@@ -34,7 +34,7 @@ function asStringArray(value: unknown, allowed: Set<string>, fallback: string[])
   return filtered.length > 0 ? filtered : [...fallback];
 }
 
-/** Preserve any non-empty platform labels from persisted JSON (UI may add placements over time). */
+/** Preserve platform labels from persisted JSON; empty array means none selected. */
 function parsePlatforms(value: unknown): Set<string> {
   if (!Array.isArray(value)) {
     return new Set(DEFAULT_FILTERS.selectedPlatforms);
@@ -42,9 +42,6 @@ function parsePlatforms(value: unknown): Set<string> {
   const labels = value.filter(
     (item): item is string => typeof item === 'string' && item.trim().length > 0,
   );
-  if (labels.length === 0) {
-    return new Set(DEFAULT_FILTERS.selectedPlatforms);
-  }
   return new Set(labels);
 }
 

--- a/frontend/src/types/generationPreferences.ts
+++ b/frontend/src/types/generationPreferences.ts
@@ -1,4 +1,5 @@
-import type { FilterState } from '../hooks/useFilterState';
+import type { FilterState, PersonalizationRange, AdFormatOption, Tone, BudgetTier, CtaStyle, ColorMode } from '../hooks/useFilterState';
+import { DEFAULT_FILTERS } from '../hooks/useFilterState';
 
 /** Persisted with campaign brief per version; snake_case matches backend `GenerationPreferences`. */
 export interface GenerationPreferences {
@@ -14,7 +15,40 @@ export interface GenerationPreferences {
   custom_color?: string;
 }
 
-/** Snapshot current filter panel for persistence at plan approval. */
+const PERSONALIZATION_RANGES = new Set<PersonalizationRange>(['individual', 'group', 'broad']);
+const AD_FORMATS = new Set<AdFormatOption>(['images', 'videos']);
+const TONES = new Set<Tone>(['formal', 'playful', 'bold', 'minimal']);
+const BUDGET_TIERS = new Set<BudgetTier>(['low', 'mid', 'premium']);
+const CTA_STYLES = new Set<CtaStyle>(['soft', 'direct', 'urgency']);
+const COLOR_MODES = new Set<ColorMode>(['brand', 'custom']);
+
+function clampVariantsPerGroup(value: unknown): number {
+  const n = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(n)) return DEFAULT_FILTERS.variantsPerGroup;
+  return Math.min(10, Math.max(1, Math.round(n)));
+}
+
+function asStringArray(value: unknown, allowed: Set<string>, fallback: string[]): string[] {
+  if (!Array.isArray(value)) return [...fallback];
+  const filtered = value.filter((item): item is string => typeof item === 'string' && allowed.has(item));
+  return filtered.length > 0 ? filtered : [...fallback];
+}
+
+/** Preserve any non-empty platform labels from persisted JSON (UI may add placements over time). */
+function parsePlatforms(value: unknown): Set<string> {
+  if (!Array.isArray(value)) {
+    return new Set(DEFAULT_FILTERS.selectedPlatforms);
+  }
+  const labels = value.filter(
+    (item): item is string => typeof item === 'string' && item.trim().length > 0,
+  );
+  if (labels.length === 0) {
+    return new Set(DEFAULT_FILTERS.selectedPlatforms);
+  }
+  return new Set(labels);
+}
+
+/** Snapshot current filter panel for persistence at plan approval or draft save. */
 export function buildGenerationPreferencesSnapshot(state: FilterState): GenerationPreferences {
   return {
     personalization_range: state.personalizationRange,
@@ -28,4 +62,91 @@ export function buildGenerationPreferencesSnapshot(state: FilterState): Generati
     color_mode: state.colorMode,
     ...(state.colorMode === 'custom' ? { custom_color: state.customColor } : {}),
   };
+}
+
+/** Hydrate filter panel state from persisted preferences (draft or approved snapshot). */
+export function parseGenerationPreferencesToFilterState(prefs: GenerationPreferences): FilterState {
+  const personalizationRange = PERSONALIZATION_RANGES.has(prefs.personalization_range as PersonalizationRange)
+    ? (prefs.personalization_range as PersonalizationRange)
+    : DEFAULT_FILTERS.personalizationRange;
+
+  const tone = TONES.has(prefs.tone as Tone) ? (prefs.tone as Tone) : DEFAULT_FILTERS.tone;
+  const budgetTier = BUDGET_TIERS.has(prefs.budget_tier as BudgetTier)
+    ? (prefs.budget_tier as BudgetTier)
+    : DEFAULT_FILTERS.budgetTier;
+  const ctaStyle = CTA_STYLES.has(prefs.cta_style as CtaStyle)
+    ? (prefs.cta_style as CtaStyle)
+    : DEFAULT_FILTERS.ctaStyle;
+
+  const colorMode = COLOR_MODES.has(prefs.color_mode as ColorMode)
+    ? (prefs.color_mode as ColorMode)
+    : DEFAULT_FILTERS.colorMode;
+
+  const adFormats = new Set(
+    asStringArray(prefs.ad_formats, AD_FORMATS as Set<string>, Array.from(DEFAULT_FILTERS.adFormats)),
+  ) as Set<AdFormatOption>;
+
+  const selectedPlatforms = parsePlatforms(prefs.platforms);
+
+  return {
+    personalizationRange,
+    variantsPerGroup: clampVariantsPerGroup(prefs.variants_per_group),
+    adFormats,
+    colorMode,
+    customColor:
+      typeof prefs.custom_color === 'string' && prefs.custom_color.trim()
+        ? prefs.custom_color
+        : DEFAULT_FILTERS.customColor,
+    selectedPlatforms,
+    tone,
+    budgetTier,
+    ctaStyle,
+    language:
+      typeof prefs.language === 'string' && prefs.language.trim()
+        ? prefs.language
+        : DEFAULT_FILTERS.language,
+  };
+}
+
+/** Latest approved version's generation_preferences from campaign.brief JSON. */
+export function resolveLatestApprovedGenerationPreferences(
+  brief: string | null | undefined,
+): GenerationPreferences | null {
+  if (!brief?.trim()) return null;
+
+  let data: unknown;
+  try {
+    data = JSON.parse(brief);
+  } catch {
+    return null;
+  }
+
+  if (!data || typeof data !== 'object' || Array.isArray(data)) return null;
+
+  const versionNumbers = Object.keys(data as Record<string, unknown>)
+    .map((key) => parseInt(key, 10))
+    .filter((n) => Number.isFinite(n) && n > 0);
+
+  if (versionNumbers.length === 0) return null;
+
+  const latestVersion = Math.max(...versionNumbers);
+  const entry = (data as Record<string, unknown>)[String(latestVersion)];
+  if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return null;
+
+  const prefs = (entry as Record<string, unknown>).generation_preferences;
+  if (!prefs || typeof prefs !== 'object' || Array.isArray(prefs)) return null;
+
+  return prefs as GenerationPreferences;
+}
+
+export function cloneDefaultFilterState(): FilterState {
+  return {
+    ...DEFAULT_FILTERS,
+    adFormats: new Set(DEFAULT_FILTERS.adFormats),
+    selectedPlatforms: new Set(DEFAULT_FILTERS.selectedPlatforms),
+  };
+}
+
+export function preferencesSnapshotJson(state: FilterState): string {
+  return JSON.stringify(buildGenerationPreferencesSnapshot(state));
 }


### PR DESCRIPTION
## Changes
- Adds campaigns.draft_generation_preferences and an authenticated PATCH /campaigns/{id}/draft-generation-preferences endpoint so Ad Studio panel","panel state syncs across devices.
- Generate Ads hydrates prefs per campaign (server draft → latest approved brief snapshot → defaults) and autosaves edits after 500ms debounce; removed the Apply button.
- Plan approve still writes the frozen snapshot to brief[version].generation_preferences and keeps the draft column in sync.

## Testing
- User testing 