### PR TITLE
Post-process ad videos with Sync Labs lip sync

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -25,6 +25,16 @@ VIDEO_SECONDS=12
 AZURE_STORAGE_CONNECTION_STRING=YOUR_AZURE_STORAGE_CONNECTION_STRING
 AZURE_STORAGE_VIDEO_CONTAINER=ad-videos
 
+# Sync Labs lip sync (post-process after Sora/Veo when classifier sets lip_sync_risk)
+# SYNC_LIPSYNC_ENABLED=false
+# SYNC_API_KEY=YOUR_SYNC_API_KEY
+# SYNC_LIPSYNC_MODEL=sync-3
+# SYNC_LIPSYNC_SYNC_MODE=remap
+# SYNC_LIPSYNC_POLL_INTERVAL_SECONDS=5
+# SYNC_LIPSYNC_MAX_POLL_ATTEMPTS=120
+# Optional JSON object merged into Sync options, e.g. {"active_speaker_detection":{"auto_detect":true}}
+# SYNC_LIPSYNC_OPTIONS=
+
 # Resend (for email verification)
 RESEND_API_KEY=YOUR_RESEND_API_KEY
 RESEND_FROM_EMAIL=noreply@yourdomain.com

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && ACCEPT_EULA=Y apt-get install -y --no-install-recommends \
         msodbcsql18 \
         unixodbc-dev \
+        ffmpeg \
     && apt-get purge -y --auto-remove curl gnupg2 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/backend/README.md
+++ b/backend/README.md
@@ -29,6 +29,14 @@ All services run on **port 8000** with different route prefixes:
 
 Script creation is a pipeline step (no HTTP); use `workers.script_creation_worker.generate_script(data)` from code.
 
+## Sync Labs lip sync (optional)
+
+When `SYNC_LIPSYNC_ENABLED=true`, `SYNC_API_KEY` is set, and the video provider classifier marks `lip_sync_risk` on the variant meta, the ad job demuxes the Sora/Veo MP4 (requires **ffmpeg** on the host) and post-processes via [Sync Generate API](https://sync.so/docs/api-reference/api/generate-api/create) (`sync-3` by default). Sync failures fail the ad job (no raw-video fallback).
+
+Local ffmpeg: `brew install ffmpeg` (macOS) or `apt install ffmpeg` (Linux). Docker image includes ffmpeg.
+
+See `backend/.env.example` for `SYNC_*` variables and `exec-plans/2026-05-25-sync-labs-lipsync-pipeline.md`.
+
 ## Testing Hello Endpoints
 
 ```bash

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -18,6 +18,7 @@ scikit-learn>=1.4.0
 numpy>=1.26.0
 httpx>=0.28.1,<1.0.0
 cryptography>=42.0.0
+syncsdk==0.3.0
 
 # Test dependencies
 pytest>=9.0.0

--- a/backend/services/media/__init__.py
+++ b/backend/services/media/__init__.py
@@ -1,0 +1,1 @@
+"""Media processing helpers (ffmpeg, etc.)."""

--- a/backend/services/media/ffmpeg_split.py
+++ b/backend/services/media/ffmpeg_split.py
@@ -1,0 +1,93 @@
+"""Demux MP4 into silent video and WAV audio via ffmpeg."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+FFMPEG_SUBPROCESS_TIMEOUT_SECONDS = 120
+
+
+class FfmpegSplitError(RuntimeError):
+    """ffmpeg failed or is unavailable."""
+
+
+async def split_video_audio(mp4_bytes: bytes) -> tuple[bytes, bytes]:
+    """Return ``(video_mp4_no_audio, audio_wav)`` from a muxed MP4."""
+    if not mp4_bytes:
+        raise FfmpegSplitError("Empty MP4 input")
+
+    with tempfile.TemporaryDirectory(prefix="adgentic-ffmpeg-") as tmp:
+        tmp_path = Path(tmp)
+        input_path = tmp_path / "input.mp4"
+        video_path = tmp_path / "video_no_audio.mp4"
+        audio_path = tmp_path / "audio.wav"
+        input_path.write_bytes(mp4_bytes)
+
+        await _run_ffmpeg(
+            "-y",
+            "-i",
+            str(input_path),
+            "-an",
+            "-c:v",
+            "copy",
+            str(video_path),
+        )
+        await _run_ffmpeg(
+            "-y",
+            "-i",
+            str(input_path),
+            "-vn",
+            "-ac",
+            "1",
+            "-ar",
+            "44100",
+            "-c:a",
+            "pcm_s16le",
+            str(audio_path),
+        )
+
+        if not video_path.is_file() or video_path.stat().st_size == 0:
+            raise FfmpegSplitError("ffmpeg produced empty video output")
+        if not audio_path.is_file() or audio_path.stat().st_size == 0:
+            raise FfmpegSplitError(
+                "ffmpeg produced empty audio output (source may have no audio track)"
+            )
+
+        return video_path.read_bytes(), audio_path.read_bytes()
+
+
+async def _run_ffmpeg(*args: str) -> None:
+    ffmpeg_bin = os.getenv("FFMPEG_PATH", "ffmpeg").strip() or "ffmpeg"
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            ffmpeg_bin,
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except FileNotFoundError as exc:
+        raise FfmpegSplitError(
+            f"{ffmpeg_bin} not found; install ffmpeg or set FFMPEG_PATH"
+        ) from exc
+
+    try:
+        _stdout, stderr = await asyncio.wait_for(
+            proc.communicate(),
+            timeout=FFMPEG_SUBPROCESS_TIMEOUT_SECONDS,
+        )
+    except asyncio.TimeoutError as exc:
+        proc.kill()
+        raise FfmpegSplitError(
+            f"ffmpeg timed out after {FFMPEG_SUBPROCESS_TIMEOUT_SECONDS}s"
+        ) from exc
+
+    if proc.returncode != 0:
+        err_text = (stderr or b"").decode("utf-8", errors="replace")[-2000:]
+        logger.error("ffmpeg failed (rc=%s): %s", proc.returncode, err_text)
+        raise FfmpegSplitError(f"ffmpeg exited with code {proc.returncode}")

--- a/backend/services/storage/ad_video_media_url.py
+++ b/backend/services/storage/ad_video_media_url.py
@@ -16,6 +16,8 @@ _AZURE_PUBLIC_BLOB_SUFFIX = ".blob.core.windows.net"
 API_SAS_EXPIRY_HOURS = 1
 # Meta publish (download + multipart): allow slow networks / large files.
 PUBLISH_SAS_EXPIRY_HOURS = 24
+# Sync Labs fetches input blobs while generation is queued/processed.
+LIPSYNC_INPUT_SAS_EXPIRY_HOURS = 4
 
 
 def parse_storage_account_key(conn_str: str) -> tuple[str, str]:
@@ -88,6 +90,24 @@ def append_query(url: str, query_fragment: str) -> str:
 def _already_has_sas_signature(media_url: str) -> bool:
     q = urlsplit(media_url).query.lower()
     return "sig=" in q
+
+
+def signed_ad_video_blob_url(blob_name: str, *, expiry_hours: int = API_SAS_EXPIRY_HOURS) -> str:
+    """Return an https URL for a blob in ``ad-videos`` with read SAS (no existing query)."""
+    conn_str = os.getenv("AZURE_STORAGE_CONNECTION_STRING", "").strip()
+    if not conn_str:
+        raise ValueError("AZURE_STORAGE_CONNECTION_STRING is not configured")
+    account_name, account_key = parse_storage_account_key(conn_str)
+    sas_token = generate_blob_sas(
+        account_name=account_name,
+        container_name=VIDEO_CONTAINER_NAME,
+        blob_name=blob_name,
+        account_key=account_key,
+        permission=BlobSasPermissions(read=True),
+        expiry=datetime.now(timezone.utc) + timedelta(hours=expiry_hours),
+    )
+    base = f"https://{account_name}{_AZURE_PUBLIC_BLOB_SUFFIX}/{VIDEO_CONTAINER_NAME}/{blob_name}"
+    return append_query(base, sas_token)
 
 
 def signed_ad_video_media_url(

--- a/backend/services/sync_labs/__init__.py
+++ b/backend/services/sync_labs/__init__.py
@@ -1,0 +1,1 @@
+"""Sync Labs lip sync API integration."""

--- a/backend/services/sync_labs/client.py
+++ b/backend/services/sync_labs/client.py
@@ -1,0 +1,224 @@
+"""Sync Labs Generate API wrapper using official Python SDK (syncsdk)."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+from sync import AsyncSync
+from sync.common import Audio, GenerationOptions, Video
+from sync.core.api_error import ApiError
+
+from services.sync_labs.config import (
+    sync_api_key,
+    sync_base_url,
+    sync_lipsync_max_poll_attempts,
+    sync_lipsync_model,
+    sync_lipsync_poll_interval_seconds,
+    sync_lipsync_sync_mode,
+    sync_lipsync_extra_options,
+)
+
+logger = logging.getLogger(__name__)
+
+TERMINAL_STATUSES = frozenset({"COMPLETED", "FAILED", "REJECTED"})
+
+
+class SyncLabsError(RuntimeError):
+    """Sync API error."""
+
+
+class SyncLabsAuthError(SyncLabsError):
+    """Invalid or missing API key."""
+
+
+@dataclass(frozen=True)
+class SyncGeneration:
+    id: str
+    status: str
+    output_url: str | None
+    error: str | None
+    error_code: str | None
+
+
+def _sdk_client(*, httpx_client: httpx.AsyncClient | None = None) -> AsyncSync:
+    api_key = sync_api_key()
+    if not api_key:
+        raise SyncLabsAuthError("SYNC_API_KEY is not configured")
+    return AsyncSync(
+        api_key=api_key,
+        base_url=sync_base_url(),
+        httpx_client=httpx_client,
+    )
+
+
+def _parse_sdk_generation(gen: Any) -> SyncGeneration:
+    gen_id = getattr(gen, "id", None)
+    status = getattr(gen, "status", None)
+    if not isinstance(gen_id, str) or not gen_id.strip():
+        raise SyncLabsError("Sync SDK returned generation with missing id")
+    if status is None:
+        raise SyncLabsError("Sync SDK returned generation with missing status")
+
+    status_str = str(status)
+    output_url = getattr(gen, "output_url", None)
+    if output_url is not None and not isinstance(output_url, str):
+        output_url = str(output_url)
+    error = getattr(gen, "error", None)
+    if error is not None and not isinstance(error, str):
+        error = str(error)
+    error_code = getattr(gen, "error_code", None)
+    if error_code is not None and not isinstance(error_code, str):
+        error_code = str(error_code)
+
+    return SyncGeneration(
+        id=gen_id.strip(),
+        status=status_str,
+        output_url=output_url,
+        error=error,
+        error_code=error_code,
+    )
+
+
+async def create_lipsync_generation(
+    *,
+    video_url: str,
+    audio_url: str,
+    model: str | None = None,
+    sync_mode: str | None = None,
+    extra_options: dict[str, Any] | None = None,
+    httpx_client: httpx.AsyncClient | None = None,
+    sync_client: Any | None = None,
+) -> str:
+    """Create a generation; returns generation id."""
+    model_name = model or sync_lipsync_model()
+    mode = sync_mode or sync_lipsync_sync_mode()
+    options_dict: dict[str, Any] = {"sync_mode": mode}
+    options_dict.update(sync_lipsync_extra_options())
+    if extra_options:
+        options_dict.update(extra_options)
+
+    owns_httpx = httpx_client is None
+    if owns_httpx:
+        httpx_client = httpx.AsyncClient(timeout=httpx.Timeout(60.0, connect=30.0))
+    owns_sync = sync_client is None
+    if owns_sync:
+        sync_client = _sdk_client(httpx_client=httpx_client)
+
+    try:
+        opts = GenerationOptions(**options_dict)
+        gen = await sync_client.generations.create(
+            model=model_name,
+            input=[Video(url=video_url), Audio(url=audio_url)],
+            options=opts,
+        )
+    except ApiError as exc:
+        msg = getattr(exc, "body", None) or str(exc)
+        raise SyncLabsError(f"Sync create generation failed: {msg}") from exc
+    finally:
+        if owns_httpx and httpx_client is not None:
+            await httpx_client.aclose()
+
+    generation = _parse_sdk_generation(gen)
+    logger.info("Sync generation created: id=%s status=%s", generation.id, generation.status)
+    return generation.id
+
+
+async def get_generation(
+    generation_id: str,
+    *,
+    httpx_client: httpx.AsyncClient | None = None,
+    sync_client: Any | None = None,
+) -> SyncGeneration:
+    owns_httpx = httpx_client is None
+    if owns_httpx:
+        httpx_client = httpx.AsyncClient(timeout=httpx.Timeout(60.0, connect=30.0))
+    owns_sync = sync_client is None
+    if owns_sync:
+        sync_client = _sdk_client(httpx_client=httpx_client)
+
+    try:
+        gen = await sync_client.generations.get(generation_id)
+        return _parse_sdk_generation(gen)
+    except ApiError as exc:
+        msg = getattr(exc, "body", None) or str(exc)
+        raise SyncLabsError(f"Sync get generation failed: {msg}") from exc
+    finally:
+        if owns_httpx and httpx_client is not None:
+            await httpx_client.aclose()
+
+
+async def wait_for_generation(
+    generation_id: str,
+    *,
+    httpx_client: httpx.AsyncClient | None = None,
+    sync_client: Any | None = None,
+) -> str:
+    """Poll until COMPLETED; return ``outputUrl``. Raises on failure/timeout."""
+    owns_httpx = httpx_client is None
+    if owns_httpx:
+        httpx_client = httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=30.0))
+    owns_sync = sync_client is None
+    if owns_sync:
+        sync_client = _sdk_client(httpx_client=httpx_client)
+
+    try:
+        interval = sync_lipsync_poll_interval_seconds()
+        max_attempts = sync_lipsync_max_poll_attempts()
+        for attempt in range(1, max_attempts + 1):
+            generation = await get_generation(
+                generation_id,
+                httpx_client=httpx_client,
+                sync_client=sync_client,
+            )
+            logger.info(
+                "Sync generation poll %s/%s: id=%s status=%s",
+                attempt,
+                max_attempts,
+                generation.id,
+                generation.status,
+            )
+            if generation.status == "COMPLETED":
+                if not generation.output_url:
+                    raise SyncLabsError(
+                        f"Sync generation {generation_id} completed without outputUrl"
+                    )
+                return generation.output_url
+            if generation.status in ("FAILED", "REJECTED"):
+                detail = generation.error or generation.error_code or generation.status
+                raise SyncLabsError(f"Sync generation {generation_id} failed: {detail}")
+            if generation.status not in TERMINAL_STATUSES:
+                await asyncio.sleep(interval)
+                continue
+            raise SyncLabsError(
+                f"Sync generation {generation_id} ended with unexpected status {generation.status!r}"
+            )
+        raise SyncLabsError(
+            f"Sync generation {generation_id} did not complete within "
+            f"{max_attempts * interval}s"
+        )
+    finally:
+        if owns_httpx and httpx_client is not None:
+            await httpx_client.aclose()
+
+
+async def download_output_url(output_url: str, *, client: httpx.AsyncClient | None = None) -> bytes:
+    owns_client = client is None
+    if owns_client:
+        client = httpx.AsyncClient(
+            timeout=httpx.Timeout(300.0, connect=30.0),
+            follow_redirects=True,
+        )
+    try:
+        response = await client.get(output_url)
+        if response.status_code >= 400:
+            raise SyncLabsError(
+                f"Sync output download failed ({response.status_code}): {output_url[:120]}"
+            )
+        return response.content
+    finally:
+        if owns_client:
+            await client.aclose()

--- a/backend/services/sync_labs/config.py
+++ b/backend/services/sync_labs/config.py
@@ -1,0 +1,95 @@
+"""Environment configuration for Sync Labs lip sync."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SYNC_BASE_URL = "https://api.sync.so"
+DEFAULT_SYNC_MODEL = "sync-3"
+DEFAULT_SYNC_MODE = "remap"
+DEFAULT_POLL_INTERVAL_SECONDS = 5
+DEFAULT_MAX_POLL_ATTEMPTS = 120
+
+
+def _env_truthy(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def sync_lipsync_enabled() -> bool:
+    return _env_truthy("SYNC_LIPSYNC_ENABLED")
+
+
+def sync_api_key() -> str:
+    return os.getenv("SYNC_API_KEY", "").strip()
+
+
+def sync_base_url() -> str:
+    return os.getenv("SYNC_API_BASE_URL", DEFAULT_SYNC_BASE_URL).strip().rstrip("/")
+
+
+def sync_lipsync_model() -> str:
+    return os.getenv("SYNC_LIPSYNC_MODEL", DEFAULT_SYNC_MODEL).strip() or DEFAULT_SYNC_MODEL
+
+
+def sync_lipsync_sync_mode() -> str:
+    return os.getenv("SYNC_LIPSYNC_SYNC_MODE", DEFAULT_SYNC_MODE).strip() or DEFAULT_SYNC_MODE
+
+
+def sync_lipsync_poll_interval_seconds() -> int:
+    raw = os.getenv("SYNC_LIPSYNC_POLL_INTERVAL_SECONDS", str(DEFAULT_POLL_INTERVAL_SECONDS)).strip()
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return DEFAULT_POLL_INTERVAL_SECONDS
+
+
+def sync_lipsync_max_poll_attempts() -> int:
+    raw = os.getenv("SYNC_LIPSYNC_MAX_POLL_ATTEMPTS", str(DEFAULT_MAX_POLL_ATTEMPTS)).strip()
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return DEFAULT_MAX_POLL_ATTEMPTS
+
+
+def sync_lipsync_extra_options() -> dict[str, Any]:
+    raw = os.getenv("SYNC_LIPSYNC_OPTIONS", "").strip()
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        logger.warning("SYNC_LIPSYNC_OPTIONS is not valid JSON: %s", exc)
+        return {}
+    if not isinstance(parsed, dict):
+        logger.warning("SYNC_LIPSYNC_OPTIONS must be a JSON object")
+        return {}
+    return parsed
+
+
+def sync_lipsync_env_skip_reason() -> str | None:
+    """Env/config reason Sync cannot run, or ``None`` if env gates pass."""
+    if not sync_lipsync_enabled():
+        return "SYNC_LIPSYNC_ENABLED is off"
+    if not sync_api_key():
+        return "SYNC_API_KEY is missing"
+    return None
+
+
+def should_run_sync_lipsync(meta: dict[str, Any] | None = None) -> bool:
+    """True when Sync lipsync is enabled, configured, and ``meta.lip_sync_risk`` is true."""
+    return sync_lipsync_skip_reason(meta) is None
+
+
+def sync_lipsync_skip_reason(meta: dict[str, Any] | None = None) -> str | None:
+    """Human-readable reason Sync lipsync will not run, or ``None`` if it will."""
+    env_reason = sync_lipsync_env_skip_reason()
+    if env_reason:
+        return env_reason
+    if not meta or not meta.get("lip_sync_risk"):
+        return "lip_sync_risk is false or absent on variant meta"
+    return None

--- a/backend/services/sync_labs/lipsync_pipeline.py
+++ b/backend/services/sync_labs/lipsync_pipeline.py
@@ -1,0 +1,122 @@
+"""Orchestrate demux → Azure temp URLs → Sync → download."""
+
+from __future__ import annotations
+
+import logging
+import os
+import uuid
+from typing import Any
+
+import httpx
+from azure.storage.blob import BlobClient, ContentSettings
+
+from services.media.ffmpeg_split import FfmpegSplitError, split_video_audio
+from services.storage.ad_video_media_url import (
+    LIPSYNC_INPUT_SAS_EXPIRY_HOURS,
+    VIDEO_CONTAINER_NAME,
+    signed_ad_video_blob_url,
+)
+from services.sync_labs.client import (
+    SyncLabsError,
+    create_lipsync_generation,
+    download_output_url,
+    wait_for_generation,
+)
+from services.sync_labs.config import sync_lipsync_model, sync_lipsync_sync_mode
+
+logger = logging.getLogger(__name__)
+
+
+def _storage_conn_str() -> str:
+    conn = os.getenv("AZURE_STORAGE_CONNECTION_STRING", "").strip()
+    if not conn:
+        raise SyncLabsError("AZURE_STORAGE_CONNECTION_STRING is not configured")
+    return conn
+
+
+def _upload_temp_blob(blob_name: str, data: bytes, content_type: str) -> None:
+    client = BlobClient.from_connection_string(
+        conn_str=_storage_conn_str(),
+        container_name=VIDEO_CONTAINER_NAME,
+        blob_name=blob_name,
+    )
+    client.upload_blob(
+        data,
+        overwrite=True,
+        content_settings=ContentSettings(content_type=content_type),
+        max_concurrency=4,
+    )
+
+
+def _delete_temp_blob(blob_name: str) -> None:
+    try:
+        client = BlobClient.from_connection_string(
+            conn_str=_storage_conn_str(),
+            container_name=VIDEO_CONTAINER_NAME,
+            blob_name=blob_name,
+        )
+        client.delete_blob()
+    except Exception:
+        logger.warning("Failed to delete temp blob %s", blob_name, exc_info=True)
+
+
+async def lipsync_ad_video(muxed_mp4: bytes, *, variant_id: int) -> tuple[bytes, dict[str, Any]]:
+    """Demux, call Sync ``sync-3``, return lip-synced MP4 bytes and meta fragment."""
+    run_id = uuid.uuid4().hex
+    prefix = f"lipsync-temp/{variant_id}/{run_id}"
+    video_blob = f"{prefix}/video.mp4"
+    audio_blob = f"{prefix}/audio.wav"
+    model = sync_lipsync_model()
+    sync_mode = sync_lipsync_sync_mode()
+
+    try:
+        try:
+            video_bytes, audio_bytes = await split_video_audio(muxed_mp4)
+        except FfmpegSplitError as exc:
+            raise SyncLabsError(str(exc)) from exc
+
+        _upload_temp_blob(video_blob, video_bytes, "video/mp4")
+        _upload_temp_blob(audio_blob, audio_bytes, "audio/wav")
+
+        video_url = signed_ad_video_blob_url(
+            video_blob, expiry_hours=LIPSYNC_INPUT_SAS_EXPIRY_HOURS
+        )
+        audio_url = signed_ad_video_blob_url(
+            audio_blob, expiry_hours=LIPSYNC_INPUT_SAS_EXPIRY_HOURS
+        )
+
+        generation_id: str | None = None
+        # One shared httpx client: used by Sync SDK (passed through) and for outputUrl download.
+        async with httpx.AsyncClient(
+            timeout=httpx.Timeout(300.0, connect=30.0),
+            follow_redirects=True,
+        ) as httpx_client:
+            generation_id = await create_lipsync_generation(
+                video_url=video_url,
+                audio_url=audio_url,
+                model=model,
+                sync_mode=sync_mode,
+                httpx_client=httpx_client,
+            )
+            output_url = await wait_for_generation(
+                generation_id,
+                httpx_client=httpx_client,
+            )
+            output_bytes = await download_output_url(output_url, client=httpx_client)
+
+        meta = {
+            "applied": True,
+            "model": model,
+            "sync_generation_id": generation_id,
+            "sync_mode": sync_mode,
+        }
+        logger.info(
+            "Sync lipsync completed variant_id=%s generation_id=%s bytes=%s",
+            variant_id,
+            generation_id,
+            len(output_bytes),
+        )
+        return output_bytes, meta
+    finally:
+        _delete_temp_blob(video_blob)
+        _delete_temp_blob(audio_blob)

--- a/backend/tests/test_ad_job_worker.py
+++ b/backend/tests/test_ad_job_worker.py
@@ -27,12 +27,29 @@ from workers.ad_job_worker.worker import (
     generate_campaign_ad_variants,
 )
 from workers.script_moderation_worker.worker import ModerationVerdict
+from workers.ad_video_generation_worker.provider_selection import (
+    ProviderDecision,
+    _empty_features,
+)
 
 _PASS_MODERATION = ModerationVerdict(passed=True, feedback="")
 
 
+def _provider_decision(*, lip_sync_risk: bool = False) -> ProviderDecision:
+    features = _empty_features()
+    features["lip_sync_risk"] = lip_sync_risk
+    return ProviderDecision(
+        provider="sora",
+        confidence=1.0,
+        reason="test",
+        primary_failure_mode="low_risk",
+        features=features,
+        fallback_used=False,
+    )
+
+
 @contextmanager
-def _mock_script_video_routing():
+def _mock_script_video_routing(*, lip_sync_risk: bool = False):
     """Isolate ad-job tests from Grok classifier and VIDEO_* env requirements."""
 
     async def _align(script: str, provider: str, **_: object):
@@ -42,7 +59,7 @@ def _mock_script_video_routing():
         patch(
             "workers.ad_job_worker.worker.resolve_video_provider_for_script",
             new_callable=AsyncMock,
-            return_value="sora",
+            return_value=("sora", _provider_decision(lip_sync_risk=lip_sync_risk)),
         ),
         patch(
             "workers.ad_job_worker.worker.align_script_with_video_provider",
@@ -227,9 +244,117 @@ async def test_execute_ad_job_returns_ad_variant_id(
 
     assert result == 42
     mock_db.close.assert_called_once()
-    # Script and video helpers should have been called
-    from workers.ad_job_worker.worker import generate_ad_script, generate_ad_video_for_script
-    # (patched, so we just check they were invoked via the fact that result is 42 and no exception)
+
+
+@pytest.mark.asyncio
+async def test_execute_ad_job_runs_lipsync_when_sync_enabled(
+    mock_db,
+    mock_session_factory,
+    mock_ad_variant,
+    mock_campaign,
+    mock_consumer,
+    mock_product,
+    mock_blob_client,
+    monkeypatch,
+):
+    """When Sync is enabled and lip_sync_risk is true, lipsync runs before final upload."""
+    monkeypatch.setenv("SYNC_LIPSYNC_ENABLED", "true")
+    monkeypatch.setenv("SYNC_API_KEY", "test-key")
+    mock_lipsync = AsyncMock(
+        return_value=(b"synced video", {"applied": True, "model": "sync-3", "sync_generation_id": "g1"})
+    )
+    with (
+        _mock_script_video_routing(lip_sync_risk=True),
+        patch("workers.ad_job_worker.worker._get_session_factory", return_value=mock_session_factory),
+        patch("workers.ad_job_worker.worker.create_ad_variant", return_value=mock_ad_variant),
+        patch("workers.ad_job_worker.worker.update_ad_variant"),
+        patch("workers.ad_job_worker.worker.get_campaign", return_value=mock_campaign),
+        patch("workers.ad_job_worker.worker.get_consumer", return_value=mock_consumer),
+        patch("workers.ad_job_worker.worker.get_product", return_value=mock_product),
+        patch("workers.ad_job_worker.worker.BlobClient") as blob_cls,
+        patch("workers.ad_job_worker.worker.evaluate_script", new_callable=AsyncMock, return_value=_PASS_MODERATION),
+        patch("workers.ad_job_worker.worker.generate_ad_script", new_callable=AsyncMock, return_value="Mock script"),
+        patch("workers.ad_job_worker.worker.generate_ad_video_for_script", new_callable=AsyncMock, return_value=b"raw video"),
+        patch("workers.ad_job_worker.worker.lipsync_ad_video", mock_lipsync),
+    ):
+        blob_cls.from_connection_string.return_value = mock_blob_client
+        result = await execute_ad_job(campaign_id=1, product_id=1, consumer_id=1, version_number=1)
+
+    assert result == 42
+    mock_lipsync.assert_awaited_once()
+    upload_call = mock_blob_client.upload_blob.call_args
+    assert upload_call[0][0] == b"synced video"
+
+
+@pytest.mark.asyncio
+async def test_execute_ad_job_skips_lipsync_when_sync_disabled(
+    mock_db,
+    mock_session_factory,
+    mock_ad_variant,
+    mock_campaign,
+    mock_consumer,
+    mock_product,
+    mock_blob_client,
+    monkeypatch,
+):
+    monkeypatch.setenv("SYNC_LIPSYNC_ENABLED", "false")
+    monkeypatch.setenv("SYNC_API_KEY", "test-key")
+    mock_lipsync = AsyncMock()
+    with (
+        _mock_script_video_routing(lip_sync_risk=True),
+        patch("workers.ad_job_worker.worker._get_session_factory", return_value=mock_session_factory),
+        patch("workers.ad_job_worker.worker.create_ad_variant", return_value=mock_ad_variant),
+        patch("workers.ad_job_worker.worker.update_ad_variant"),
+        patch("workers.ad_job_worker.worker.get_campaign", return_value=mock_campaign),
+        patch("workers.ad_job_worker.worker.get_consumer", return_value=mock_consumer),
+        patch("workers.ad_job_worker.worker.get_product", return_value=mock_product),
+        patch("workers.ad_job_worker.worker.BlobClient") as blob_cls,
+        patch("workers.ad_job_worker.worker.evaluate_script", new_callable=AsyncMock, return_value=_PASS_MODERATION),
+        patch("workers.ad_job_worker.worker.generate_ad_script", new_callable=AsyncMock, return_value="Mock script"),
+        patch("workers.ad_job_worker.worker.generate_ad_video_for_script", new_callable=AsyncMock, return_value=b"raw video"),
+        patch("workers.ad_job_worker.worker.lipsync_ad_video", mock_lipsync),
+    ):
+        blob_cls.from_connection_string.return_value = mock_blob_client
+        await execute_ad_job(campaign_id=1, product_id=1, consumer_id=1, version_number=1)
+
+    mock_lipsync.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_execute_ad_job_skips_lipsync_when_no_lip_sync_risk(
+    mock_db,
+    mock_session_factory,
+    mock_ad_variant,
+    mock_campaign,
+    mock_consumer,
+    mock_product,
+    mock_blob_client,
+    monkeypatch,
+):
+    """Sync enabled but lip_sync_risk false: upload raw provider MP4."""
+    monkeypatch.setenv("SYNC_LIPSYNC_ENABLED", "true")
+    monkeypatch.setenv("SYNC_API_KEY", "test-key")
+    mock_lipsync = AsyncMock()
+    with (
+        _mock_script_video_routing(lip_sync_risk=False),
+        patch("workers.ad_job_worker.worker._get_session_factory", return_value=mock_session_factory),
+        patch("workers.ad_job_worker.worker.create_ad_variant", return_value=mock_ad_variant),
+        patch("workers.ad_job_worker.worker.update_ad_variant"),
+        patch("workers.ad_job_worker.worker.get_campaign", return_value=mock_campaign),
+        patch("workers.ad_job_worker.worker.get_consumer", return_value=mock_consumer),
+        patch("workers.ad_job_worker.worker.get_product", return_value=mock_product),
+        patch("workers.ad_job_worker.worker.BlobClient") as blob_cls,
+        patch("workers.ad_job_worker.worker.evaluate_script", new_callable=AsyncMock, return_value=_PASS_MODERATION),
+        patch("workers.ad_job_worker.worker.generate_ad_script", new_callable=AsyncMock, return_value="Mock script"),
+        patch("workers.ad_job_worker.worker.generate_ad_video_for_script", new_callable=AsyncMock, return_value=b"raw video"),
+        patch("workers.ad_job_worker.worker.lipsync_ad_video", mock_lipsync),
+    ):
+        blob_cls.from_connection_string.return_value = mock_blob_client
+        await execute_ad_job(campaign_id=1, product_id=1, consumer_id=1, version_number=1)
+
+    mock_lipsync.assert_not_awaited()
+    upload_call = mock_blob_client.upload_blob.call_args
+    assert upload_call[0][0] == b"raw video"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_ffmpeg_split.py
+++ b/backend/tests/test_ffmpeg_split.py
@@ -1,0 +1,39 @@
+"""Tests for ffmpeg demux helper."""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+_backend_dir = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_backend_dir))
+
+from services.media.ffmpeg_split import FfmpegSplitError, split_video_audio
+
+
+@pytest.mark.asyncio
+async def test_split_video_audio_empty_input():
+    with pytest.raises(FfmpegSplitError, match="Empty"):
+        await split_video_audio(b"")
+
+
+@pytest.mark.asyncio
+async def test_split_video_audio_success():
+    with patch(
+        "services.media.ffmpeg_split._run_ffmpeg",
+        new_callable=AsyncMock,
+    ) as mock_run:
+
+        async def write_outputs(*args: str) -> None:
+            out = args[-1]
+            if out.endswith("video_no_audio.mp4"):
+                Path(out).write_bytes(b"video-bytes")
+            elif out.endswith("audio.wav"):
+                Path(out).write_bytes(b"audio-bytes")
+
+        mock_run.side_effect = write_outputs
+        video, audio = await split_video_audio(b"fake-muxed")
+    assert video == b"video-bytes"
+    assert audio == b"audio-bytes"
+    assert mock_run.await_count == 2

--- a/backend/tests/test_script_creation_worker.py
+++ b/backend/tests/test_script_creation_worker.py
@@ -137,6 +137,20 @@ class TestBuildScriptPrompt:
         assert "#FF00AA" in out
         assert "Brief here." in out
 
+    def test_ai_video_first_guidance_without_lip_sync_model_framing(self):
+        out = _build_script_prompt(
+            product_name="X",
+            product_description="Y",
+            consumer_profile_text="Z",
+            campaign_brief="",
+        )
+        assert "Shot design for I2V" in out
+        assert "product-in-hand" in out
+        assert "Voiceover plus visual story" in out
+        assert "Do not constrain shots for lip-sync quality" in out
+        assert "lip-sync models" not in out.lower()
+        assert "fairly frontal" not in out
+
     def test_includes_time_bucketed_beats(self):
         out = _build_script_prompt(
             product_name="X",

--- a/backend/tests/test_signed_ad_video_blob_url.py
+++ b/backend/tests/test_signed_ad_video_blob_url.py
@@ -1,0 +1,21 @@
+"""Tests for signed_ad_video_blob_url helper."""
+
+import sys
+from pathlib import Path
+
+_backend_dir = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_backend_dir))
+
+from services.storage.ad_video_media_url import signed_ad_video_blob_url
+
+
+def test_signed_ad_video_blob_url_includes_sig(monkeypatch):
+    monkeypatch.setenv(
+        "AZURE_STORAGE_CONNECTION_STRING",
+        "DefaultEndpointsProtocol=https;AccountName=testacct;AccountKey="
+        "dGVzdGtleXRlc3RrZXl0ZXN0a2V5dGVzdGtleTE=;EndpointSuffix=core.windows.net",
+    )
+    url = signed_ad_video_blob_url("lipsync-temp/1/run/video.mp4", expiry_hours=4)
+    assert "testacct.blob.core.windows.net" in url
+    assert "/ad-videos/lipsync-temp/1/run/video.mp4" in url
+    assert "sig=" in url

--- a/backend/tests/test_sync_labs_client.py
+++ b/backend/tests/test_sync_labs_client.py
@@ -1,0 +1,95 @@
+"""Tests for Sync Labs client wrapper (mocked Sync SDK)."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_backend_dir = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_backend_dir))
+
+from services.sync_labs.client import (
+    SyncLabsError,
+    create_lipsync_generation,
+    wait_for_generation,
+)
+
+
+@pytest.fixture
+def sync_env(monkeypatch):
+    monkeypatch.setenv("SYNC_API_KEY", "test-sync-key")
+    monkeypatch.setenv("SYNC_API_BASE_URL", "https://api.sync.so")
+
+
+@pytest.mark.asyncio
+async def test_create_lipsync_generation_returns_id(sync_env):
+    class _Gen:
+        id = "gen-1"
+        status = "PENDING"
+        output_url = None
+        error = None
+        error_code = None
+
+    class _Generations:
+        async def create(self, *, model, input, options):  # noqa: A002
+            assert model == "sync-3"
+            assert len(input) == 2
+            return _Gen()
+
+    class _Client:
+        generations = _Generations()
+
+    gen_id = await create_lipsync_generation(
+        video_url="https://example.com/v.mp4",
+        audio_url="https://example.com/a.wav",
+        sync_client=_Client(),
+    )
+    assert gen_id == "gen-1"
+
+
+@pytest.mark.asyncio
+async def test_wait_for_generation_completed(sync_env, monkeypatch):
+    monkeypatch.setenv("SYNC_LIPSYNC_POLL_INTERVAL_SECONDS", "0")
+    monkeypatch.setenv("SYNC_LIPSYNC_MAX_POLL_ATTEMPTS", "5")
+    calls = {"n": 0}
+
+    class _Gen:
+        def __init__(self, *, status: str, output_url: str | None = None, error: str | None = None):
+            self.id = "gen-1"
+            self.status = status
+            self.output_url = output_url
+            self.error = error
+            self.error_code = None
+
+    class _Generations:
+        async def get(self, _id: str):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return _Gen(status="PROCESSING")
+            return _Gen(status="COMPLETED", output_url="https://cdn.example.com/out.mp4")
+
+    class _Client:
+        generations = _Generations()
+
+    url = await wait_for_generation("gen-1", sync_client=_Client())
+    assert url == "https://cdn.example.com/out.mp4"
+
+
+@pytest.mark.asyncio
+async def test_get_generation_failed_raises(sync_env):
+    class _Gen:
+        id = "gen-1"
+        status = "FAILED"
+        output_url = None
+        error = "bad input"
+        error_code = None
+
+    class _Generations:
+        async def get(self, _id: str):
+            return _Gen()
+
+    class _Client:
+        generations = _Generations()
+
+    with pytest.raises(SyncLabsError, match="failed"):
+        await wait_for_generation("gen-1", sync_client=_Client())

--- a/backend/tests/test_sync_labs_config.py
+++ b/backend/tests/test_sync_labs_config.py
@@ -1,0 +1,35 @@
+"""Tests for Sync Labs gating and config."""
+
+import sys
+from pathlib import Path
+
+_backend_dir = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_backend_dir))
+
+from services.sync_labs.config import should_run_sync_lipsync
+
+
+class TestShouldRunSyncLipsync:
+    def test_false_when_disabled(self, monkeypatch):
+        monkeypatch.setenv("SYNC_LIPSYNC_ENABLED", "false")
+        monkeypatch.setenv("SYNC_API_KEY", "key")
+        assert should_run_sync_lipsync() is False
+        assert should_run_sync_lipsync({"lip_sync_risk": True}) is False
+
+    def test_false_without_api_key(self, monkeypatch):
+        monkeypatch.setenv("SYNC_LIPSYNC_ENABLED", "true")
+        monkeypatch.delenv("SYNC_API_KEY", raising=False)
+        assert should_run_sync_lipsync() is False
+        assert should_run_sync_lipsync({"lip_sync_risk": True}) is False
+
+    def test_false_without_lip_sync_risk(self, monkeypatch):
+        monkeypatch.setenv("SYNC_LIPSYNC_ENABLED", "true")
+        monkeypatch.setenv("SYNC_API_KEY", "test-key")
+        assert should_run_sync_lipsync() is False
+        assert should_run_sync_lipsync({}) is False
+        assert should_run_sync_lipsync({"lip_sync_risk": False}) is False
+
+    def test_true_when_enabled_and_lip_sync_risk(self, monkeypatch):
+        monkeypatch.setenv("SYNC_LIPSYNC_ENABLED", "true")
+        monkeypatch.setenv("SYNC_API_KEY", "test-key")
+        assert should_run_sync_lipsync({"lip_sync_risk": True}) is True

--- a/backend/tests/test_video_provider_config.py
+++ b/backend/tests/test_video_provider_config.py
@@ -48,10 +48,26 @@ def test_choose_video_provider_skips_grok_when_veo_disabled():
     )
 
     with patch.dict("os.environ", {"VEO_GENERATION_ENABLED": "false"}, clear=False):
-        decision = choose_video_provider_with_reason(
-            "Founder on camera: Hi, I'm the CEO and this product changed my life."
-        )
+        grok = type(
+            "_Grok",
+            (),
+            {
+                "provider": "veo",
+                "confidence": 0.91,
+                "reason": "mocked",
+                "primary_failure_mode": "bad_lipsync",
+                "features": {"lip_sync_risk": True},
+            },
+        )()
+
+        with patch(
+            "workers.ad_video_generation_worker.provider_selection._classify_script_with_grok",
+            return_value=grok,
+        ):
+            decision = choose_video_provider_with_reason(
+                "Founder on camera: Hi, I'm the CEO and this product changed my life."
+            )
 
     assert decision.provider == "sora"
-    assert "VEO_GENERATION_ENABLED" in decision.reason
+    assert "Veo generation disabled" in decision.reason
     assert decision.fallback_used is False

--- a/backend/workers/ad_job_worker/script_video.py
+++ b/backend/workers/ad_job_worker/script_video.py
@@ -8,7 +8,10 @@ from typing import TYPE_CHECKING
 
 from utils.video_provider_config import veo_configured
 from utils.video_timing import VEO_DURATION_SECONDS, allowed_video_seconds
-from workers.ad_video_generation_worker.provider_selection import choose_video_provider_with_reason
+from workers.ad_video_generation_worker.provider_selection import (
+    ProviderDecision,
+    choose_video_provider_with_reason,
+)
 from workers.ad_video_generation_worker.worker import VideoProvider, resolve_video_provider
 from workers.script_creation_worker.worker import generate_ad_script, retime_ad_script_for_veo
 from workers.script_moderation_worker.worker import evaluate_script
@@ -53,11 +56,13 @@ async def _moderate_script_with_optional_revision(
     )
 
 
-async def resolve_video_provider_for_script(script: str) -> VideoProvider:
+async def resolve_video_provider_for_script(script: str) -> tuple[VideoProvider, ProviderDecision]:
     decision = await asyncio.to_thread(choose_video_provider_with_reason, script)
     if decision.fallback_used:
-        return resolve_video_provider(script, preferred="sora")
-    return resolve_video_provider(script, preferred=decision.provider)
+        provider = resolve_video_provider(script, preferred="sora")
+    else:
+        provider = resolve_video_provider(script, preferred=decision.provider)
+    return provider, decision
 
 
 async def align_script_with_video_provider(

--- a/backend/workers/ad_job_worker/worker.py
+++ b/backend/workers/ad_job_worker/worker.py
@@ -41,6 +41,12 @@ from workers.ad_job_worker.script_video import (
 from workers.script_creation_worker.worker import generate_ad_script
 from workers.ad_video_generation_worker.worker import generate_ad_video_for_script
 from workers.script_moderation_worker.worker import evaluate_script
+from services.sync_labs.config import (
+    should_run_sync_lipsync,
+    sync_lipsync_env_skip_reason,
+    sync_lipsync_skip_reason,
+)
+from services.sync_labs.lipsync_pipeline import lipsync_ad_video
 from azure.core.exceptions import ResourceNotFoundError
 from azure.storage.blob import BlobClient, ContentSettings
 
@@ -170,8 +176,8 @@ async def execute_ad_job(campaign_id: int, product_id: int, consumer_id: int, ve
                 generation_preferences=generation_preferences,
                 moderation_feedback=verdict.feedback,
             )
-        provider = await resolve_video_provider_for_script(script)
-        script, provider, clip_seconds = await align_script_with_video_provider(
+        provider, provider_decision = await resolve_video_provider_for_script(script)
+        aligned_script, provider, clip_seconds = await align_script_with_video_provider(
             script,
             provider,
             product_name=product_name,
@@ -185,23 +191,26 @@ async def execute_ad_job(campaign_id: int, product_id: int, consumer_id: int, ve
             campaign_product_context=campaign.product_context or "",
             generation_preferences=generation_preferences,
         )
+        if aligned_script != script:
+            _, provider_decision = await resolve_video_provider_for_script(aligned_script)
+        script = aligned_script
+        variant_meta: dict = {
+            "script": script,
+            "video_provider": provider,
+            "clip_seconds": clip_seconds,
+            "lip_sync_risk": bool(provider_decision.features.get("lip_sync_risk")),
+            "primary_failure_mode": provider_decision.primary_failure_mode,
+        }
         update_ad_variant(
             db,
             ad_variant_id,
-            AdVariantUpdate(
-                meta=json.dumps(
-                    {
-                        "script": script,
-                        "video_provider": provider,
-                        "clip_seconds": clip_seconds,
-                    }
-                )
-            ),
+            AdVariantUpdate(meta=json.dumps(variant_meta)),
         )
         logger.info(
-            "Finished generating ad script (provider=%s, clip_seconds=%s)",
+            "Finished generating ad script (provider=%s, clip_seconds=%s, lip_sync_risk=%s)",
             provider,
             clip_seconds,
+            variant_meta["lip_sync_risk"],
         )
 
         logger.info("Generating ad video")
@@ -213,6 +222,28 @@ async def execute_ad_job(campaign_id: int, product_id: int, consumer_id: int, ve
             provider=provider,
         )
         logger.info("Finished generating ad video")
+        if should_run_sync_lipsync(variant_meta):
+            logger.info("Running Sync Labs lip sync")
+            ad_video_bytes, lipsync_meta = await lipsync_ad_video(
+                ad_video_bytes, variant_id=ad_variant_id
+            )
+            variant_meta["lipsync"] = lipsync_meta
+            update_ad_variant(
+                db,
+                ad_variant_id,
+                AdVariantUpdate(meta=json.dumps(variant_meta)),
+            )
+            logger.info("Finished Sync Labs lip sync")
+        else:
+            skip = sync_lipsync_skip_reason(variant_meta)
+            if skip:
+                logger.info("Skipping Sync Labs lip sync: %s", skip)
+            env_skip = sync_lipsync_env_skip_reason()
+            if variant_meta.get("lip_sync_risk") and env_skip:
+                logger.warning(
+                    "lip_sync_risk is true but Sync lipsync will not run: %s",
+                    env_skip,
+                )
         blob_client = BlobClient.from_connection_string(
             conn_str=os.getenv("AZURE_STORAGE_CONNECTION_STRING", "").strip(),
             container_name="ad-videos",

--- a/backend/workers/ad_video_generation_worker/provider_selection.py
+++ b/backend/workers/ad_video_generation_worker/provider_selection.py
@@ -308,17 +308,11 @@ def _classifier_failure_decision(reason: str) -> ProviderDecision:
 
 
 def choose_video_provider_with_reason(script: str) -> ProviderDecision:
-    """Classify the full script with Grok; Sora preferred when classification fails."""
-    if not veo_generation_enabled():
-        return ProviderDecision(
-            provider="sora",
-            confidence=1.0,
-            reason="Veo generation disabled (VEO_GENERATION_ENABLED); using Sora.",
-            primary_failure_mode="low_risk",
-            features=_empty_features(),
-            fallback_used=False,
-        )
+    """Classify the full script with Grok; Sora preferred when classification fails.
 
+    Grok runs whenever the script is non-empty so ``lip_sync_risk`` and related
+  features are available for Sync lipsync — even when Veo routing is disabled.
+    """
     if not script or not script.strip():
         return ProviderDecision(
             provider="sora",
@@ -330,12 +324,27 @@ def choose_video_provider_with_reason(script: str) -> ProviderDecision:
         )
 
     try:
-        return _decision_from_grok(_classify_script_with_grok(script))
+        grok = _classify_script_with_grok(script)
     except VideoProviderClassificationError as exc:
         logger.warning("Video provider classification failed: %s", exc)
         return _classifier_failure_decision(
             f"Grok classifier failed ({exc}); defaulting to Sora."
         )
+
+    if not veo_generation_enabled():
+        return ProviderDecision(
+            provider="sora",
+            confidence=grok.confidence,
+            reason=(
+                "Veo generation disabled (VEO_GENERATION_ENABLED); using Sora. "
+                f"Classifier: {grok.reason}"
+            ),
+            primary_failure_mode=grok.primary_failure_mode,
+            features=dict(grok.features),
+            fallback_used=False,
+        )
+
+    return _decision_from_grok(grok)
 
 
 def choose_video_provider(script: str) -> VideoProvider:

--- a/backend/workers/script_creation_worker/worker.py
+++ b/backend/workers/script_creation_worker/worker.py
@@ -147,10 +147,12 @@ def _build_script_prompt(
     AI-generated video production (hard rules — the finished clip is rendered by an image-to-video model such as OpenAI Sora or Google Veo from a product reference frame, not a film crew):
     - You will receive a reference image of the product; Beat 1 may open on that pack shot, but transition into the story within Beat 1 — do not script a static product slide for the whole spot.
     - One beat = one continuous shot in one place: no hard cuts, montages, split screens, or "cut to" between unrelated locations inside a single beat.
-    - Keep motion simple and legible: one primary action per beat (reach, open, pour, react, walk, turn, reveal). Avoid crowds, fight scenes, sports plays, dexterous hand tricks, mirror reflections, or whip pans that reverse direction.
-    - Favor stable framing: single focal subject, medium or close shots, consistent lighting and wardrobe for the whole clip; avoid morphing identities, costume changes, or heavy VFX.
-    - If someone speaks on camera, keep their face visible and fairly frontal with minimal occlusion — lip-sync models struggle with profile faces, hats, and hands over the mouth.
-    - Do not script split dialogue between multiple speakers at once, phone screens with readable UI, microscopic detail, or brand mascots / copyrighted characters.
+    - Shot design for I2V: single clear focal subject per beat; medium or close framing; slow, simple camera (static with subject motion, gentle push-in, or light handheld drift). Same room, lighting direction, and wardrobe within a beat — no morphing identities, costume changes, or heavy VFX mid-beat.
+    - Motion the model handles well: one primary action per beat (reach, open, pour, react, smile, reveal product, walk a few steps, turn to camera). Prefer product-in-hand, reaction, demonstration, and expressive performance over complex choreography.
+    - Avoid: crowds, fight scenes, sports plays, dexterous hand tricks, mirror reflections, whip pans, hard cuts inside a beat, split dialogue between multiple speakers talking at once, phone screens with readable UI, microscopic detail, or brand mascots / copyrighted characters.
+    - Dialogue vs voiceover: on-camera lines are fine when the concept needs them — script natural performance and timing, not a rigid talking-head for lip-sync. Voiceover plus visual story (B-roll, POV, product moments) is often the most reliable pattern when the brief allows.
+    - Visual craft: strong opening visual in Beat 1 (respect the silent hook window); clear emotional progression across beats; creator-native formats (POV, reaction, day-in-the-life) through action and setting, not on-screen text.
+    - Do not constrain shots for lip-sync quality; focus on simple, legible visuals and performance that image-to-video models can render. Spoken dialogue timing must still fit the audio-safe timeline below.
 
     Product Name: {product_name}
     Product Description: {product_description or 'Not provided'}


### PR DESCRIPTION
## Changes
- Adds Sync Labs (sync-3) post-processing after Sora/Veo: ffmpeg demux → temp Azure blobs with SAS → poll → upload lip-synced MP4.
- Runs only when SYNC_LIPSYNC_ENABLED, SYNC_API_KEY, and classifier lip_sync_risk are all set; Sync/ffmpeg errors fail the ad job (no raw-video fallback).
- Persists lip_sync_risk, primary_failure_mode, and lipsync metadata on the variant; re-classifies with Grok only when Veo retime changes the script.
- Updates script prompts for AI-video-first guidance (lip sync handled downstream); still classifies with Grok when Veo routing is disabled.
- Docker: installs ffmpeg; adds syncsdk dependency.

## Testing
- unit tests
- end 2 end test